### PR TITLE
[SELC - 2472] - implemented consume token api

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -3543,6 +3543,79 @@
         } ]
       }
     },
+    "/onboarding/{tokenId}/consume" : {
+      "post" : {
+        "tags" : [ "Onboarding" ],
+        "summary" : "Consume token onboarding request without digest verification ",
+        "description" : "Consume token onboarding request without digest verification ",
+        "operationId" : "consumeTokenUsingPOST",
+        "parameters" : [ {
+          "name" : "tokenId",
+          "in" : "path",
+          "description" : "contract's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "multipart/form-data" : {
+              "schema" : {
+                "required" : [ "contract" ],
+                "type" : "object",
+                "properties" : {
+                  "contract" : {
+                    "type" : "string",
+                    "description" : "contract",
+                    "format" : "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/tokens/token" : {
       "get" : {
         "tags" : [ "Token" ],

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
@@ -2,12 +2,7 @@ package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
-import it.pagopa.selfcare.mscore.model.onboarding.OnboardingInfo;
-import it.pagopa.selfcare.mscore.model.onboarding.OnboardingLegalsRequest;
-import it.pagopa.selfcare.mscore.model.onboarding.OnboardingOperatorsRequest;
-import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
-import it.pagopa.selfcare.mscore.model.onboarding.ResourceResponse;
-import it.pagopa.selfcare.mscore.model.onboarding.Token;
+import it.pagopa.selfcare.mscore.model.onboarding.*;
 import it.pagopa.selfcare.mscore.model.user.RelationshipInfo;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -28,6 +23,8 @@ public interface OnboardingService {
     void completeOboarding(Token token, MultipartFile contract);
 
     void invalidateOnboarding(Token token);
+
+    void completeOboardingWithoutSignatureVerification(Token token, MultipartFile contract);
 
     void approveOnboarding(Token token, SelfCareUser selfCareUser);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
@@ -20,11 +20,11 @@ public interface OnboardingService {
 
     void onboardingInstitutionComplete(OnboardingRequest request, SelfCareUser principal);
 
-    void completeOboarding(Token token, MultipartFile contract);
+    void completeOnboarding(Token token, MultipartFile contract);
 
     void invalidateOnboarding(Token token);
 
-    void completeOboardingWithoutSignatureVerification(Token token, MultipartFile contract);
+    void completeOnboardingWithoutSignatureVerification(Token token, MultipartFile contract);
 
     void approveOnboarding(Token token, SelfCareUser selfCareUser);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -131,7 +131,7 @@ public class OnboardingServiceImpl implements OnboardingService {
 
     @Override
     public void completeOnboardingWithoutSignatureVerification(Token token, MultipartFile contract){
-        Consumer<List<User>> verification = users -> contractService.verifySignature(contract, token, users);
+        Consumer<List<User>> verification = ignored -> {};
         this.completeOnboarding(token, contract, verification);
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -29,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.mscore.constant.CustomError.DOCUMENT_NOT_FOUND;
@@ -122,9 +123,19 @@ public class OnboardingServiceImpl implements OnboardingService {
                 .retrieveOnboardingInstitutionStrategyWithoutContractAndComplete(request.getInstitutionUpdate().getInstitutionType())
                 .onboardingInstitution(request, principal);
     }
+    @Override
+    public void completeOboarding(Token token, MultipartFile contract){
+        Consumer<List<User>> verification = users -> contractService.verifySignature(contract, token, users);
+        this.completeOboarding(token, contract, verification);
+    }
 
     @Override
-    public void completeOboarding(Token token, MultipartFile contract) {
+    public void completeOboardingWithoutSignatureVerification(Token token, MultipartFile contract){
+        Consumer<List<User>> verification = ignored -> {};
+        this.completeOboarding(token, contract, verification);
+    }
+
+    public void completeOboarding(Token token, MultipartFile contract, Consumer<List<User>> verification) {
         log.trace("completeOnboarding start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "completeOboarding token = {} contract = {}", token, contract);
         checkAndHandleExpiring(token);
@@ -144,7 +155,7 @@ public class OnboardingServiceImpl implements OnboardingService {
 
         Product product = onboardingDao.getProductById(token.getProductId());
         if (pagoPaSignatureConfig.isVerifyEnabled()) {
-            contractService.verifySignature(contract, token, managersData);
+            verification.accept(managersData);
         }
         File logoFile = contractService.getLogoFile();
         String fileName = contractService.uploadContract(token.getId(), contract);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -124,18 +124,18 @@ public class OnboardingServiceImpl implements OnboardingService {
                 .onboardingInstitution(request, principal);
     }
     @Override
-    public void completeOboarding(Token token, MultipartFile contract){
+    public void completeOnboarding(Token token, MultipartFile contract){
         Consumer<List<User>> verification = users -> contractService.verifySignature(contract, token, users);
-        this.completeOboarding(token, contract, verification);
+        this.completeOnboarding(token, contract, verification);
     }
 
     @Override
-    public void completeOboardingWithoutSignatureVerification(Token token, MultipartFile contract){
-        Consumer<List<User>> verification = ignored -> {};
-        this.completeOboarding(token, contract, verification);
+    public void completeOnboardingWithoutSignatureVerification(Token token, MultipartFile contract){
+        Consumer<List<User>> verification = users -> contractService.verifySignature(contract, token, users);
+        this.completeOnboarding(token, contract, verification);
     }
 
-    public void completeOboarding(Token token, MultipartFile contract, Consumer<List<User>> verification) {
+    public void completeOnboarding(Token token, MultipartFile contract, Consumer<List<User>> verification) {
         log.trace("completeOnboarding start");
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "completeOboarding token = {} contract = {}", token, contract);
         checkAndHandleExpiring(token);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class OnboardingServiceImplTest {
 
+
     @Mock
     private ContractService contractService;
     @Mock
@@ -196,7 +197,7 @@ class OnboardingServiceImplTest {
 
 
     /**
-     * Method under test: {@link OnboardingServiceImpl#completeOboarding(Token, MultipartFile)}
+     * Method under test: {@link OnboardingServiceImpl#completeOnboarding(Token, MultipartFile)}
      */
     @Test
     void shouldThrowExceptionCompleteOnboarding() {
@@ -206,12 +207,12 @@ class OnboardingServiceImplTest {
         when(institutionService.retrieveInstitutionById(any())).thenReturn(new Institution());
         when(institutionConnector.findWithFilter(any(), any(), any())).thenReturn(List.of(new Institution()));
 
-        Assertions.assertThrows(InvalidRequestException.class, () -> onboardingServiceImpl.completeOboarding(token,
+        Assertions.assertThrows(InvalidRequestException.class, () -> onboardingServiceImpl.completeOnboarding(token,
                 new MockMultipartFile("Name", new ByteArrayInputStream("AXAXAXAX".getBytes(StandardCharsets.UTF_8)))));
     }
 
     /**
-     * Method under test: {@link OnboardingServiceImpl#completeOboarding(Token, MultipartFile)}
+     * Method under test: {@link OnboardingServiceImpl#completeOnboarding(Token, MultipartFile)}
      */
     @Test
     void testCompleteOnboarding() {
@@ -223,7 +224,7 @@ class OnboardingServiceImplTest {
         when(institutionService.retrieveInstitutionById(any())).thenReturn(new Institution());
         when(institutionConnector.findWithFilter(any(), any(), any())).thenReturn(List.of());
 
-        Assertions.assertDoesNotThrow(() -> onboardingServiceImpl.completeOboarding(token,
+        Assertions.assertDoesNotThrow(() -> onboardingServiceImpl.completeOnboarding(token,
                 new MockMultipartFile("Name", new ByteArrayInputStream("AXAXAXAX".getBytes(StandardCharsets.UTF_8)))));
     }
 
@@ -1360,6 +1361,7 @@ class OnboardingServiceImplTest {
 
         assertDoesNotThrow(() -> onboardingServiceImpl.onboardingInstitutionComplete(onboardingRequest, mock(SelfCareUser.class)));
     }
+
 
 }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -229,6 +229,75 @@ class OnboardingServiceImplTest {
     }
 
     /**
+     * Method under test: {@link OnboardingServiceImpl#completeOnboarding(Token, MultipartFile)}
+     */
+    @Test
+    void testCompleteOnboarding2() {
+
+        Token token = TestUtils.dummyToken();
+        token.setInstitutionUpdate(TestUtils.createSimpleInstitutionUpdate());
+
+        when(onboardingDao.persistForUpdate(any(), any(), any(), any())).thenReturn(new OnboardingUpdateRollback());
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(new Institution());
+        when(institutionConnector.findWithFilter(any(), any(), any())).thenReturn(List.of());
+        when(pagoPaSignatureConfig.isVerifyEnabled()).thenReturn(true);
+
+        Assertions.assertDoesNotThrow(() -> onboardingServiceImpl.completeOnboarding(token,
+                new MockMultipartFile("Name", new ByteArrayInputStream("AXAXAXAX".getBytes(StandardCharsets.UTF_8)))));
+    }
+
+    /**
+     * Method under test: {@link OnboardingServiceImpl#completeOnboardingWithoutSignatureVerification(Token, MultipartFile)}
+     */
+    @Test
+    void testCompleteOnboardingWithoutSignatureVerification() {
+
+        Token token = TestUtils.dummyToken();
+        token.setInstitutionUpdate(TestUtils.createSimpleInstitutionUpdate());
+
+        when(onboardingDao.persistForUpdate(any(), any(), any(), any())).thenReturn(new OnboardingUpdateRollback());
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(new Institution());
+        when(institutionConnector.findWithFilter(any(), any(), any())).thenReturn(List.of());
+
+        Assertions.assertDoesNotThrow(() -> onboardingServiceImpl.completeOnboardingWithoutSignatureVerification(token,
+                new MockMultipartFile("Name", new ByteArrayInputStream("AXAXAXAX".getBytes(StandardCharsets.UTF_8)))));
+    }
+
+    /**
+     * Method under test: {@link OnboardingServiceImpl#completeOnboardingWithoutSignatureVerification(Token, MultipartFile)}
+     */
+    @Test
+    void testCompleteOnboardingWithoutSignatureVerification2() {
+
+        Token token = TestUtils.dummyToken();
+        token.setInstitutionUpdate(TestUtils.createSimpleInstitutionUpdate());
+
+        when(onboardingDao.persistForUpdate(any(), any(), any(), any())).thenReturn(new OnboardingUpdateRollback());
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(new Institution());
+        when(institutionConnector.findWithFilter(any(), any(), any())).thenReturn(List.of());
+        when(pagoPaSignatureConfig.isVerifyEnabled()).thenReturn(true);
+
+        Assertions.assertDoesNotThrow(() -> onboardingServiceImpl.completeOnboardingWithoutSignatureVerification(token,
+                new MockMultipartFile("Name", new ByteArrayInputStream("AXAXAXAX".getBytes(StandardCharsets.UTF_8)))));
+
+    }
+
+    /**
+     * Method under test: {@link OnboardingServiceImpl#completeOnboardingWithoutSignatureVerification(Token, MultipartFile)}
+     */
+    @Test
+    void shouldThrowExceptionCompleteOnboardingWithoutSignatureVerification() {
+
+        Token token = TestUtils.dummyToken();
+
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(new Institution());
+        when(institutionConnector.findWithFilter(any(), any(), any())).thenReturn(List.of(new Institution()));
+
+        Assertions.assertThrows(InvalidRequestException.class, () -> onboardingServiceImpl.completeOnboardingWithoutSignatureVerification(token,
+                new MockMultipartFile("Name", new ByteArrayInputStream("AXAXAXAX".getBytes(StandardCharsets.UTF_8)))));
+    }
+
+    /**
      * Method under test: {@link OnboardingServiceImpl#approveOnboarding(Token, SelfCareUser)}
      */
     @Test

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
@@ -341,4 +341,29 @@ public class OnboardingController {
         }
         return ResponseEntity.ok().headers(headers).body(file.getData());
     }
+
+    /**
+     * The function consume token onboarding request without verify method
+     *
+     * @param tokenId String
+     * @param contract MultipartFile
+     * @return no content
+     * * Code: 204, Message: successful operation, DataType: TokenId
+     * * Code: 400, Message: Invalid ID supplied, DataType: Problem
+     * * Code: 404, Message: Not found, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "${swagger.mscore.token.consume}", notes = "${swagger.mscore.token.consume}")
+    @PostMapping(value = "/{tokenId}/consume")
+    public ResponseEntity<Void> consumeToken(@ApiParam("${swagger.mscore.token.tokenId}")
+                                             @PathVariable(value = "tokenId") String tokenId,
+                                             @RequestPart MultipartFile contract) {
+        log.trace("consumeToken start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "consumeToken tokenId = {}, contract = {}", tokenId, contract);
+        CustomExceptionMessage.setCustomMessage(GenericError.CONFIRM_ONBOARDING_ERROR);
+        Token token = tokenService.verifyToken(tokenId);
+        onboardingService.completeOboardingWithoutSignatureVerification(token, contract);
+        log.trace("consumeToken end");
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
@@ -194,7 +194,7 @@ public class OnboardingController {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "completeOnboarding tokenId = {}, contract = {}", tokenId, contract);
         CustomExceptionMessage.setCustomMessage(GenericError.CONFIRM_ONBOARDING_ERROR);
         Token token = tokenService.verifyToken(tokenId);
-        onboardingService.completeOboarding(token, contract);
+        onboardingService.completeOnboarding(token, contract);
         log.trace("completeOnboarding end");
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
@@ -343,7 +343,7 @@ public class OnboardingController {
     }
 
     /**
-     * The function consume token onboarding request without verify method
+     * Consume onboarding tokens requested without signature verification
      *
      * @param tokenId String
      * @param contract MultipartFile
@@ -362,7 +362,7 @@ public class OnboardingController {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "consumeToken tokenId = {}, contract = {}", tokenId, contract);
         CustomExceptionMessage.setCustomMessage(GenericError.CONFIRM_ONBOARDING_ERROR);
         Token token = tokenService.verifyToken(tokenId);
-        onboardingService.completeOboardingWithoutSignatureVerification(token, contract);
+        onboardingService.completeOnboardingWithoutSignatureVerification(token, contract);
         log.trace("consumeToken end");
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -59,3 +59,4 @@ swagger.mscore.relationships.get=Return a list of relationships
 swagger.mscore.institutions.geotaxonomy.searchMode=The search mode to perform, as default 'any'
 swagger.mscore.institutions.geotaxonomy=Comma separated list of the geographic taxonomies to search
 swagger.mscore.product.model.id=Product's unique identifier
+swagger.mscore.token.consume=Consume token onboarding request without digest verification 

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
@@ -745,7 +745,7 @@ class OnboardingControllerTest {
     }
 
     @Test
-    public void testConsumeToken() throws Exception {
+    void testConsumeToken() throws Exception {
         doNothing().when(onboardingService).completeOnboardingWithoutSignatureVerification(any(), any());
         MockMultipartFile file = new MockMultipartFile("contract", "".getBytes());
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
@@ -3,10 +3,10 @@ package it.pagopa.selfcare.mscore.web.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.TokenType;
 import it.pagopa.selfcare.mscore.core.OnboardingService;
-import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.core.TokenService;
 import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.institution.DataProtectionOfficer;
@@ -33,26 +33,22 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestBuilders;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.springframework.web.multipart.MultipartFile;
-
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -62,6 +58,9 @@ import static org.mockito.Mockito.*;
 class OnboardingControllerTest {
     @InjectMocks
     private OnboardingController onboardingController;
+
+    @InjectMocks
+    private TokenController tokenController;
 
     @Mock
     private OnboardingService onboardingService;
@@ -744,5 +743,20 @@ class OnboardingControllerTest {
                 .perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
+
+    @Test
+    public void testConsumeToken() throws Exception {
+        doNothing().when(onboardingService).completeOboardingWithoutSignatureVerification(any(), any());
+        MockMultipartFile file = new MockMultipartFile("contract", "".getBytes());
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .multipart("/onboarding/{tokenId}/consume",
+                        "42")
+                .file(file);
+        MockMvcBuilders.standaloneSetup(onboardingController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+
 }
 

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
@@ -610,7 +610,7 @@ class OnboardingControllerTest {
      */
     @Test
     void testCompleteOnboarding() throws Exception {
-        doNothing().when(onboardingService).completeOboarding(any(), any());
+        doNothing().when(onboardingService).completeOnboarding(any(), any());
         MockMultipartFile file = new MockMultipartFile("contract", "".getBytes());
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                 .multipart("/onboarding/complete/{tokenId}",
@@ -746,7 +746,7 @@ class OnboardingControllerTest {
 
     @Test
     public void testConsumeToken() throws Exception {
-        doNothing().when(onboardingService).completeOboardingWithoutSignatureVerification(any(), any());
+        doNothing().when(onboardingService).completeOnboardingWithoutSignatureVerification(any(), any());
         MockMultipartFile file = new MockMultipartFile("contract", "".getBytes());
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                 .multipart("/onboarding/{tokenId}/consume",


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

implementation of the API that allows onboarding without going through the validation phase.
The API is identical to "completeOnboarding" but the validation phase is not performed

#### Motivation and Context

this implementation was performed to allow manual onboardings in case of need

#### How Has This Been Tested?

In addition to the unit tests implemented, local tests were performed to verify the correct functioning of the API

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.