### PR TITLE
Feature/selc 2661

### DIFF
--- a/app/src/main/resources/config/kafka.properties
+++ b/app/src/main/resources/config/kafka.properties
@@ -1,4 +1,5 @@
 kafka-manager.datalake-contracts-sasl-jaas-config = ${KAFKA_CONTRACTS_SELFCARE_WO_SASL_JAAS_CONFIG}
+kafka-manager.users-sasl-jaas-config = ${KAFKA_USERS_SELFCARE_WO_SASL_JAAS_CONFIG}
 kafka-manager.datalake-contracts-topic = ${KAFKA_CONTRACTS_TOPIC}
 kafka-manager.sc-users-topic= ${KAFKA_USER_TOPIC}
 kafka-manager.sasl-mechanism = ${KAFKA_SASL_MECHANISM:PLAIN}

--- a/app/src/main/resources/config/kafka.properties
+++ b/app/src/main/resources/config/kafka.properties
@@ -1,5 +1,6 @@
 kafka-manager.datalake-contracts-sasl-jaas-config = ${KAFKA_CONTRACTS_SELFCARE_WO_SASL_JAAS_CONFIG}
 kafka-manager.datalake-contracts-topic = ${KAFKA_CONTRACTS_TOPIC}
+kafka-manager.sc-users-topic= ${KAFKA_USER_TOPIC}
 kafka-manager.sasl-mechanism = ${KAFKA_SASL_MECHANISM:PLAIN}
 kafka-manager.security-protocol = ${KAFKA_SECURITY_PROTOCOL:SASL_SSL}
 kafka-manager.bootstrap-servers = ${KAFKA_BROKER}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserConnector.java
@@ -52,4 +52,5 @@ public interface UserConnector {
     List<OnboardedUser> updateUserBindingCreatedAt(String institutionId, String productId, List<String> users, OffsetDateTime createdAt);
 
     List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter);
