### PR TITLE
Added new API to retrieve technical partners according to product id and type

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -2361,6 +2361,72 @@
         } ]
       }
     },
+    "/institutions/{productId}/brokers/{institutionType}" : {
+      "get" : {
+        "tags" : [ "Institution" ],
+        "summary" : "getInstitutionBrokers",
+        "description" : "${swagger.mscore.institutions.getInstitutionBrokers}",
+        "operationId" : "getInstitutionBrokersUsingGET",
+        "parameters" : [ {
+          "name" : "productId",
+          "in" : "path",
+          "description" : "Product's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "institutionType",
+          "in" : "path",
+          "description" : "Institution's type",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "GSP", "PA", "PG", "PSP", "PT", "SCP" ]
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/BrokerResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/bulk/institutions" : {
       "post" : {
         "tags" : [ "Management" ],
@@ -4383,6 +4449,22 @@
           },
           "vatNumber" : {
             "type" : "string"
+          }
+        }
+      },
+      "BrokerResponse" : {
+        "title" : "BrokerResponse",
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "numberOfDelegations" : {
+            "type" : "integer",
+            "format" : "int32"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.api;
 
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.SearchMode;
 import it.pagopa.selfcare.mscore.model.institution.*;
@@ -54,4 +55,6 @@ public interface InstitutionConnector {
     List<String> findByExternalIdsAndProductId(List<ValidInstitution> externalIds, String productId);
 
     Institution updateOnboardedProductCreatedAt(String institutionId, String productId, OffsetDateTime createdAt);
+
+    List<Institution> findBrokers(String productId, InstitutionType type);
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -7,6 +7,7 @@ import it.pagopa.selfcare.mscore.connector.dao.model.inner.OnboardingEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.InstitutionEntityMapper;
 
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.InstitutionMapperHelper;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.SearchMode;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
@@ -211,9 +212,9 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     public List<Onboarding> findOnboardingByIdAndProductId(String institutionId, String productId) {
 
         Optional<InstitutionEntity> optionalInstitution =  Objects.nonNull(productId)
-            ? Optional
+                ? Optional
                 .ofNullable(repository.findByInstitutionIdAndOnboardingProductId(institutionId, productId))
-            : repository.findById(institutionId);
+                : repository.findById(institutionId);
         return optionalInstitution
                 .map(institutionMapper::convertToInstitution)
                 .map(Institution::getOnboarding)
@@ -231,8 +232,8 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
 
         Page<InstitutionEntity> institutionEntities = repository.find(query, pageable, InstitutionEntity.class);
         return  institutionEntities.getContent().stream()
-                        .map(institutionMapper::convertToInstitution)
-                        .collect(Collectors.toList());
+                .map(institutionMapper::convertToInstitution)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -268,9 +269,9 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
         optProductId.ifPresent(productId -> criteriaOnboarding.and(Onboarding.Fields.productId.name()).is(productId));
 
         return repository.exists(Query.query(criteriaInstitution)
-                                .addCriteria(Criteria.where(InstitutionEntity.Fields.onboarding.name())
-                                        .elemMatch(criteriaOnboarding))
-                        , InstitutionEntity.class);
+                        .addCriteria(Criteria.where(InstitutionEntity.Fields.onboarding.name())
+                                .elemMatch(criteriaOnboarding))
+                , InstitutionEntity.class);
     }
 
     @Override
@@ -310,6 +311,17 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
         return institutionMapper.convertToInstitution(repository.findAndModify(query, updateInstitutionEntityUpdatedAt, findAndModifyOptions, InstitutionEntity.class));
     }
 
+    @Override
+    public List<Institution> findBrokers(String productId, InstitutionType type) {
+
+        Query query = Query.query(Criteria.where(InstitutionEntity.Fields.institutionType.name()).is(type)
+                .and(InstitutionEntity.Fields.onboarding.name()).elemMatch(Criteria.where(Onboarding.Fields.productId.name()).is(productId)));
+
+        List<InstitutionEntity> institutionEntities = repository.find(query, InstitutionEntity.class);
+        return  institutionEntities.stream()
+                .map(institutionMapper::convertToInstitution)
+                .collect(Collectors.toList());
+    }
 
     private Query constructQueryWithSearchMode(List<String> geo, SearchMode searchMode) {
         String geoQuery = InstitutionEntity.Fields.geographicTaxonomies.name()

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class InstitutionConnectorImplTest {
 
-
     @InjectMocks
     InstitutionConnectorImpl institutionConnectorImpl;
 
@@ -2620,6 +2619,137 @@ class InstitutionConnectorImplTest {
 
         Pageable capturedPage = pageableArgumentCaptor.getValue();
         assertEquals(pageNumber, capturedPage.getPageNumber());
+        verifyNoMoreInteractions(institutionRepository);
+    }
+
+    @Test
+    void findBrokers() {
+        final String productId = "productId";
+
+        BillingEntity billingEntity = new BillingEntity();
+        billingEntity.setPublicServices(true);
+        billingEntity.setRecipientCode("Recipient Code");
+        billingEntity.setVatNumber("42");
+
+        DataProtectionOfficerEntity dataProtectionOfficerEntity = new DataProtectionOfficerEntity();
+        dataProtectionOfficerEntity.setAddress("42 Main St");
+        dataProtectionOfficerEntity.setEmail("jane.doe@example.org");
+        dataProtectionOfficerEntity.setPec("Pec");
+
+        PaymentServiceProviderEntity paymentServiceProviderEntity = new PaymentServiceProviderEntity();
+        paymentServiceProviderEntity.setAbiCode("Abi Code");
+        paymentServiceProviderEntity.setBusinessRegisterNumber("42");
+        paymentServiceProviderEntity.setLegalRegisterName("Legal Register Name");
+        paymentServiceProviderEntity.setLegalRegisterNumber("42");
+        paymentServiceProviderEntity.setVatNumberGroup(true);
+
+        OnboardingEntity onboardingEntity = new OnboardingEntity();
+        onboardingEntity.setBilling(billingEntity);
+        onboardingEntity.setClosedAt(null);
+        onboardingEntity.setContract("Contract");
+        onboardingEntity.setCreatedAt(null);
+        onboardingEntity.setPricingPlan("Pricing Plan");
+        onboardingEntity.setProductId(productId);
+        onboardingEntity.setStatus(RelationshipState.PENDING);
+        onboardingEntity.setTokenId("42");
+        onboardingEntity.setUpdatedAt(null);
+
+        InstitutionEntity institutionEntity = new InstitutionEntity();
+        institutionEntity.setAddress("42 Main St");
+        institutionEntity.setAttributes(new ArrayList<>());
+        institutionEntity.setBilling(billingEntity);
+        institutionEntity.setBusinessRegisterPlace("Business Register Place");
+        institutionEntity.setCreatedAt(null);
+        institutionEntity.setDataProtectionOfficer(dataProtectionOfficerEntity);
+        institutionEntity.setDescription("The characteristics of someone or something");
+        institutionEntity.setDigitalAddress("42 Main St");
+        institutionEntity.setExternalId("42");
+        institutionEntity.setGeographicTaxonomies(new ArrayList<>());
+        institutionEntity.setId("42");
+        institutionEntity.setImported(true);
+        institutionEntity.setInstitutionType(InstitutionType.PA);
+        institutionEntity.setOnboarding(List.of(onboardingEntity));
+        institutionEntity.setOrigin(Origin.MOCK);
+        institutionEntity.setOriginId("42");
+        institutionEntity.setPaymentServiceProvider(paymentServiceProviderEntity);
+        institutionEntity.setRea("Rea");
+        institutionEntity.setShareCapital("Share Capital");
+        institutionEntity.setSupportEmail("jane.doe@example.org");
+        institutionEntity.setSupportPhone("6625550144");
+        institutionEntity.setTaxCode("Tax Code");
+        institutionEntity.setUpdatedAt(null);
+        institutionEntity.setZipCode("21654");
+
+        BillingEntity billingEntity1 = new BillingEntity();
+        billingEntity1.setPublicServices(false);
+        billingEntity1.setRecipientCode("it.pagopa.selfcare.mscore.connector.dao.model.inner.BillingEntity");
+        billingEntity1.setVatNumber("Vat Number");
+
+        DataProtectionOfficerEntity dataProtectionOfficerEntity1 = new DataProtectionOfficerEntity();
+        dataProtectionOfficerEntity1.setAddress("17 High St");
+        dataProtectionOfficerEntity1.setEmail("john.smith@example.org");
+        dataProtectionOfficerEntity1
+                .setPec("it.pagopa.selfcare.mscore.connector.dao.model.inner.DataProtectionOfficerEntity");
+
+        PaymentServiceProviderEntity paymentServiceProviderEntity1 = new PaymentServiceProviderEntity();
+        paymentServiceProviderEntity1
+                .setAbiCode("it.pagopa.selfcare.mscore.connector.dao.model.inner.PaymentServiceProviderEntity");
+        paymentServiceProviderEntity1.setBusinessRegisterNumber("Business Register Number");
+        paymentServiceProviderEntity1
+                .setLegalRegisterName("it.pagopa.selfcare.mscore.connector.dao.model.inner.PaymentServiceProviderEntity");
+        paymentServiceProviderEntity1.setLegalRegisterNumber("Legal Register Number");
+        paymentServiceProviderEntity1.setVatNumberGroup(false);
+
+        OnboardingEntity onboardingEntity1 = new OnboardingEntity();
+        onboardingEntity1.setBilling(billingEntity);
+        onboardingEntity1.setClosedAt(null);
+        onboardingEntity1.setContract("Contract");
+        onboardingEntity1.setCreatedAt(null);
+        onboardingEntity1.setPricingPlan("Pricing Plan");
+        onboardingEntity1.setProductId(productId);
+        onboardingEntity1.setStatus(RelationshipState.PENDING);
+        onboardingEntity1.setTokenId("42");
+        onboardingEntity1.setUpdatedAt(null);
+
+        InstitutionEntity institutionEntity1 = new InstitutionEntity();
+        institutionEntity1.setAddress("17 High St");
+        institutionEntity1.setAttributes(new ArrayList<>());
+        institutionEntity1.setBilling(billingEntity1);
+        institutionEntity1.setBusinessRegisterPlace("it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity");
+        institutionEntity1.setCreatedAt(null);
+        institutionEntity1.setDataProtectionOfficer(dataProtectionOfficerEntity1);
+        institutionEntity1.setDescription("Description");
+        institutionEntity1.setDigitalAddress("17 High St");
+        institutionEntity1.setExternalId("External Id");
+        institutionEntity1.setGeographicTaxonomies(new ArrayList<>());
+        institutionEntity1.setId("Id");
+        institutionEntity1.setImported(false);
+        institutionEntity1.setInstitutionType(InstitutionType.PG);
+        institutionEntity1.setOnboarding(List.of(onboardingEntity1));
+        institutionEntity1.setOrigin(Origin.IPA);
+        institutionEntity1.setOriginId("Origin Id");
+        institutionEntity1.setPaymentServiceProvider(paymentServiceProviderEntity1);
+        institutionEntity1.setRea("it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity");
+        institutionEntity1.setShareCapital("it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity");
+        institutionEntity1.setSupportEmail("john.smith@example.org");
+        institutionEntity1.setSupportPhone("8605550118");
+        institutionEntity1.setTaxCode("it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity");
+        institutionEntity1.setUpdatedAt(null);
+        institutionEntity1.setZipCode("OX1 1PT");
+
+        List<InstitutionEntity> institutionEntityList = List.of(institutionEntity, institutionEntity1);
+
+        doReturn(institutionEntityList)
+                .when(institutionRepository)
+                .find(any(), any());
+
+        // When
+        List<Institution> institutionsResult = institutionConnectorImpl.findBrokers(productId, InstitutionType.PT);
+        // Then
+        assertNotNull(institutionsResult);
+        assertEquals(2, institutionsResult.size());
+        verify(institutionRepository, times(1))
+                .find(queryArgumentCaptor.capture(), Mockito.eq(InstitutionEntity.class));
         verifyNoMoreInteractions(institutionRepository);
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.SearchMode;
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
@@ -69,4 +70,6 @@ public interface InstitutionService {
     List<RelationshipInfo> retrieveAllProduct(String userId, UserBinding binding, Institution institution, List<PartyRole> roles, List<RelationshipState> states, List<String> products, List<String> productRoles);
 
     List<Institution> getInstitutionsByProductId(String productId, Integer page, Integer size);
+
+    List<Institution> getInstitutionBrokers(String productId, InstitutionType type);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -425,6 +425,11 @@ public class InstitutionServiceImpl implements InstitutionService {
         return relationshipInfoList;
     }
 
+    @Override
+    public List<Institution> getInstitutionBrokers(String productId, InstitutionType type) {
+        return institutionConnector.findBrokers(productId, type);
+    }
+
     protected Boolean filterProduct(OnboardedProduct product, List<PartyRole> roles, List<RelationshipState> states, List<String> products, List<String> productRoles) {
 
         if (roles != null && !roles.isEmpty() && !roles.contains(product.getRole())) {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static it.pagopa.selfcare.mscore.core.util.TestUtils.dummyInstitutionPa;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -1432,6 +1433,24 @@ class InstitutionServiceImplTest {
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, executable);
         assertEquals("A createdAt date is required.", illegalArgumentException.getMessage());
         verifyNoInteractions(institutionConnector, tokenConnector, userConnector);
+
+    }
+
+    /**
+     * Method under test: {@link InstitutionServiceImpl#getInstitutionBrokers(String, InstitutionType)}
+     */
+    @Test
+    void getInstitutionBrokers() {
+
+        Institution institution = new Institution();
+        institution.setId("id");
+        when(institutionConnector.findBrokers(any(), any())).thenReturn(List.of(institution));
+        List<Institution> institutions = institutionServiceImpl.getInstitutionBrokers("42", InstitutionType.PT);
+        assertNotNull(institutions);
+        assertFalse(institutions.isEmpty());
+        assertNotNull(institutions.get(0));
+        assertEquals(institutions.get(0).getId(), institution.getId());
+        verify(institutionConnector).findBrokers(any(), any());
 
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -6,6 +6,7 @@ import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.mscore.constant.GenericError;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.InstitutionService;
 import it.pagopa.selfcare.mscore.model.institution.GeographicTaxonomies;
@@ -14,10 +15,7 @@ import it.pagopa.selfcare.mscore.model.institution.Onboarding;
 import it.pagopa.selfcare.mscore.model.institution.ValidInstitution;
 import it.pagopa.selfcare.mscore.model.user.RelationshipInfo;
 import it.pagopa.selfcare.mscore.web.model.institution.*;
-import it.pagopa.selfcare.mscore.web.model.mapper.InstitutionResourceMapper;
-import it.pagopa.selfcare.mscore.web.model.mapper.InstitutionMapperCustom;
-import it.pagopa.selfcare.mscore.web.model.mapper.OnboardingResourceMapper;
-import it.pagopa.selfcare.mscore.web.model.mapper.RelationshipMapper;
+import it.pagopa.selfcare.mscore.web.model.mapper.*;
 import it.pagopa.selfcare.mscore.web.model.onboarding.OnboardedProducts;
 import it.pagopa.selfcare.mscore.web.util.CustomExceptionMessage;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import javax.validation.ValidationException;
 import java.time.OffsetDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -43,13 +42,16 @@ public class InstitutionController {
     private final InstitutionService institutionService;
     private final OnboardingResourceMapper onboardingResourceMapper;
     private final InstitutionResourceMapper institutionResourceMapper;
+    private final BrokerMapper brokerMapper;
 
     public InstitutionController(InstitutionService institutionService,
                                  OnboardingResourceMapper onboardingResourceMapper,
-                                 InstitutionResourceMapper institutionResourceMapper) {
+                                 InstitutionResourceMapper institutionResourceMapper,
+                                 BrokerMapper brokerMapper) {
         this.institutionService = institutionService;
         this.onboardingResourceMapper = onboardingResourceMapper;
         this.institutionResourceMapper = institutionResourceMapper;
+        this.brokerMapper = brokerMapper;
     }
 
     /**
@@ -405,5 +407,23 @@ public class InstitutionController {
 
         log.trace("findFromProduct end");
         return ResponseEntity.ok().body(institutionListResponse);
+    }
+
+    @GetMapping(value = "/{productId}/brokers/{institutionType}")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "", notes = "${swagger.mscore.institutions.getInstitutionBrokers}")
+    public Collection<BrokerResponse> getInstitutionBrokers(@ApiParam("${swagger.mscore.institutions.model.productId}")
+                                                            @PathVariable("productId")
+                                                            String productId,
+                                                            @ApiParam("${swagger.mscore.institutions.model.type}")
+                                                            @PathVariable("institutionType")
+                                                            InstitutionType institutionType) {
+        log.trace("getInstitutionBrokers start");
+        log.debug("productId = {}, institutionType = {}", productId, institutionType);
+        List<Institution> institutions = institutionService.getInstitutionBrokers(productId, institutionType);
+        List<BrokerResponse> result = brokerMapper.toBrokers(institutions);
+        log.debug("getInstitutionBrokers result = {}", result);
+        log.trace("getInstitutionBrokers end");
+        return result;
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/BrokerResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/BrokerResponse.java
@@ -1,0 +1,12 @@
+package it.pagopa.selfcare.mscore.web.model.institution;
+
+import lombok.Data;
+
+@Data
+public class BrokerResponse {
+
+    private String id;
+    private String description;
+    private int numberOfDelegations;
+
+}

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/BrokerMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/BrokerMapper.java
@@ -1,0 +1,14 @@
+package it.pagopa.selfcare.mscore.web.model.mapper;
+
+import it.pagopa.selfcare.mscore.model.institution.Institution;
+import it.pagopa.selfcare.mscore.web.model.institution.BrokerResponse;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BrokerMapper {
+
+    BrokerResponse toBroker(Institution institution);
+    List<BrokerResponse> toBrokers(List<Institution> institutions);
+}

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -31,6 +31,7 @@ swagger.mscore.institutions.model.relationshipState=List of Relationship state f
 swagger.mscore.institutions.valid=Retrieve list of institution which logged user can onboard
 swagger.mscore.institutions.model.internalIds=List of Institution to onboard
 swagger.mscore.institutions.model.createdAt=The createdAt date
+swagger.mscore.institutions.model.type=Institution's type
 swagger.mscore.onboarding.institution.complete = update institution and users data without adding a new token
 swagger.mscore.onboarding.institution=create a new Token (contract), and update institution and users data
 swagger.mscore.onboarding.complete=complete an onboarding request

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/model/mapper/BrokerMapperImplTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/model/mapper/BrokerMapperImplTest.java
@@ -1,0 +1,39 @@
+package it.pagopa.selfcare.mscore.web.model.mapper;
+
+import it.pagopa.selfcare.mscore.model.institution.Institution;
+import it.pagopa.selfcare.mscore.web.model.institution.BrokerResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class BrokerMapperImplTest {
+
+    @Test
+    void toBroker() {
+        BrokerMapperImpl mapper = new BrokerMapperImpl();
+        Institution institution = new Institution();
+        institution.setId("id");
+        institution.setDescription("description");
+        BrokerResponse broker = mapper.toBroker(institution);
+        assertNotNull(broker);
+        assertEquals(broker.getId(), institution.getId());
+        assertEquals(broker.getDescription(), institution.getDescription());
+    }
+
+    @Test
+    void toBrokers() {
+        BrokerMapperImpl mapper = new BrokerMapperImpl();
+        Institution institution = new Institution();
+        institution.setId("id");
+        institution.setDescription("description");
+        List<BrokerResponse> brokers = mapper.toBrokers(List.of(institution));
+        assertNotNull(brokers);
+        assertEquals(1, brokers.size());
+        assertNotNull(brokers.get(0));
+        assertEquals(brokers.get(0).getId(), institution.getId());
+        assertEquals(brokers.get(0).getDescription(), institution.getDescription());
+    }
+}


### PR DESCRIPTION
#### List of Changes

Created new API to retrieve technical partners that match product id and institution type in input.

#### Motivation and Context

This development is part of a new feature that allow to link a technical partner to an institution.

#### How Has This Been Tested?

I have run ms-core microservice locally aiming to dev environment. I have tested the specific api and verified that http status code of respons is 200 and payload is not empty according to data of collection in dev environment.
