### PR TITLE
[SELC - 2777] added subUnitCode, subUnitType and RootParent to send notificat…

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
@@ -24,5 +24,8 @@ public class InstitutionToNotify {
     private String city;
     private String country;
     private String county;
+    private String subUnitCode;
+    private String subUnitType;
+    private RootParent rootParent;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/RootParent.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/RootParent.java
@@ -1,0 +1,13 @@
+package it.pagopa.selfcare.mscore.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RootParent {
+    private String id;
+    private String description;
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -29,6 +29,7 @@ import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.InstitutionToNotify;
 import it.pagopa.selfcare.mscore.model.NotificationToSend;
 import it.pagopa.selfcare.mscore.model.QueueEvent;
+import it.pagopa.selfcare.mscore.model.RootParent;
 import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
 import it.pagopa.selfcare.mscore.model.onboarding.ResourceResponse;
@@ -290,6 +291,11 @@ public class ContractService {
         toNotify.setOriginId(institution.getOriginId());
         toNotify.setZipCode(institution.getZipCode());
         toNotify.setPaymentServiceProvider(institution.getPaymentServiceProvider());
+        toNotify.setSubUnitCode(institution.getSubunitCode());
+        toNotify.setSubUnitType(institution.getSubunitType());
+        RootParent rootParent = new RootParent();
+        rootParent.setDescription(institution.getDescription());
+        toNotify.setRootParent(rootParent);
         try {
             InstitutionProxyInfo institutionProxyInfo = partyRegistryProxyConnector.getInstitutionById(institution.getExternalId());
             toNotify.setIstatCode(institutionProxyInfo.getIstatCode());


### PR DESCRIPTION
…ion to DataLake

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

The subUnitCode, subUnitType and RootParent fields have been added for sending the notification to datalake
#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?


To test the change made, an onboarding was performed in order to send a notification to datalake, subsequently it was verified that the added fields had been sent

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.