+
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserNotificationToSend.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserNotificationToSend.java
@@ -1,0 +1,20 @@
+package it.pagopa.selfcare.mscore.model;
+
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+public class UserNotificationToSend {
+
+    private String id;
+    private String institutionId;
+    private String productId;
+    private String onboardingTokenId;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+    private RelationshipState relationshipStatus;
+    private UserToNotify user;
+
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserNotificationToSend.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserNotificationToSend.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.mscore.model;
 
-import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import lombok.Data;
 
 import java.time.OffsetDateTime;
@@ -14,7 +13,6 @@ public class UserNotificationToSend {
     private String onboardingTokenId;
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
-    private RelationshipState relationshipStatus;
     private UserToNotify user;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserToNotify.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserToNotify.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.mscore.model;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,5 +18,6 @@ public class UserToNotify {
     private String email;
     private PartyRole role;
     private String productRole;
+    private RelationshipState relationshipStatus;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserToNotify.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserToNotify.java
@@ -5,15 +5,19 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class UserToNotify {
 
+    private String userId;
     private String name;
     private String familyName;
     private String fiscalCode;
     private String email;
     private PartyRole role;
+    private List<String> productRoles;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserToNotify.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/UserToNotify.java
@@ -5,8 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,6 +16,6 @@ public class UserToNotify {
     private String fiscalCode;
     private String email;
     private PartyRole role;
-    private List<String> productRoles;
+    private String productRole;
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -44,6 +44,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final InstitutionService institutionService;
     private final UserService userService;
     private final UserRelationshipService userRelationshipService;
+    private final UserEventService userEventService;
     private final ContractService contractService;
     private final EmailService emailService;
     private final PagoPaSignatureConfig pagoPaSignatureConfig;
@@ -58,7 +59,7 @@ public class OnboardingServiceImpl implements OnboardingService {
                                  InstitutionService institutionService,
                                  UserService userService,
                                  UserRelationshipService userRelationshipService,
-                                 ContractService contractService,
+                                 UserEventService userEventService, ContractService contractService,
                                  EmailService emailService,
                                  PagoPaSignatureConfig pagoPaSignatureConfig,
                                  OnboardingInstitutionStrategyFactory institutionStrategyFactory,
@@ -67,6 +68,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         this.institutionService = institutionService;
         this.userService = userService;
         this.userRelationshipService = userRelationshipService;
+        this.userEventService = userEventService;
         this.contractService = contractService;
         this.emailService = emailService;
         this.pagoPaSignatureConfig = pagoPaSignatureConfig;
@@ -169,10 +171,7 @@ public class OnboardingServiceImpl implements OnboardingService {
             contractService.deleteContract(fileName, token.getId());
         }
         contractService.sendDataLakeNotification(rollback.getUpdatedInstitution(), token, QueueEvent.ADD);
-        token.getUsers().forEach(tokenUser -> {
-            User user = userService.retrieveUserFromUserRegistry(token.getId(), EnumSet.allOf(User.Fields.class));
-            contractService.sendLegalUserNotification(user, token);
-        });
+        userEventService.sendLegalUserNotification(token);
         log.trace("completeOboarding end");
     }
 
@@ -232,7 +231,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         OnboardingInstitutionUtils.verifyUsers(onboardingOperatorRequest.getUsers(), List.of(role));
         Institution institution = institutionService.retrieveInstitutionById(onboardingOperatorRequest.getInstitutionId());
         List<RelationshipInfo> relationshipInfos = onboardingDao.onboardOperator(onboardingOperatorRequest, institution);
-        relationshipInfos.forEach(contractService::sendCreateUserNotification);
+        relationshipInfos.forEach(userEventService::sendCreateUserNotification);
         return relationshipInfos;
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -171,7 +171,7 @@ public class OnboardingServiceImpl implements OnboardingService {
             contractService.deleteContract(fileName, token.getId());
         }
         contractService.sendDataLakeNotification(rollback.getUpdatedInstitution(), token, QueueEvent.ADD);
-        userEventService.sendLegalUserNotification(token);
+        userEventService.sendLegalTokenUserNotification(token);
         log.trace("completeOboarding end");
     }
 
@@ -231,7 +231,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         OnboardingInstitutionUtils.verifyUsers(onboardingOperatorRequest.getUsers(), List.of(role));
         Institution institution = institutionService.retrieveInstitutionById(onboardingOperatorRequest.getInstitutionId());
         List<RelationshipInfo> relationshipInfos = onboardingDao.onboardOperator(onboardingOperatorRequest, institution);
-        relationshipInfos.forEach(userEventService::sendCreateUserNotification);
+        relationshipInfos.forEach(userEventService::sendOperatorUserNotification);
         return relationshipInfos;
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserEventService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserEventService.java
@@ -97,6 +97,7 @@ public class UserEventService {
                     userToNotify.setFiscalCode(user.getFiscalCode());
                     userToNotify.setEmail(user.getWorkContacts().get(institutionId).getEmail());
                     userToNotify.setRole(onboardedProduct.getRole());
+                    userToNotify.setRelationshipStatus(onboardedProduct.getStatus());
                     userToNotify.setProductRole(onboardedProduct.getProductRole());
                     return userToNotify;
                 })
@@ -129,7 +130,6 @@ public class UserEventService {
         notification.setProductId(relationshipInfo.getOnboardedProduct().getProductId());
         notification.setCreatedAt(relationshipInfo.getOnboardedProduct().getCreatedAt());
         notification.setUpdatedAt(relationshipInfo.getOnboardedProduct().getUpdatedAt());
-        notification.setRelationshipStatus(relationshipInfo.getOnboardedProduct().getStatus());
         notification.setUser(user);
         return notification;
     }
@@ -142,7 +142,6 @@ public class UserEventService {
         notification.setCreatedAt(token.getCreatedAt());
         notification.setUpdatedAt(token.getUpdatedAt());
         notification.setOnboardingTokenId(token.getId());
-        notification.setRelationshipStatus(token.getStatus());
         notification.setUser(user);
         return notification;
     }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserEventService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserEventService.java
@@ -1,0 +1,130 @@
+package it.pagopa.selfcare.mscore.core;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.mscore.api.UserConnector;
+import it.pagopa.selfcare.mscore.api.UserRegistryConnector;
+import it.pagopa.selfcare.mscore.config.CoreConfig;
+import it.pagopa.selfcare.mscore.core.config.KafkaPropertiesConfig;
+import it.pagopa.selfcare.mscore.model.UserToNotify;
+import it.pagopa.selfcare.mscore.model.onboarding.OnboardedProduct;
+import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
+import it.pagopa.selfcare.mscore.model.onboarding.Token;
+import it.pagopa.selfcare.mscore.model.onboarding.TokenUser;
+import it.pagopa.selfcare.mscore.model.user.RelationshipInfo;
+import it.pagopa.selfcare.mscore.model.user.User;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class UserEventService {
+    private final CoreConfig coreConfig;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final KafkaPropertiesConfig kafkaPropertiesConfig;
+    private final ObjectMapper mapper;
+    private final UserConnector userConnector;
+    private final UserRegistryConnector userRegistryConnector;
+
+    public UserEventService(CoreConfig coreConfig,
+                            KafkaTemplate<String, String> kafkaTemplate,
+                            KafkaPropertiesConfig kafkaPropertiesConfig,
+                            ObjectMapper mapper,
+                            UserConnector userConnector, UserRegistryConnector userRegistryConnector) {
+        this.coreConfig = coreConfig;
+        this.kafkaTemplate = kafkaTemplate;
+        this.kafkaPropertiesConfig = kafkaPropertiesConfig;
+        this.mapper = mapper;
+        this.userConnector = userConnector;
+        this.userRegistryConnector = userRegistryConnector;
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addSerializer(OffsetDateTime.class, new JsonSerializer<>() {
+            @Override
+            public void serialize(OffsetDateTime offsetDateTime, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+                jsonGenerator.writeString(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(offsetDateTime));
+            }
+        });
+        mapper.registerModule(simpleModule);
+    }
+
+    public void sendLegalUserNotification(Token token) {
+        token.getUsers().forEach(tokenUser -> {
+            UserToNotify userToNotify = toUserToNotify(tokenUser, token.getInstitutionId(), token.getProductId());
+            try {
+                String msg = mapper.writeValueAsString(userToNotify);
+                sendUserNotification(msg, userToNotify.getUserId());
+            } catch (JsonProcessingException e) {
+                log.warn("error during send dataLake notification for user {}", userToNotify.getUserId());
+            }
+
+        });
+    }
+
+    private UserToNotify toUserToNotify(TokenUser tokenUser, String institutionId, String productId) {
+        UserToNotify userToNotify = new UserToNotify();
+        User user = userRegistryConnector.getUserByInternalId(tokenUser.getUserId(), EnumSet.allOf(User.Fields.class));
+        OnboardedUser onboardedUser = userConnector.findById(tokenUser.getUserId());
+        List<String> userProductRoles = onboardedUser.getBindings().stream()
+                .filter(userBinding -> institutionId.equals(userBinding.getInstitutionId()))
+                .flatMap(userBinding -> userBinding.getProducts().stream())
+                .filter(onboardedProduct -> productId.equals(onboardedProduct.getProductId()))
+                .map(OnboardedProduct::getProductRole)
+                .collect(Collectors.toList());
+        userToNotify.setUserId(tokenUser.getUserId());
+        userToNotify.setName(user.getName());
+        userToNotify.setFamilyName(user.getFamilyName());
+        userToNotify.setFiscalCode(user.getFiscalCode());
+        userToNotify.setEmail(user.getWorkContacts().get(institutionId).getEmail());
+        userToNotify.setRole(tokenUser.getRole());
+        userToNotify.setProductRoles(userProductRoles);
+
+        return userToNotify;
+    }
+
+    public void sendCreateUserNotification(RelationshipInfo relationshipInfo) {
+        if (relationshipInfo != null) {
+            log.debug(LogUtils.CONFIDENTIAL_MARKER, "Notification to send to the data lake, notification: {}", relationshipInfo);
+            try {
+                String msg = mapper.writeValueAsString(relationshipInfo);
+                sendUserNotification(msg, relationshipInfo.getUserId());
+            } catch (JsonProcessingException e) {
+                log.warn("error during send dataLake notification for user {}", relationshipInfo.getUserId());
+            }
+        }
+    }
+
+
+    private void sendUserNotification(String message, String userId) {
+        ListenableFuture<SendResult<String, String>> future =
+                kafkaTemplate.send(kafkaPropertiesConfig.getScUsersTopic(), message);
+
+        future.addCallback(new ListenableFutureCallback<>() {
+
+            @Override
+            public void onSuccess(SendResult<String, String> result) {
+                log.info("sent dataLake notification for user : {}", userId);
+            }
+
+            @Override
+            public void onFailure(Throwable ex) {
+                log.warn("error during send dataLake notification for user {}: {} ", userId, ex.getMessage(), ex);
+            }
+        });
+    }
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserEventService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserEventService.java
@@ -80,7 +80,7 @@ public class UserEventService {
         });
     }
 
-    private List<UserToNotify> toUserToNotify(String userId, String institutionId, String productId, Optional<String> relationshipId, Optional<String> tokenId) {
+    protected List<UserToNotify> toUserToNotify(String userId, String institutionId, String productId, Optional<String> relationshipId, Optional<String> tokenId) {
         User user = userRegistryConnector.getUserByInternalId(userId, EnumSet.allOf(User.Fields.class));
         OnboardedUser onboardedUser = userConnector.findById(userId);
         return onboardedUser.getBindings().stream()

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserRelationshipServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserRelationshipServiceImpl.java
@@ -40,7 +40,7 @@ public class UserRelationshipServiceImpl implements UserRelationshipService {
         OnboardedUser user = findByRelationshipId(relationshipId);
         try {
             onboardingDao.updateUserProductState(user, relationshipId, RelationshipState.ACTIVE);
-            sendRelationshipEventNotification(relationshipId);
+            sendRelationshipEventNotification(user, relationshipId);
         } catch (InvalidRequestException e) {
             throw new InvalidRequestException(String.format(RELATIONSHIP_NOT_ACTIVABLE.getMessage(), relationshipId), RELATIONSHIP_NOT_ACTIVABLE.getCode());
         }
@@ -51,26 +51,30 @@ public class UserRelationshipServiceImpl implements UserRelationshipService {
         OnboardedUser user = findByRelationshipId(relationshipId);
         try {
             onboardingDao.updateUserProductState(user, relationshipId, RelationshipState.SUSPENDED);
-            sendRelationshipEventNotification(relationshipId);
+            sendRelationshipEventNotification(user, relationshipId);
         } catch (InvalidRequestException e) {
             throw new InvalidRequestException(String.format(RELATIONSHIP_NOT_SUSPENDABLE.getMessage(), relationshipId), RELATIONSHIP_NOT_SUSPENDABLE.getCode());
         }
     }
 
-    private void sendRelationshipEventNotification(String relationshipId){
-        RelationshipInfo relationshipInfo = retrieveRelationship(relationshipId);
+    private void sendRelationshipEventNotification(OnboardedUser user, String relationshipId){
+        RelationshipInfo relationshipInfo = getRelationshipInfoFromUser(user, relationshipId);
         userEventService.sendOperatorUserNotification(relationshipInfo);
     }
     @Override
     public void deleteRelationship(String relationshipId) {
         OnboardedUser user = findByRelationshipId(relationshipId);
         onboardingDao.updateUserProductState(user, relationshipId, RelationshipState.DELETED);
-        sendRelationshipEventNotification(relationshipId);
+        sendRelationshipEventNotification(user, relationshipId);
     }
 
     @Override
     public RelationshipInfo retrieveRelationship(String relationshipId) {
         OnboardedUser user = findByRelationshipId(relationshipId);
+        return getRelationshipInfoFromUser(user, relationshipId);
+    }
+
+    private RelationshipInfo getRelationshipInfoFromUser(OnboardedUser user, String relationshipId){
         for (UserBinding userBinding : user.getBindings()) {
             for (OnboardedProduct product : userBinding.getProducts()) {
                 if (relationshipId.equalsIgnoreCase(product.getRelationshipId())) {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/config/KafkaProducerConfig.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/config/KafkaProducerConfig.java
@@ -47,9 +47,35 @@ public class KafkaProducerConfig {
                 StringSerializer.class);
         return new DefaultKafkaProducerFactory<>(configProps);
     }
+    @Bean
+    ProducerFactory<String, String> producerFactoryUser(){
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                kafkaPropertiesConfig.getBootstrapServers());
+        configProps.put(
+                AdminClientConfig.SECURITY_PROTOCOL_CONFIG,
+                kafkaPropertiesConfig.getSecurityProtocol());
+        configProps.put(
+                SaslConfigs.SASL_MECHANISM,
+                kafkaPropertiesConfig.getSaslMechanism());
+        configProps.put(
+                SaslConfigs.SASL_JAAS_CONFIG,
+                kafkaPropertiesConfig.getUsersSaslJaasConfig());
+        configProps.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        configProps.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
 
     @Bean
     public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplateUsers(){return new KafkaTemplate<>(producerFactoryUser());}
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/config/KafkaPropertiesConfig.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/config/KafkaPropertiesConfig.java
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.PropertySource;
 @ToString
 public class KafkaPropertiesConfig {
     private String datalakeContractsSaslJaasConfig;
+    private String usersSaslJaasConfig;
     private String datalakeContractsTopic ;
     private String scUsersTopic;
     private String saslMechanism;

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/config/KafkaPropertiesConfig.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/config/KafkaPropertiesConfig.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.PropertySource;
 public class KafkaPropertiesConfig {
     private String datalakeContractsSaslJaasConfig;
     private String datalakeContractsTopic ;
+    private String scUsersTopic;
     private String saslMechanism;
     private String securityProtocol;
     private String bootstrapServers;

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/NotificationMapper.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/NotificationMapper.java
@@ -1,0 +1,25 @@
+package it.pagopa.selfcare.mscore.core.util;
+
+import it.pagopa.selfcare.mscore.model.UserNotificationToSend;
+import it.pagopa.selfcare.mscore.model.UserToNotify;
+import it.pagopa.selfcare.mscore.model.onboarding.Token;
+import it.pagopa.selfcare.mscore.model.user.RelationshipInfo;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+
+    @Mapping(source = "relationshipInfo.institution.id", target = "institutionId")
+    @Mapping(source = "relationshipInfo.onboardedProduct.productId", target = "productId")
+    @Mapping(source = "relationshipInfo.onboardedProduct.createdAt", target = "createdAt")
+    @Mapping(source = "relationshipInfo.onboardedProduct.updatedAt", target = "updatedAt")
+    UserNotificationToSend setNotificationDetailsFromRelationship(RelationshipInfo relationshipInfo, UserToNotify user);
+
+    @Mapping(source = "token.institutionId", target = "institutionId")
+    @Mapping(source = "token.productId", target = "productId")
+    @Mapping(source  = "token.id", target = "onboardingTokenId")
+    @Mapping(source  = "token.createdAt", target = "createdAt")
+    @Mapping(source  = "token.updatedAt", target = "updatedAt")
+    UserNotificationToSend setNotificationDetailsFromToken(Token token, UserToNotify user);
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtils.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtils.java
@@ -251,4 +251,5 @@ public class OnboardingInstitutionUtils {
         }
         return onboardedProduct;
     }
+
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -57,6 +57,9 @@ class OnboardingServiceImplTest {
 
     @Mock
     private ContractService contractService;
+
+    @Mock
+    private UserService userService;
     @Mock
     private EmailService emailService;
 
@@ -73,7 +76,7 @@ class OnboardingServiceImplTest {
     private InstitutionService institutionService;
 
     @Mock
-    private UserService userService;
+    private UserEventService userEventService;
 
     @Mock
     private PagoPaSignatureConfig pagoPaSignatureConfig;

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserEventServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserEventServiceTest.java
@@ -6,6 +6,8 @@ import it.pagopa.selfcare.mscore.api.UserConnector;
 import it.pagopa.selfcare.mscore.api.UserRegistryConnector;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.core.config.KafkaPropertiesConfig;
+import it.pagopa.selfcare.mscore.core.util.NotificationMapper;
+import it.pagopa.selfcare.mscore.core.util.NotificationMapperImpl;
 import it.pagopa.selfcare.mscore.core.util.model.DummyUser;
 import it.pagopa.selfcare.mscore.model.UserToNotify;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
@@ -60,7 +62,8 @@ class UserEventServiceTest {
     @Mock
     private ListenableFuture<SendResult<String, String>> mockFuture;
 
-
+    @Spy
+    private NotificationMapper notificationMapper = new NotificationMapperImpl();
 
     @Test
     void sendLegalTokenUserNotification_ok() {
@@ -129,7 +132,7 @@ class UserEventServiceTest {
         OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
         UserBinding userBinding = new UserBinding(institutionId, List.of(onboardedProduct));
         onboardedUser.setBindings(List.of(userBinding));
-        final User userMock = new DummyUser(institutionId);
+        final User userMock = new DummyUser("institutionId");
         when(userRegistryConnector.getUserByInternalId(any(), any()))
                 .thenReturn(userMock);
         when(userConnector.findById(any())).thenReturn(onboardedUser);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserEventServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserEventServiceTest.java
@@ -1,0 +1,168 @@
+package it.pagopa.selfcare.mscore.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.mscore.api.UserConnector;
+import it.pagopa.selfcare.mscore.api.UserRegistryConnector;
+import it.pagopa.selfcare.mscore.config.CoreConfig;
+import it.pagopa.selfcare.mscore.core.config.KafkaPropertiesConfig;
+import it.pagopa.selfcare.mscore.core.util.model.DummyUser;
+import it.pagopa.selfcare.mscore.model.UserToNotify;
+import it.pagopa.selfcare.mscore.model.onboarding.OnboardedProduct;
+import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
+import it.pagopa.selfcare.mscore.model.user.User;
+import it.pagopa.selfcare.mscore.model.user.UserBinding;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserEventServiceTest {
+    @Mock
+    private KafkaTemplate<String, String> kafkaTemplateUsers;
+    @InjectMocks
+    private UserEventService userEventService;
+    @Mock
+    private KafkaPropertiesConfig kafkaPropertiesConfig;
+    @Spy
+    private ObjectMapper mapper;
+    @Mock
+    private UserConnector userConnector;
+    @Mock
+    private UserRegistryConnector userRegistryConnector;
+    @Mock
+    private CoreConfig coreConfig;
+
+
+    @Test
+    void sendLegalTokenUserNotification(){
+
+    }
+
+    @Test
+    void toUserToNotifyFromToken(){
+        //given
+        Optional<String> tokenId = Optional.of(UUID.randomUUID().toString());
+        Optional<String> relationshipId = Optional.empty();
+        String userId = UUID.randomUUID().toString();
+        String institutionId = UUID.randomUUID().toString();
+        String productId = "prod-test";
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setTokenId(tokenId.get());
+        onboardedProduct.setProductId(productId);
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        onboardedUser.setId(userId);
+        UserBinding userBinding = new UserBinding(institutionId, List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        User userMock = new DummyUser(institutionId);
+        when(userRegistryConnector.getUserByInternalId(any(), any()))
+                .thenReturn(userMock);
+        when(userConnector.findById(any())).thenReturn(onboardedUser);
+
+
+        //when
+        List<UserToNotify> usersToNotify = userEventService.toUserToNotify(userId, institutionId, productId, relationshipId, tokenId);
+        //then
+        assertEquals(1, usersToNotify.size());
+        verify(userConnector, times(1)).findById(userId);
+        verify(userRegistryConnector, times(1)).getUserByInternalId(userId, EnumSet.allOf(User.Fields.class));
+        verifyNoMoreInteractions(userConnector, userRegistryConnector);
+    }
+
+    @Test
+    void userToNotifyFromRelationship(){
+        //given
+        Optional<String> tokenId = Optional.empty();
+        Optional<String> relationshipId = Optional.of(UUID.randomUUID().toString());
+        String userId = UUID.randomUUID().toString();
+        String institutionId = UUID.randomUUID().toString();
+        String productId = "prod-test";
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setRelationshipId(relationshipId.get());
+        onboardedProduct.setProductId(productId);
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        onboardedUser.setId(userId);
+        UserBinding userBinding = new UserBinding(institutionId, List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        User userMock = new DummyUser(institutionId);
+        when(userRegistryConnector.getUserByInternalId(any(), any()))
+                .thenReturn(userMock);
+        when(userConnector.findById(any())).thenReturn(onboardedUser);
+        //when
+        List<UserToNotify> usersToNotify = userEventService.toUserToNotify(userId, institutionId, productId, relationshipId, tokenId);
+        //then
+        assertEquals(1, usersToNotify.size());
+        verify(userConnector, times(1)).findById(userId);
+        verify(userRegistryConnector, times(1)).getUserByInternalId(userId, EnumSet.allOf(User.Fields.class));
+        verifyNoMoreInteractions(userConnector, userRegistryConnector);
+    }
+
+    @Test
+    void toUserToNotifyNoProduct(){
+        //given
+        Optional<String> tokenId = Optional.empty();
+        Optional<String> relationshipId = Optional.of(UUID.randomUUID().toString());
+        String userId = UUID.randomUUID().toString();
+        String institutionId = UUID.randomUUID().toString();
+        String productId = "prod-test";
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setRelationshipId(relationshipId.get());
+        onboardedProduct.setProductId("prod-diff");
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        onboardedUser.setId(userId);
+        UserBinding userBinding = new UserBinding(institutionId, List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        User userMock = new DummyUser(institutionId);
+        when(userRegistryConnector.getUserByInternalId(any(), any()))
+                .thenReturn(userMock);
+        when(userConnector.findById(any())).thenReturn(onboardedUser);
+        //when
+        List<UserToNotify> usersToNotify = userEventService.toUserToNotify(userId, institutionId, productId, relationshipId, tokenId);
+        //then
+        assertEquals(0, usersToNotify.size());
+        verify(userConnector, times(1)).findById(userId);
+        verify(userRegistryConnector, times(1)).getUserByInternalId(userId, EnumSet.allOf(User.Fields.class));
+        verifyNoMoreInteractions(userConnector, userRegistryConnector);
+    }
+
+    @Test
+    void toUserToNotifyDifferentInstitution(){
+        //given
+        Optional<String> tokenId = Optional.empty();
+        Optional<String> relationshipId = Optional.of(UUID.randomUUID().toString());
+        String userId = UUID.randomUUID().toString();
+        String institutionId = UUID.randomUUID().toString();
+        String productId = "prod-test";
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setRelationshipId(relationshipId.get());
+        onboardedProduct.setProductId(productId);
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        onboardedUser.setId(userId);
+        UserBinding userBinding = new UserBinding(UUID.randomUUID().toString(), List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        User userMock = new DummyUser(institutionId);
+        when(userRegistryConnector.getUserByInternalId(any(), any()))
+                .thenReturn(userMock);
+        when(userConnector.findById(any())).thenReturn(onboardedUser);
+        //when
+        List<UserToNotify> usersToNotify = userEventService.toUserToNotify(userId, institutionId, productId, relationshipId, tokenId);
+        //then
+        assertEquals(0, usersToNotify.size());
+        verify(userConnector, times(1)).findById(userId);
+        verify(userRegistryConnector, times(1)).getUserByInternalId(userId, EnumSet.allOf(User.Fields.class));
+        verifyNoMoreInteractions(userConnector, userRegistryConnector);
+    }
+}

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserRelationshipServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserRelationshipServiceImplTest.java
@@ -27,6 +27,9 @@ class UserRelationshipServiceImplTest {
     private InstitutionService institutionService;
 
     @Mock
+    private UserEventService userEventService;
+
+    @Mock
     private OnboardingDao onboardingDao;
 
     @Mock

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserRelationshipServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserRelationshipServiceImplTest.java
@@ -17,7 +17,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
+import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -76,10 +79,17 @@ class UserRelationshipServiceImplTest {
      */
     @Test
     void testActivateRelationship() {
+        String relationshipId = UUID.randomUUID().toString();
         doNothing().when(onboardingDao)
                 .updateUserProductState(any(), any(), any());
-        when(userConnector.findByRelationshipId(any())).thenReturn(new OnboardedUser());
-        userRelationshipServiceImpl.activateRelationship("42");
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        UserBinding userBinding = mockInstance(new UserBinding());
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setRelationshipId(relationshipId);
+        userBinding.setProducts(List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        when(userConnector.findByRelationshipId(any())).thenReturn(onboardedUser);
+        userRelationshipServiceImpl.activateRelationship(relationshipId);
         verify(onboardingDao).updateUserProductState(any(), any(), any());
         verify(userConnector).findByRelationshipId(any());
     }
@@ -100,10 +110,17 @@ class UserRelationshipServiceImplTest {
      */
     @Test
     void testSuspendRelationship() {
+        String relationshipId = UUID.randomUUID().toString();
         doNothing().when(onboardingDao)
                 .updateUserProductState(any(), any(), any());
-        when(userConnector.findByRelationshipId(any())).thenReturn(new OnboardedUser());
-        userRelationshipServiceImpl.suspendRelationship("42");
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        UserBinding userBinding = mockInstance(new UserBinding());
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setRelationshipId(relationshipId);
+        userBinding.setProducts(List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        when(userConnector.findByRelationshipId(any())).thenReturn(onboardedUser);
+        userRelationshipServiceImpl.suspendRelationship(relationshipId);
         verify(onboardingDao).updateUserProductState(any(), any(), any());
         verify(userConnector).findByRelationshipId(any());
     }
@@ -124,10 +141,17 @@ class UserRelationshipServiceImplTest {
      */
     @Test
     void testDeleteRelationship() {
+        String relationshipId = UUID.randomUUID().toString();
         doNothing().when(onboardingDao)
                 .updateUserProductState(any(), any(), any());
-        when(userConnector.findByRelationshipId(any())).thenReturn(new OnboardedUser());
-        userRelationshipServiceImpl.deleteRelationship("42");
+        OnboardedUser onboardedUser = mockInstance(new OnboardedUser());
+        UserBinding userBinding = mockInstance(new UserBinding());
+        OnboardedProduct onboardedProduct = mockInstance(new OnboardedProduct());
+        onboardedProduct.setRelationshipId(relationshipId);
+        userBinding.setProducts(List.of(onboardedProduct));
+        onboardedUser.setBindings(List.of(userBinding));
+        when(userConnector.findByRelationshipId(any())).thenReturn(onboardedUser);
+        userRelationshipServiceImpl.deleteRelationship(relationshipId);
         verify(onboardingDao).updateUserProductState(any(), any(), any());
         verify(userConnector).findByRelationshipId(any());
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/model/DummyUser.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/model/DummyUser.java
@@ -1,0 +1,38 @@
+package it.pagopa.selfcare.mscore.core.util.model;
+
+import it.pagopa.selfcare.mscore.model.CertifiedField;
+import it.pagopa.selfcare.mscore.model.institution.WorkContact;
+import it.pagopa.selfcare.mscore.model.user.User;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class DummyUser extends User {
+
+ public DummyUser(String institutionId){
+     this.setId(UUID.randomUUID().toString());
+     this.setFiscalCode("fiscalCode");
+     this.setName(setValue("name"));
+     this.setFamilyName(setValue("familyName"));
+     this.setWorkContacts(setContact(institutionId, setWorkContact("email")));
+ }
+
+ private CertifiedField<String> setValue(String value){
+     CertifiedField<String> certifiedField = new CertifiedField<>();
+     certifiedField.setValue(value);
+     return certifiedField;
+ }
+
+ private Map<String, WorkContact> setContact(String institutionId, WorkContact workContact){
+     Map<String, WorkContact> contactMap = new HashMap<>();
+     contactMap.put(institutionId, workContact);
+     return contactMap;
+ }
+
+ private WorkContact setWorkContact(String value){
+     WorkContact contact = new WorkContact();
+     contact.setEmail(setValue(value));
+     return contact;
+ }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Sending notification to new eventhub dedicated for user related events,
Two separate methods are implemented, one for Legal users(MANAGERs, DELEGATEs) and another one for (SUB_DELEGATEs, OPERATORs).

#### Motivation and Context

Two parties are going to connecto to the new topic, datalake and external-interceptor. The first needs the legals details in order to issue billings for products related operations, the latter will send all user related events to third party products.

#### How Has This Been Tested?

- Operator adding events has been tested deploying locally
- Managers and SUB_delegates been tested deploying locally


#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.