### PR TITLE
feat: remove set subunitype for EC when saving institution from ipa

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -5090,7 +5090,7 @@
           },
           "subunitType" : {
             "type" : "string",
-            "enum" : [ "AOO", "EC", "UO" ]
+            "enum" : [ "AOO", "UO" ]
           },
           "taxCode" : {
             "type" : "string"

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
@@ -60,7 +60,7 @@ public class CreateInstitutionStrategyIpa implements CreateInstitutionStrategy {
                 throw new MsCoreException(CREATE_INSTITUTION_ERROR.getMessage(), CREATE_INSTITUTION_ERROR.getCode());
             }
         } else {
-           if(Objects.isNull(subunitType) || InstitutionPaSubunitType.EC.equals(subunitType)){
+           if(Objects.isNull(subunitType)){
                throw new ResourceConflictException(String
                        .format(CustomError.CREATE_INSTITUTION_CONFLICT.getMessage(), strategyInput.getTaxCode()),
                        CustomError.CREATE_INSTITUTION_CONFLICT.getCode());
@@ -91,7 +91,6 @@ public class CreateInstitutionStrategyIpa implements CreateInstitutionStrategy {
     private Institution getInstitutionEC(String taxCode, InstitutionProxyInfo institutionProxyInfo, CategoryProxyInfo categoryProxyInfo) {
 
         Institution newInstitution = institutionMapper.fromInstitutionProxyInfo(institutionProxyInfo);
-        newInstitution.setSubunitType(InstitutionPaSubunitType.EC.name());
         newInstitution.setExternalId(taxCode);
         newInstitution.setOrigin(Origin.IPA.getValue());
         newInstitution.setCreatedAt(OffsetDateTime.now());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/InstitutionPaSubunitType.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/InstitutionPaSubunitType.java
@@ -1,5 +1,5 @@
 package it.pagopa.selfcare.mscore.core.util;
 
 public enum InstitutionPaSubunitType {
-    EC, AOO, UO
+    AOO, UO
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -304,7 +304,7 @@ class InstitutionServiceImplTest {
 
     @Test
     void testCreateInstitution() {
-        when(createInstitutionStrategyFactory.createInstitutionStrategy((Institution) any())).thenReturn(createInstitutionStrategy);
+        when(createInstitutionStrategyFactory.createInstitutionStrategy(any())).thenReturn(createInstitutionStrategy);
         when(createInstitutionStrategy.createInstitution(any())).thenReturn(new Institution());
         Institution institution = institutionServiceImpl.createInstitution(new Institution());
         assertNotNull(institution);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -146,6 +146,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getSubunitCode()).isNull();
         assertThat(actual.getSubunitType()).isNull();
         assertThat(actual.getInstitutionType()).isEqualTo(InstitutionType.GSP);
+        assertThat(actual.getSubunitType()).isNull();
 
         verify(institutionConnector).save(any());
         verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), any());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/PdfMapperTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/PdfMapperTest.java
@@ -53,7 +53,6 @@ class PdfMapperTest {
         ArrayList<User> users = new ArrayList<>();
         Institution institution = new Institution();
         institution.setId("id");
-        institution.setSubunitType(InstitutionPaSubunitType.EC.name());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -225,7 +224,6 @@ class PdfMapperTest {
         Institution institution = new Institution();
         institution.setId("id");
         institution.setInstitutionType(InstitutionType.GSP);
-        institution.setSubunitType(InstitutionPaSubunitType.EC.name());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -345,7 +343,6 @@ class PdfMapperTest {
         Institution institution = new Institution();
         institution.setId("id");
         institution.setInstitutionType(InstitutionType.SCP);
-        institution.setSubunitType(InstitutionPaSubunitType.EC.name());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -489,7 +486,6 @@ class PdfMapperTest {
         Institution institution = new Institution();
         institution.setId("id");
         institution.setInstitutionType(InstitutionType.PSP);
-        institution.setSubunitType(InstitutionPaSubunitType.EC.name());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -579,7 +575,6 @@ class PdfMapperTest {
         user.setWorkContacts(map1);
         ArrayList<User> users = new ArrayList<>();
         Institution institution = dummyInstitutionPa();
-        institution.setSubunitType(InstitutionPaSubunitType.EC.name());
 
         Billing billing1 = new Billing();
         billing1.setPublicServices(true);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Remove set subunitype for EC when saving institution from ipa

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Subunitype must be valued only if an institution is AOO or UO

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Try to save institution EC and check if subunitType is null

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.