### PR TITLE
Added activatedAt and deletedAt to Token Entity

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -5489,6 +5489,12 @@
             "type" : "string",
             "enum" : [ "GSP", "PA", "PG", "PSP", "PT", "SCP" ]
           },
+          "onboarding" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/OnboardedProductResponse"
+            }
+          },
           "origin" : {
             "type" : "string"
           },
@@ -6041,6 +6047,22 @@
           "updatedAt" : {
             "type" : "string",
             "format" : "date-time"
+          }
+        }
+      },
+      "OnboardedProductResponse" : {
+        "title" : "OnboardedProductResponse",
+        "type" : "object",
+        "properties" : {
+          "billing" : {
+            "$ref" : "#/components/schemas/BillingResponse"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "ACTIVE", "DELETED", "PENDING", "REJECTED", "SUSPENDED", "TOBEVALIDATED" ]
           }
         }
       },
@@ -6611,6 +6633,10 @@
         "title" : "Token",
         "type" : "object",
         "properties" : {
+          "activatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
           "checksum" : {
             "type" : "string"
           },
@@ -6631,6 +6657,10 @@
             "type" : "string"
           },
           "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "deletedAt" : {
             "type" : "string",
             "format" : "date-time"
           },

--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -6640,10 +6640,6 @@
           "checksum" : {
             "type" : "string"
           },
