### PR TITLE
fix: correctly set the digital address when the PagoPA operator rejec…

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/EmailService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/EmailService.java
@@ -97,9 +97,7 @@ public class EmailService {
     }
 
     private List<String> getRejectDestinationMails(Institution institution) {
-        if (coreConfig.getDestinationMails() != null) {
-            return coreConfig.getDestinationMails();
-        } else if (institution.getDigitalAddress() != null) {
+        if (coreConfig.isSendEmailToInstitution()) {
             return List.of(institution.getDigitalAddress());
         } else {
             return List.of(coreConfig.getInstitutionAlternativeEmail());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/EmailServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/EmailServiceTest.java
@@ -529,8 +529,8 @@ class EmailServiceTest {
         product.setStatus(ProductStatus.ACTIVE);
         product.setTitle("Dr");
 
-        when(mailParametersMapper.getOnboardingRejectMailParameters(any(),any())).thenReturn(new HashMap<>());
-        when(coreConfig.getDestinationMails()).thenReturn(new ArrayList<>());
+        when(coreConfig.isSendEmailToInstitution()).thenReturn(false);
+        when(coreConfig.getInstitutionAlternativeEmail()).thenReturn("42");
         when(mailParametersMapper.getOnboardingRejectNotificationPath()).thenReturn("42");
         emailService.sendRejectMail(file,institution,product);
         assertNotNull(product);
@@ -551,8 +551,7 @@ class EmailServiceTest {
         product.setStatus(ProductStatus.ACTIVE);
         product.setTitle("Dr");
 
-        when(mailParametersMapper.getOnboardingRejectMailParameters(any(),any())).thenReturn(new HashMap<>());
-        when(coreConfig.getDestinationMails()).thenReturn(null);
+        when(coreConfig.isSendEmailToInstitution()).thenReturn(true);
         when(mailParametersMapper.getOnboardingRejectNotificationPath()).thenReturn("42");
         emailService.sendRejectMail(file,institution,product);
         assertNotNull(product);


### PR DESCRIPTION
…ts the onboarding request for no-PA institution

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

the condition for verifying whether to use the real institution's digital address or the PagoPA test pec has been changed

#### Motivation and Context

The condition as it was written did not work correctly and a check was made on an empty and non-null value, not allowing the PagoPA operator to refuse onboarding requests from no-PA institution

#### How Has This Been Tested?

the test performed was done in the dev environment by reconstructing the scenario present in prod

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.