### PR TITLE
add city, country and county to notification message

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
@@ -21,5 +21,8 @@ public class InstitutionToNotify {
     private String zipCode;
     private PaymentServiceProvider paymentServiceProvider;
     private String istatCode;
+    private String city;
+    private String country;
+    private String county;
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -71,6 +71,7 @@ import static it.pagopa.selfcare.mscore.core.util.PdfMapper.*;
 @Service
 public class ContractService {
 
+    static final String DESCRIPTION_TO_REPLACE_REGEX = " - COMUNE";
     private final PagoPaSignatureConfig pagoPaSignatureConfig;
     private final PadesSignService padesSignService;
     private final FileStorageConnector fileStorageConnector;
@@ -296,7 +297,7 @@ public class ContractService {
             GeographicTaxonomies geographicTaxonomies = partyRegistryProxyConnector.getExtByCode(toNotify.getIstatCode());
             toNotify.setCounty(geographicTaxonomies.getProvinceAbbreviation());
             toNotify.setCountry(geographicTaxonomies.getCountryAbbreviation());
-            toNotify.setCity(geographicTaxonomies.getDescription().replace(" - COMUNE", ""));
+            toNotify.setCity(geographicTaxonomies.getDescription().replace(DESCRIPTION_TO_REPLACE_REGEX, ""));
         } catch (MsCoreException | ResourceNotFoundException e) {
             log.warn("Error while searching institution {} on IPA, {} ", institution.getExternalId(), e.getMessage());
             toNotify.setIstatCode(null);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -30,10 +30,7 @@ import it.pagopa.selfcare.mscore.model.InstitutionToNotify;
 import it.pagopa.selfcare.mscore.model.NotificationToSend;
 import it.pagopa.selfcare.mscore.model.QueueEvent;
 import it.pagopa.selfcare.mscore.model.UserToNotify;
-import it.pagopa.selfcare.mscore.model.institution.Institution;
-import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
-import it.pagopa.selfcare.mscore.model.institution.InstitutionProxyInfo;
-import it.pagopa.selfcare.mscore.model.institution.Onboarding;
+import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
 import it.pagopa.selfcare.mscore.model.onboarding.ResourceResponse;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
@@ -296,6 +293,10 @@ public class ContractService {
         try {
             InstitutionProxyInfo institutionProxyInfo = partyRegistryProxyConnector.getInstitutionById(institution.getExternalId());
             toNotify.setIstatCode(institutionProxyInfo.getIstatCode());
+            GeographicTaxonomies geographicTaxonomies = partyRegistryProxyConnector.getExtByCode(toNotify.getIstatCode());
+            toNotify.setCounty(geographicTaxonomies.getProvinceAbbreviation());
+            toNotify.setCountry(geographicTaxonomies.getCountryAbbreviation());
+            toNotify.setCity(geographicTaxonomies.getDescription().replace(" - COMUNE", ""));
         } catch (MsCoreException | ResourceNotFoundException e) {
             log.warn("Error while searching institution {} on IPA, {} ", institution.getExternalId(), e.getMessage());
             toNotify.setIstatCode(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractServiceTest.java
@@ -267,8 +267,11 @@ class ContractServiceTest {
         InstitutionProxyInfo institutionProxyInfoMock = mockInstance(new InstitutionProxyInfo());
         institutionProxyInfoMock.setTaxCode(institution.getExternalId());
 
+        GeographicTaxonomies geographicTaxonomiesMock = mockInstance(new GeographicTaxonomies());
+        geographicTaxonomiesMock.setIstatCode(institutionProxyInfoMock.getIstatCode());
         when(partyRegistryProxyConnector.getInstitutionById(any()))
                 .thenReturn(institutionProxyInfoMock);
+        when(partyRegistryProxyConnector.getExtByCode(any())).thenReturn(geographicTaxonomiesMock);
 
         assertThrows(IllegalArgumentException.class, () -> contractService.sendDataLakeNotification(institution, token, QueueEvent.ADD),
                 "Topic cannot be null");
@@ -412,8 +415,11 @@ class ContractServiceTest {
         InstitutionProxyInfo institutionProxyInfoMock = mockInstance(new InstitutionProxyInfo());
         institutionProxyInfoMock.setTaxCode(institution.getExternalId());
 
+        GeographicTaxonomies geographicTaxonomiesMock = mockInstance(new GeographicTaxonomies());
+        geographicTaxonomiesMock.setIstatCode(institutionProxyInfoMock.getIstatCode());
         when(partyRegistryProxyConnector.getInstitutionById(any()))
                 .thenReturn(institutionProxyInfoMock);
+        when(partyRegistryProxyConnector.getExtByCode(any())).thenReturn(geographicTaxonomiesMock);
 
         assertThrows(IllegalArgumentException.class, () -> contractService.sendDataLakeNotification(institution, token, QueueEvent.UPDATE),
                 "Topic cannot be null");


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Need to add city, country and county to notification message sent to Data Lake

#### Motivation and Context
Needed for SAP to billing requirements

#### How Has This Been Tested?

Deployed on dev environment and tested by onboarding an institution and checked if the fields are filled correctly

#### Screenshots (if appropriate):

{
   "id":"18971cd9-65c0-4a21-b50f-2d287c13851b",
   "internalIstitutionID":"d0d28367-1695-4c50-a260-6fda526e9aab",
   "product":"prod-fd",
   "state":"ACTIVE",
   "filePath":"parties/docs/18971cd9-65c0-4a21-b50f-2d287c13851b/Prod Fideiussioni Digitali_accordo_adesione (2).pdf",
   "fileName":"Prod Fideiussioni Digitali_accordo_adesione (2).pdf",
   "contentType":"application/pdf",
   "onboardingTokenId":"18971cd9-65c0-4a21-b50f-2d287c13851b",
   "institution":{
      "institutionType":"PA",
      "description":"Comune di Milano",
      "digitalAddress":"protocollo@postacert.comune.milano.it",
      "address":"Piazza Della Scala, 2",
      "taxCode":"01199250158",
      "origin":"IPA",
      "originId":"c_f205",
      "zipCode":"20121",
      "paymentServiceProvider":null,
      "istatCode":"015146",
      **"city":"MILANO",
      "country":"IT",
      "county":"MI"**
   },
   "billing":{
      "vatNumber":"01199250158",
      "recipientCode":"sdke",
      "publicServices":false
   },
   "createdAt":"2023-06-20T13:35:24.186157Z",
   "updatedAt":"2023-06-20T13:35:24.186167Z",
   "notificationType":"ADD"
}

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.