### PR TITLE
Feature/selc 2424 (#106) - Retrive product name instead product id in subject and body's mail and in contract name 

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/EmailService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/EmailService.java
@@ -43,8 +43,8 @@ public class EmailService {
         this.mailTemplateConfig = mailTemplateConfig;
     }
 
-    public void sendAutocompleteMail(List<String> destinationMail, Map<String, String> templateParameters, File file, String fileName, String productId) {
-        emailConnector.sendMail(mailTemplateConfig.getAutocompletePath(), destinationMail, file, productId, templateParameters, fileName);
+    public void sendAutocompleteMail(List<String> destinationMail, Map<String, String> templateParameters, File file, String fileName, String productName) {
+        emailConnector.sendMail(mailTemplateConfig.getAutocompletePath(), destinationMail, file, productName, templateParameters, fileName);
     }
 
     public void sendMail(File pdf, Institution institution, User user, OnboardingRequest request, String token, boolean isApproved, InstitutionType institutionType) {
@@ -58,14 +58,14 @@ public class EmailService {
             destinationMail = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
                     ? coreConfig.getDestinationMails() : List.of(institution.getDigitalAddress());
             log.info(DESTINATION_MAIL_LOG, destinationMail);
-            emailConnector.sendMail(mailTemplateConfig.getPath(), destinationMail, pdf, request.getProductId(), mailParameters, request.getProductId() + "_accordo_adesione.pdf");
+            emailConnector.sendMail(mailTemplateConfig.getPath(), destinationMail, pdf, request.getProductName(), mailParameters, request.getProductName() + "_accordo_adesione.pdf");
             log.info("onboarding-contract-email Email successful sent");
         } else {
             mailParameters = mailParametersMapper.getOnboardingMailNotificationParameter(user, request, token);
             log.debug(MAIL_PARAMETER_LOG, mailParameters);
             destinationMail = mailParametersMapper.getOnboardingNotificationAdminEmail();
             log.info(DESTINATION_MAIL_LOG, destinationMail);
-            emailConnector.sendMail(mailParametersMapper.getOnboardingNotificationPath(), destinationMail, pdf, request.getProductId(), mailParameters, request.getProductId() + "_accordo_adesione.pdf");
+            emailConnector.sendMail(mailParametersMapper.getOnboardingNotificationPath(), destinationMail, pdf, request.getProductName(), mailParameters, request.getProductName() + "_accordo_adesione.pdf");
             log.info("onboarding-complete-email-notification Email successful sent");
         }
     }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -21,8 +21,10 @@ import it.pagopa.selfcare.mscore.model.user.User;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-import java.time.OffsetDateTime;
-import java.util.*;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -185,7 +187,7 @@ public class OnboardingInstitutionStrategyFactory {
 
                     File logoFile = contractService.getLogoFile();
 
-                    emailService.sendAutocompleteMail(destinationMails, new HashMap<>(), logoFile, EmailService.PAGOPA_LOGO_FILENAME, strategyInput.getOnboardingRequest().getProductId());
+                    emailService.sendAutocompleteMail(destinationMails, new HashMap<>(), logoFile, EmailService.PAGOPA_LOGO_FILENAME, strategyInput.getOnboardingRequest().getProductName());
                 }
 
                 //[TODO https://pagopa.atlassian.net/wiki/spaces/SCP/pages/710901785/RFC+Proposta+per+gestione+asincrona+degli+eventi]

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapper.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapper.java
@@ -18,7 +18,7 @@ public class MailParametersMapper {
 
     public Map<String, String> getOnboardingMailParameter(User user, OnboardingRequest request, String token) {
         Map<String, String> map = new HashMap<>();
-        map.put(mailTemplateConfig.getProductName(), request.getProductId());
+        map.put(mailTemplateConfig.getProductName(), request.getProductName());
         if(user.getName()!=null) {
             map.put(mailTemplateConfig.getUserName(), user.getName());
         }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/EmailServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/EmailServiceTest.java
@@ -22,16 +22,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.nio.file.Paths;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,16 +54,40 @@ class EmailServiceTest {
     @Mock
     private EmailConnector emailConnector;
 
+    /**
+     * Method under test: {@link EmailService#sendMail(File, Institution, User, OnboardingRequest, String, boolean, InstitutionType)}
+     */
+    @Test
+    void testSendAutocompleteMail() {
+        Institution institution = new Institution();
+        institution.setDigitalAddress("example@pec.it");
+        File file = Mockito.mock(File.class);
+        String fileName= "42";
+        List<String> destinationMail = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
+                ? coreConfig.getDestinationMails() : List.of(institution.getDigitalAddress());
+
+        when(coreConfig.getDestinationMails()).thenReturn(destinationMail);
+
+
+        emailService.sendAutocompleteMail(destinationMail, new HashMap<>(), file, fileName, "App IO");
+        verify(emailConnector, times(1)).sendMail(any(), any(), any(), any(), any(), any());
+    }
 
     /**
      * Method under test: {@link EmailService#sendMail(File, Institution, User, OnboardingRequest, String, boolean, InstitutionType)}
      */
     @Test
     void testSendMail() {
-        when(coreConfig.getDestinationMails()).thenReturn(new ArrayList<>());
+
+
         File pdf = Paths.get(System.getProperty("java.io.tmpdir"), "test.txt").toFile();
         Institution institution = new Institution();
         institution.setDigitalAddress("example@pec.it");
+
+        List<String> destinationMail = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
+                ? coreConfig.getDestinationMails() : List.of(institution.getDigitalAddress());
+
+        when(coreConfig.getDestinationMails()).thenReturn(destinationMail);
 
         User user = new User();
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1) retrive product name for subject's mail instead of product id
2) retrive product name for body's mail instead of product id  
3) retrive product name for contract name instead of product id  

#### Motivation and Context

this fix allows the user to see the product name instead of the product id when receiving the mail after an onboarding
ES. "Firma con IO" instead "prdo-io-sign"

#### How Has This Been Tested?

an onboarding request was made and subsequently it was verified that the product name was actually retrieved in the subject and body of the email and in the name of the contract

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.