-          "closedAt" : {
-            "type" : "string",
-            "format" : "date-time"
-          },
           "contentType" : {
             "type" : "string"
           },

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/NotificationToSend.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/NotificationToSend.java
@@ -25,6 +25,7 @@ public class NotificationToSend {
     private OffsetDateTime createdAt;
     private OffsetDateTime activatedAt;
     private OffsetDateTime deletedAt;
+    private OffsetDateTime closedAt;
     private OffsetDateTime updatedAt;
     private List<UserToNotify> users;
     private QueueEvent notificationType;

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/Token.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/Token.java
@@ -32,6 +32,5 @@ public class Token {
     private OffsetDateTime activatedAt;
     private OffsetDateTime updatedAt;
     private OffsetDateTime deletedAt;
-    private OffsetDateTime closedAt;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/Token.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/Token.java
@@ -29,7 +29,9 @@ public class Token {
     private List<TokenUser> users;
     private InstitutionUpdate institutionUpdate;
     private OffsetDateTime createdAt;
+    private OffsetDateTime activatedAt;
     private OffsetDateTime updatedAt;
+    private OffsetDateTime deletedAt;
     private OffsetDateTime closedAt;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/utils/MockUtils.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/utils/MockUtils.java
@@ -43,7 +43,7 @@ public class MockUtils {
         tokenMock.setInstitutionUpdate(createInstitutionUpdateMock(bias, institutionType));
         tokenMock.setCreatedAt(OffsetDateTime.now().minusDays(2));
         tokenMock.setUpdatedAt(OffsetDateTime.now().minusDays(1));
-        tokenMock.setClosedAt((status.equals(RelationshipState.DELETED) ? OffsetDateTime.now() : null));
+        tokenMock.setDeletedAt((status.equals(RelationshipState.DELETED) ? OffsetDateTime.now() : null));
         return tokenMock;
     }
 

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
@@ -100,8 +100,12 @@ public class TokenConnectorImpl implements TokenConnector {
         if (token.getContentType() != null) {
             updateDefinition.set(TokenEntity.Fields.contentType.name(), token.getContentType());
         }
+        if (status == RelationshipState.ACTIVE){
+            updateDefinition.set(TokenEntity.Fields.activatedAt.name(), now);
+        }
         if (status == RelationshipState.DELETED) {
-            updateDefinition.set(TokenEntity.Fields.closedAt.name(), now);
+            updateDefinition.set(TokenEntity.Fields.closedAt.name(), now)
+                    .set(TokenEntity.Fields.deletedAt.name(), now);
         }
         FindAndModifyOptions findAndModifyOptions = FindAndModifyOptions.options().upsert(false).returnNew(false);
         return convertToToken(tokenRepository.findAndModify(query, updateDefinition, findAndModifyOptions, TokenEntity.class));

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
@@ -104,8 +104,7 @@ public class TokenConnectorImpl implements TokenConnector {
             updateDefinition.set(TokenEntity.Fields.activatedAt.name(), now);
         }
         if (status == RelationshipState.DELETED) {
-            updateDefinition.set(TokenEntity.Fields.closedAt.name(), now)
-                    .set(TokenEntity.Fields.deletedAt.name(), now);
+            updateDefinition.set(TokenEntity.Fields.deletedAt.name(), now);
         }
         FindAndModifyOptions findAndModifyOptions = FindAndModifyOptions.options().upsert(false).returnNew(false);
         return convertToToken(tokenRepository.findAndModify(query, updateDefinition, findAndModifyOptions, TokenEntity.class));

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/TokenEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/TokenEntity.java
@@ -39,9 +39,8 @@ public class TokenEntity {
     @Indexed
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
-    private OffsetDateTime closedAt;
-    private OffsetDateTime activatedAt;
     private OffsetDateTime deletedAt;
+    private OffsetDateTime activatedAt;
 
 }
 

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/TokenEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/TokenEntity.java
@@ -40,5 +40,8 @@ public class TokenEntity {
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
     private OffsetDateTime closedAt;
+    private OffsetDateTime activatedAt;
+    private OffsetDateTime deletedAt;
+
 }
 

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/utils/DaoMockUtils.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/utils/DaoMockUtils.java
@@ -34,7 +34,7 @@ public class DaoMockUtils {
         tokenEntityMock.setContractSigned("ContractPath/" + tokenEntityMock.getId() + "/FileName");
         tokenEntityMock.setCreatedAt(OffsetDateTime.now().minusDays(2));
         tokenEntityMock.setUpdatedAt(OffsetDateTime.now().minusDays(1));
-        tokenEntityMock.setClosedAt((status.equals(RelationshipState.DELETED) ? OffsetDateTime.now() : null));
+        tokenEntityMock.setDeletedAt((status.equals(RelationshipState.DELETED) ? OffsetDateTime.now() : null));
         return tokenEntityMock;
     }
 }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
@@ -1121,6 +1121,33 @@ class TokenConnectorImplTest {
     }
 
     @Test
+    void findAndUpdateTokenActivated(){
+        // Given
+        Token tokenMock = MockUtils.createTokenMock(null, RelationshipState.ACTIVE, InstitutionType.GSP);
+        tokenMock.setContractSigned(null);
+        tokenMock.setContentType(null);
+        RelationshipState statusMock = RelationshipState.ACTIVE;
+        TokenEntity updatedTokenMock = DaoMockUtils.createTokenEntityMock(null, RelationshipState.ACTIVE);
+
+        when(tokenRepository.findAndModify(any(), any(), any(), any()))
+                .thenReturn(updatedTokenMock);
+        // When
+        Token result = tokenConnectorImpl.findAndUpdateToken(tokenMock, statusMock, null);
+        // Then
+        assertNotNull(result);
+        verify(tokenRepository, times(1))
+                .findAndModify(queryArgumentCaptor.capture(), updateArgumentCaptor.capture(), findAndModifyOptionsArgumentCaptor.capture(), Mockito.eq(TokenEntity.class));
+        Query capturedQuery = queryArgumentCaptor.getValue();
+        assertTrue(capturedQuery.getQueryObject().get(TokenEntity.Fields.id.name()).toString().contains(tokenMock.getId()));
+        Update capturedUpdate = updateArgumentCaptor.getValue();
+        assertTrue(capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.status.name()) &&
+                capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.updatedAt.name()) &&
+                capturedUpdate.getUpdateObject().get("$set").toString().contains(statusMock.toString()) &&
+                capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.activatedAt.name()));
+        verifyNoMoreInteractions(tokenRepository);
+    }
+
+    @Test
     void findWithFilter() {
         TokenEntity token = new TokenEntity();
         token.setId("507f1f77bcf86cd799439011");

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
@@ -106,7 +106,7 @@ class TokenConnectorImplTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -163,7 +163,7 @@ class TokenConnectorImplTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -214,7 +214,7 @@ class TokenConnectorImplTest {
 
         TokenEntity tokenEntity1 = new TokenEntity();
         tokenEntity1.setChecksum("it.pagopa.selfcare.mscore.connector.dao.model.TokenEntity");
-        tokenEntity1.setClosedAt(null);
+        tokenEntity1.setDeletedAt(null);
         tokenEntity1.setContractSigned("it.pagopa.selfcare.mscore.connector.dao.model.TokenEntity");
         tokenEntity1.setContractTemplate("it.pagopa.selfcare.mscore.connector.dao.model.TokenEntity");
         tokenEntity1.setCreatedAt(null);
@@ -354,7 +354,7 @@ class TokenConnectorImplTest {
         when(tokenEntity.getUpdatedAt()).thenReturn(null);
         when(tokenEntity.getUsers()).thenReturn(new ArrayList<>());
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -487,7 +487,7 @@ class TokenConnectorImplTest {
         when(tokenEntity.getUpdatedAt()).thenReturn(null);
         when(tokenEntity.getUsers()).thenReturn(new ArrayList<>());
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -593,7 +593,7 @@ class TokenConnectorImplTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -634,7 +634,7 @@ class TokenConnectorImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -778,7 +778,7 @@ class TokenConnectorImplTest {
         when(tokenEntity.getUpdatedAt()).thenReturn(null);
         when(tokenEntity.getUsers()).thenReturn(new ArrayList<>());
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -819,7 +819,7 @@ class TokenConnectorImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -967,7 +967,7 @@ class TokenConnectorImplTest {
         when(tokenEntity.getUpdatedAt()).thenReturn(null);
         when(tokenEntity.getUsers()).thenReturn(new ArrayList<>());
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -1008,7 +1008,7 @@ class TokenConnectorImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -1087,7 +1087,7 @@ class TokenConnectorImplTest {
         assertTrue(capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.checksum.name()) &&
                 capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.contractSigned.name()) &&
                 capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.contentType.name()) &&
-                capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.closedAt.name()) &&
+                capturedUpdate.getUpdateObject().get("$set").toString().contains(TokenEntity.Fields.deletedAt.name()) &&
                 capturedUpdate.getUpdateObject().get("$set").toString().contains(digestMock) &&
                 capturedUpdate.getUpdateObject().get("$set").toString().contains(tokenMock.getContractSigned()) &&
                 capturedUpdate.getUpdateObject().get("$set").toString().contains(tokenMock.getContentType()));

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/TokenMapperTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/TokenMapperTest.java
@@ -1,16 +1,8 @@
 package it.pagopa.selfcare.mscore.connector.dao.model.mapper;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.mscore.connector.dao.model.TokenEntity;
-import it.pagopa.selfcare.mscore.connector.dao.model.inner.DataProtectionOfficerEntity;
-import it.pagopa.selfcare.mscore.connector.dao.model.inner.GeoTaxonomyEntity;
-import it.pagopa.selfcare.mscore.connector.dao.model.inner.InstitutionUpdateEntity;
-import it.pagopa.selfcare.mscore.connector.dao.model.inner.PaymentServiceProviderEntity;
-import it.pagopa.selfcare.mscore.connector.dao.model.inner.TokenUserEntity;
+import it.pagopa.selfcare.mscore.connector.dao.model.inner.*;
 import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.TokenType;
@@ -20,11 +12,12 @@ import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
 import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
 import it.pagopa.selfcare.mscore.model.onboarding.TokenUser;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 class TokenMapperTest {
     /**
@@ -53,7 +46,7 @@ class TokenMapperTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -106,7 +99,7 @@ class TokenMapperTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -170,7 +163,7 @@ class TokenMapperTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -243,7 +236,7 @@ class TokenMapperTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -321,7 +314,7 @@ class TokenMapperTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -401,7 +394,7 @@ class TokenMapperTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -434,7 +427,7 @@ class TokenMapperTest {
     void testConvertToToken2() {
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -484,7 +477,7 @@ class TokenMapperTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -536,7 +529,7 @@ class TokenMapperTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);
@@ -576,7 +569,7 @@ class TokenMapperTest {
 
         TokenEntity tokenEntity = new TokenEntity();
         tokenEntity.setChecksum("Checksum");
-        tokenEntity.setClosedAt(null);
+        tokenEntity.setDeletedAt(null);
         tokenEntity.setContractSigned("Contract Signed");
         tokenEntity.setContractTemplate("Contract Template");
         tokenEntity.setCreatedAt(null);

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/utils/TestUtils.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/utils/TestUtils.java
@@ -137,7 +137,7 @@ public class TestUtils {
     public static Token createSimpleToken(InstitutionUpdate institutionUpdate) {
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -251,7 +251,6 @@ public class ContractService {
         if (queueEvent.equals(QueueEvent.ADD)) {
             notification.setId(token.getId());
             notification.setState(RelationshipState.ACTIVE.toString());
-            notification.setCreatedAt(token.getActivatedAt());
         } else {
             notification.setId(UUID.randomUUID().toString());
             notification.setState(token.getStatus() == RelationshipState.DELETED ? "CLOSED" : token.getStatus().toString());
@@ -260,7 +259,7 @@ public class ContractService {
         notification.setProduct(token.getProductId());
         notification.setFilePath(token.getContractSigned());
         notification.setOnboardingTokenId(token.getId());
-        notification.setCreatedAt(token.getCreatedAt());
+        notification.setCreatedAt(token.getActivatedAt());
         notification.setUpdatedAt(Optional.ofNullable(token.getUpdatedAt()).orElse(token.getCreatedAt()));
         if (token.getStatus().equals(RelationshipState.DELETED)) {
             notification.setClosedAt(token.getDeletedAt());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -251,7 +251,7 @@ public class ContractService {
         if (queueEvent.equals(QueueEvent.ADD)) {
             notification.setId(token.getId());
             notification.setState(RelationshipState.ACTIVE.toString());
-            notification.setActivatedAt(OffsetDateTime.now());
+            notification.setCreatedAt(token.getActivatedAt());
         } else {
             notification.setId(UUID.randomUUID().toString());
             notification.setState(token.getStatus() == RelationshipState.DELETED ? "CLOSED" : token.getStatus().toString());
@@ -263,7 +263,7 @@ public class ContractService {
         notification.setCreatedAt(token.getCreatedAt());
         notification.setUpdatedAt(Optional.ofNullable(token.getUpdatedAt()).orElse(token.getCreatedAt()));
         if (token.getStatus().equals(RelationshipState.DELETED)) {
-            notification.setDeletedAt(token.getUpdatedAt());
+            notification.setClosedAt(token.getDeletedAt());
         }
         notification.setNotificationType(queueEvent);
         notification.setFileName(retrieveFileName(token.getContractSigned(), token.getId()));

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractServiceTest.java
@@ -238,7 +238,7 @@ class ContractServiceTest {
         token.setProductId("prod");
         token.setStatus(RelationshipState.ACTIVE);
         token.setInstitutionUpdate(institutionUpdate);
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setUsers(List.of(tokenUser1, tokenUser2));
         token.setContractSigned("ContractPath".concat("/").concat(token.getId()).concat("/").concat("fileName.pdf"));
         token.setContentType(MediaType.APPLICATION_JSON_VALUE);
@@ -318,7 +318,7 @@ class ContractServiceTest {
         token.setProductId("prod");
         token.setStatus(RelationshipState.ACTIVE);
         token.setInstitutionUpdate(institutionUpdate);
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setUsers(List.of(tokenUser1, tokenUser2));
         token.setContractSigned("");
 
@@ -386,7 +386,7 @@ class ContractServiceTest {
         token.setProductId("prod");
         token.setStatus(RelationshipState.DELETED);
         token.setInstitutionUpdate(institutionUpdate);
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setUsers(List.of(tokenUser1, tokenUser2));
         token.setContractSigned(null);
         token.setContentType(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
@@ -661,7 +661,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -709,7 +709,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -756,7 +756,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -803,7 +803,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -853,7 +853,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -1008,7 +1008,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -2038,7 +2038,7 @@ class OnboardingDaoTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -391,7 +391,7 @@ class OnboardingServiceImplTest {
         institution.setOnboarding(onboardingList);
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -506,7 +506,7 @@ class OnboardingServiceImplTest {
         institution.setOnboarding(onboardingList);
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -560,7 +560,7 @@ class OnboardingServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -600,7 +600,7 @@ class OnboardingServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -639,7 +639,7 @@ class OnboardingServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -696,7 +696,7 @@ class OnboardingServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -1193,7 +1193,7 @@ class OnboardingServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -1281,7 +1281,7 @@ class OnboardingServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -1316,7 +1316,7 @@ class OnboardingServiceImplTest {
         Token token = mock(Token.class);
         when(token.getExpiringDate()).thenReturn(null);
         doNothing().when(token).setChecksum(any());
-        doNothing().when(token).setClosedAt(any());
+        doNothing().when(token).setDeletedAt(any());
         doNothing().when(token).setContractSigned(any());
         doNothing().when(token).setContractTemplate(any());
         doNothing().when(token).setCreatedAt(any());
@@ -1329,7 +1329,7 @@ class OnboardingServiceImplTest {
         doNothing().when(token).setType(any());
         doNothing().when(token).setUpdatedAt(any());
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -1345,7 +1345,7 @@ class OnboardingServiceImplTest {
         onboardingServiceImpl.checkAndHandleExpiring(token);
         verify(token).getExpiringDate();
         verify(token).setChecksum(any());
-        verify(token).setClosedAt(any());
+        verify(token).setDeletedAt(any());
         verify(token).setContractSigned(any());
         verify(token).setContractTemplate(any());
         verify(token).setCreatedAt(any());
@@ -1400,7 +1400,7 @@ class OnboardingServiceImplTest {
         token.setInstitutionUpdate(institutionUpdate);
         token.setCreatedAt(token.getExpiringDate().minusDays(150));
         token.setUpdatedAt(null);
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
 
         Institution institution = new Institution();
         institution.setId("InstitutionId");

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/TestUtils.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/TestUtils.java
@@ -29,7 +29,7 @@ public class TestUtils {
     public static Token dummyToken() {
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/migration/MigrationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/migration/MigrationServiceImplTest.java
@@ -1,11 +1,5 @@
 package it.pagopa.selfcare.mscore.core.migration;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.TokenConnector;
 import it.pagopa.selfcare.mscore.api.UserConnector;
@@ -18,16 +12,18 @@ import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
 import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 @ContextConfiguration(classes = {MigrationServiceImpl.class})
 @ExtendWith(SpringExtension.class)
@@ -48,7 +44,7 @@ class MigrationServiceImplTest {
     void testCreateToken2(){
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -91,7 +87,7 @@ class MigrationServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -127,7 +123,7 @@ class MigrationServiceImplTest {
 
         Token token1 = new Token();
         token1.setChecksum("Checksum");
-        token1.setClosedAt(null);
+        token1.setDeletedAt(null);
         token1.setContractSigned("Contract Signed");
         token1.setContractTemplate("Contract Template");
         token1.setCreatedAt(null);
@@ -231,7 +227,7 @@ class MigrationServiceImplTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.verify;
 
 
 @ExtendWith(MockitoExtension.class)
@@ -144,7 +143,7 @@ class OnboardingInstitutionStrategyTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -215,7 +214,7 @@ class OnboardingInstitutionStrategyTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -281,7 +280,7 @@ class OnboardingInstitutionStrategyTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -488,7 +487,7 @@ class OnboardingInstitutionStrategyTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtilsTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtilsTest.java
@@ -1,7 +1,10 @@
 package it.pagopa.selfcare.mscore.core.util;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
-import it.pagopa.selfcare.mscore.constant.*;
+import it.pagopa.selfcare.mscore.constant.Env;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
+import it.pagopa.selfcare.mscore.constant.TokenType;
 import it.pagopa.selfcare.mscore.core.TestUtils;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
@@ -12,7 +15,6 @@ import it.pagopa.selfcare.mscore.model.user.UserToOnboard;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-
 
 import java.util.ArrayList;
 import java.util.List;
@@ -105,7 +107,7 @@ class OnboardingInstitutionUtilsTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -153,7 +155,7 @@ class OnboardingInstitutionUtilsTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -203,7 +205,7 @@ class OnboardingInstitutionUtilsTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -253,7 +255,7 @@ class OnboardingInstitutionUtilsTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -371,7 +373,7 @@ class OnboardingInstitutionUtilsTest {
         institution.setOnboarding(onboardingList);
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -428,7 +430,7 @@ class OnboardingInstitutionUtilsTest {
         institution.setOnboarding(onboardingList);
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TokenUtilsTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TokenUtilsTest.java
@@ -4,21 +4,18 @@ import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.TokenType;
 import it.pagopa.selfcare.mscore.model.institution.*;
-import it.pagopa.selfcare.mscore.model.institution.DataProtectionOfficer;
-import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
-import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
-import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
 import it.pagopa.selfcare.mscore.model.onboarding.Contract;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
 import it.pagopa.selfcare.mscore.model.onboarding.TokenRelationships;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -246,7 +243,7 @@ class TokenUtilsTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/TokenMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/TokenMapper.java
@@ -55,7 +55,7 @@ public class TokenMapper {
             resource.setInstitutionUpdate(model.getInstitutionUpdate());
             resource.setCreatedAt(model.getCreatedAt());
             resource.setUpdatedAt(model.getUpdatedAt());
-            resource.setClosedAt(model.getClosedAt());
+            resource.setClosedAt(model.getDeletedAt());
         }
         return resource;
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/migration/MigrationMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/migration/MigrationMapper.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.migration;
-import it.pagopa.selfcare.mscore.model.institution.*;
+
+import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
 import lombok.AccessLevel;
@@ -24,7 +25,7 @@ public class MigrationMapper {
         token.setInstitutionUpdate(migrationToken.getInstitutionUpdate());
         token.setCreatedAt(migrationToken.getCreatedAt());
         token.setUpdatedAt(migrationToken.getUpdatedAt());
-        token.setClosedAt(migrationToken.getClosedAt());
+        token.setDeletedAt(migrationToken.getClosedAt());
         return token;
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/CrudControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/CrudControllerTest.java
@@ -1,25 +1,14 @@
 package it.pagopa.selfcare.mscore.web.controller;
 
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.TokenType;
 import it.pagopa.selfcare.mscore.core.migration.MigrationService;
-import it.pagopa.selfcare.mscore.model.institution.Billing;
-import it.pagopa.selfcare.mscore.model.institution.DataProtectionOfficer;
-import it.pagopa.selfcare.mscore.model.institution.Institution;
-import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
-import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
+import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
-
-import java.util.ArrayList;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +22,10 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.ArrayList;
+
+import static org.mockito.Mockito.*;
 
 @ContextConfiguration(classes = {CrudController.class})
 @ExtendWith(SpringExtension.class)
@@ -66,7 +59,7 @@ class CrudControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -102,7 +95,7 @@ class CrudControllerTest {
 
         Token token1 = new Token();
         token1.setChecksum("Checksum");
-        token1.setClosedAt(null);
+        token1.setDeletedAt(null);
         token1.setContractSigned("Contract Signed");
         token1.setContractTemplate("Contract Template");
         token1.setCreatedAt(null);
@@ -224,7 +217,7 @@ class CrudControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/OnboardingControllerTest.java
@@ -156,7 +156,7 @@ class OnboardingControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -469,7 +469,7 @@ class OnboardingControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -557,7 +557,7 @@ class OnboardingControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -686,7 +686,7 @@ class OnboardingControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);
@@ -736,7 +736,7 @@ class OnboardingControllerTest {
 
         Token token = new Token();
         token.setChecksum("Checksum");
-        token.setClosedAt(null);
+        token.setDeletedAt(null);
         token.setContractSigned("Contract Signed");
         token.setContractTemplate("Contract Template");
         token.setCreatedAt(null);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added new Fields to Token Entity; activatedAt and deletedAt

#### Motivation and Context

Need to save the instant when a token is consumed and the onboarding is completed and also when a token is regected saving the deletion instant

#### How Has This Been Tested?

deployed from branch and verified on DB and eventhub
#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.