### PR TITLE
Added rootParentId into OnboaringInfo response

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -6065,6 +6065,9 @@
             "type" : "string",
             "enum" : [ "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE" ]
           },
+          "rootParentId" : {
+            "type" : "string"
+          },
           "state" : {
             "type" : "string"
           },

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
@@ -42,7 +42,6 @@ public class Institution {
     private String subunitType;
     private String rootParentId;
     private String parentDescription;
-    private String rootParentId;
     private PaAttributes paAttributes;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
@@ -41,6 +41,7 @@ public class Institution {
 
     private String subunitCode;
     private String subunitType;
+    private String rootParentId;
     private String parentDescription;
     private PaAttributes paAttributes;
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
@@ -38,7 +38,6 @@ public class Institution {
     private boolean imported;
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
-
     private String subunitCode;
     private String subunitType;
     private String rootParentId;

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/InstitutionEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/InstitutionEntity.java
@@ -47,10 +47,10 @@ public class InstitutionEntity {
     private boolean imported;
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;
-
     private String subunitCode;
     private String subunitType;
     private String parentDescription;
+    private String rootParentId;
     private PaAttributesEntity paAttributes;
 
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils {
                 "The characteristics of someone or something", institutionType, "42 Main St", "42 Main St", "21654",
                 "TaxCode", billing, onboarding, geographicTaxonomies, attributes, paymentServiceProvider,
                 new DataProtectionOfficer(), null, null, "START - setupCommonData", "START - setupCommonData",
-                "START - setupCommonData", true, OffsetDateTime.now(), OffsetDateTime.now(), null, null, null, new PaAttributes());
+                "START - setupCommonData", true, OffsetDateTime.now(), OffsetDateTime.now(), null, null, null, null, new PaAttributes());
     }
 
     public static OnboardingRequest dummyOnboardingRequest(Billing billing, Contract contract, InstitutionUpdate institutionUpdate){

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingMapper.java
@@ -79,6 +79,7 @@ public class OnboardingMapper {
         institutionResponse.setPaymentServiceProvider(InstitutionMapperCustom.toPaymentServiceProviderResponse(institution.getPaymentServiceProvider()));
         institutionResponse.setDataProtectionOfficer(InstitutionMapperCustom.toDataProtectionOfficerResponse(institution.getDataProtectionOfficer()));
         institutionResponse.setParentDescription(institution.getParentDescription());
+        institutionResponse.setRootParentId(institution.getRootParentId());
         institutionResponse.setSubunitCode(institution.getSubunitCode());
         institutionResponse.setSubunitType(institution.getSubunitType());
         institutionResponse.setAooParentCode(Optional.ofNullable(institution.getPaAttributes()).map(PaAttributes::getAooParentCode).orElse(null));

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/OnboardedInstitutionResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/OnboardedInstitutionResponse.java
@@ -38,6 +38,7 @@ public class OnboardedInstitutionResponse {
     private PaymentServiceProviderResponse paymentServiceProvider;
     private DataProtectionOfficerResponse dataProtectionOfficer;
     private String parentDescription;
+    private String rootParentId;
     private String subunitCode;
     private String subunitType;
     private String aooParentCode;


### PR DESCRIPTION
#### List of Changes

Added root parent id as attribute of response of onboaring/info api in order to manage this field in ExchangeTokenService

#### Motivation and Context

It's necessary to manage this field into dashboard backend 

#### How Has This Been Tested?

I have tested the api onboarding/info api locally, aiming to dev environment

