### PR TITLE
refactor: handle resource not found when retrieve geotax by proxy

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.mscore.model.UnitaOrganizzativa;
 import it.pagopa.selfcare.mscore.model.institution.*;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PartyRegistryProxyConnector {
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/exception/BadGatewayException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/exception/BadGatewayException.java
@@ -1,0 +1,11 @@
+package it.pagopa.selfcare.mscore.exception;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class BadGatewayException extends RuntimeException {
+
+    public BadGatewayException(String message) {
+        super(message);
+    }
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/exception/ServiceUnavailableException.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/exception/ServiceUnavailableException.java
@@ -1,0 +1,4 @@
+package it.pagopa.selfcare.mscore.exception;
+
+public class ServiceUnavailableException extends RuntimeException {
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/decoder/FeignErrorDecoder.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/decoder/FeignErrorDecoder.java
@@ -1,0 +1,22 @@
+package it.pagopa.selfcare.mscore.connector.rest.decoder;
+
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import it.pagopa.selfcare.mscore.exception.BadGatewayException;
+import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.mscore.exception.ServiceUnavailableException;
+
+public class FeignErrorDecoder extends ErrorDecoder.Default {
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        if (response.status() == 503 || response.status() == 504)
+            throw new ServiceUnavailableException();
+        if(response.status() >= 500 && response.status() <= 509)
+            throw new BadGatewayException(response.reason());
+        if(response.status() == 404)
+            throw new ResourceNotFoundException(response.reason(), "0000");
+
+        return super.decode(methodKey, response);
+    }
+}

--- a/connector/rest/src/main/resources/config/party-registry-proxy-rest-client.properties
+++ b/connector/rest/src/main/resources/config/party-registry-proxy-rest-client.properties
@@ -14,5 +14,7 @@ feign.client.config.party-registry-proxy.connectTimeout=${PARTY_REGISTRY_PROXY_C
 feign.client.config.party-registry-proxy.readTimeout=${PARTY_REGISTRY_PROXY_CLIENT_READ_TIMEOUT:${REST_CLIENT_READ_TIMEOUT:5000}}
 feign.client.config.party-registry-proxy.loggerLevel=${PARTY_REGISTRY_PROXY_LOG_LEVEL:${REST_CLIENT_LOG_LEVEL:FULL}}
 
+feign.client.config.party-registry-proxy.errorDecoder=it.pagopa.selfcare.mscore.connector.rest.decoder.FeignErrorDecoder
+
 
 

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
@@ -9,6 +9,7 @@ import it.pagopa.selfcare.mscore.connector.rest.mapper.UoMapperImpl;
 import it.pagopa.selfcare.mscore.connector.rest.model.geotaxonomy.GeographicTaxonomiesResponse;
 import it.pagopa.selfcare.mscore.connector.rest.model.registryproxy.*;
 import it.pagopa.selfcare.mscore.constant.Origin;
+import it.pagopa.selfcare.mscore.exception.BadGatewayException;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.AreaOrganizzativaOmogenea;
@@ -23,6 +24,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -462,7 +464,7 @@ class PartyRegistryProxyConnectorImplTest {
 
 
     @Test
-    void testGetExtByCode() {
+    void getExtByCode() {
         GeographicTaxonomiesResponse geographicTaxonomiesResponse = new GeographicTaxonomiesResponse();
         geographicTaxonomiesResponse.setGeotaxId("Code");
         geographicTaxonomiesResponse.setCountry("GB");
@@ -482,23 +484,9 @@ class PartyRegistryProxyConnectorImplTest {
     }
 
     @Test
-    void testGetExtByCode2() {
-        GeographicTaxonomiesResponse geographicTaxonomiesResponse = new GeographicTaxonomiesResponse();
-        geographicTaxonomiesResponse.setGeotaxId("Code");
-        geographicTaxonomiesResponse.setCountry("GB");
-        geographicTaxonomiesResponse.setCountryAbbreviation("GB");
-        geographicTaxonomiesResponse.setDescription("The characteristics of someone or something");
-        geographicTaxonomiesResponse.setEnable(false);
-        geographicTaxonomiesResponse.setIstatCode("");
-        geographicTaxonomiesResponse.setProvinceId("Province");
-        geographicTaxonomiesResponse.setProvinceAbbreviation("Province Abbreviation");
-        geographicTaxonomiesResponse.setRegionId("us-east-2");
-        when(partyRegistryProxyRestClient.getExtByCode(any())).thenReturn(geographicTaxonomiesResponse);
-        GeographicTaxonomies actualExtByCode = partyRegistryProxyConnectorImpl.getExtByCode("Code");
-        assertEquals("Code", actualExtByCode.getGeotaxId());
-        assertFalse(actualExtByCode.isEnable());
-        assertEquals("The characteristics of someone or something", actualExtByCode.getDescription());
-        verify(partyRegistryProxyRestClient).getExtByCode(any());
+    void getExtByCode_notFound() {
+        when(partyRegistryProxyRestClient.getExtByCode(any())).thenThrow(new ResourceNotFoundException("", ""));
+        assertThrows(ResourceNotFoundException.class, () -> partyRegistryProxyConnectorImpl.getExtByCode("Code"));
     }
 
     @Test

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/decoder/FeignErrorDecoderTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/decoder/FeignErrorDecoderTest.java
@@ -1,0 +1,90 @@
+package it.pagopa.selfcare.mscore.connector.rest.decoder;
+
+import feign.Request;
+import feign.Response;
+import it.pagopa.selfcare.mscore.exception.BadGatewayException;
+import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static feign.Util.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FeignErrorDecoderTest {
+    FeignErrorDecoder feignDecoder = new FeignErrorDecoder();
+
+    private final Map<String, Collection<String>> headers = new LinkedHashMap<>();
+
+    @Test
+    void testDecodeToResourceNotFound() {
+        //given
+        Response response = Response.builder()
+                .status(404)
+                .reason("ResourceNotFound")
+                .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+                .headers(headers)
+                .body("hello world", UTF_8)
+                .build();
+        //when
+        Executable executable = () -> feignDecoder.decode("", response);
+        //then
+        assertThrows(ResourceNotFoundException.class, executable);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {500,502,509})
+    void testDecodeToBadGateway(int status) {
+        //given
+        Response response = Response.builder()
+                .status(status)
+                .reason("Bad Gateway")
+                .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+                .headers(headers)
+                .body("hello world", UTF_8)
+                .build();
+        //when
+        Executable executable = () -> feignDecoder.decode("", response);
+        //then
+        assertThrows(BadGatewayException.class, executable);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {504,503,509})
+    void testDecodeServiceUnvailable() {
+        //given
+        Response response = Response.builder()
+                .status(504)
+                .reason("Service Unvailable")
+                .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+                .headers(headers)
+                .body("hello world", UTF_8)
+                .build();
+        //when
+        Executable executable = () -> feignDecoder.decode("", response);
+        //then
+    }
+
+    @Test
+    void testDecodeDefault() {
+        //given
+        Response response = Response.builder()
+                .status(200)
+                .reason("OK")
+                .request(Request.create(Request.HttpMethod.GET, "/api", Collections.emptyMap(), null, UTF_8))
+                .headers(headers)
+                .body("hello world", UTF_8)
+                .build();
+        //when
+        Executable executable = () -> feignDecoder.decode("", response);
+        //then
+        assertDoesNotThrow(executable);
+    }
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -12,6 +12,7 @@ import it.pagopa.selfcare.mscore.model.user.UserBinding;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface InstitutionService {
 
@@ -51,7 +52,7 @@ public interface InstitutionService {
 
     List<GeographicTaxonomies> retrieveInstitutionGeoTaxonomies(Institution institution);
 
-    GeographicTaxonomies retrieveGeoTaxonomies(String code);
+    Optional<GeographicTaxonomies> retrieveGeoTaxonomies(String code);
 
     List<Institution> findInstitutionsByGeoTaxonomies(String geoTaxonomies, SearchMode searchMode);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -251,8 +251,8 @@ public class InstitutionServiceImpl implements InstitutionService {
         log.info("Retrieving geographic taxonomies for institution {}", institution.getId());
         if (institution.getGeographicTaxonomies() != null) {
             List<GeographicTaxonomies> geographicTaxonomies = institution.getGeographicTaxonomies().stream()
-                    .map(InstitutionGeographicTaxonomies::getCode)
-                    .map(this::retrieveGeoTaxonomies)
+                    .map(institutionGeoTax -> retrieveGeoTaxonomies(institutionGeoTax.getCode())
+                        .orElseThrow(() -> new MsCoreException(String.format(CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getMessage(), institutionGeoTax.getCode()), CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getCode())))
                     .collect(Collectors.toList());
             if (!geographicTaxonomies.isEmpty()) {
                 return geographicTaxonomies;
@@ -262,8 +262,12 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public GeographicTaxonomies retrieveGeoTaxonomies(String code) {
-        return partyRegistryProxyConnector.getExtByCode(code);
+    public Optional<GeographicTaxonomies> retrieveGeoTaxonomies(String code) {
+        try {
+            return Optional.of(partyRegistryProxyConnector.getExtByCode(code));
+        } catch (ResourceNotFoundException e){
+            return Optional.empty();
+        }
     }
 
     @Override
@@ -280,8 +284,10 @@ public class InstitutionServiceImpl implements InstitutionService {
         if (institutionUpdate.getGeographicTaxonomies() != null) {
             return institutionUpdate.getGeographicTaxonomies()
                     .stream()
-                    .map(geoTaxonomy -> retrieveGeoTaxonomies(geoTaxonomy.getCode()))
-                    .map(geo -> new InstitutionGeographicTaxonomies(geo.getGeotaxId(), geo.getDescription())).collect(Collectors.toList());
+                    .map(geoTaxonomy -> retrieveGeoTaxonomies(geoTaxonomy.getCode())
+                            .orElseThrow(() -> new MsCoreException(String.format(CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getMessage(), geoTaxonomy.getCode()), geoTaxonomy.getCode())))
+                    .map(geo -> new InstitutionGeographicTaxonomies(geo.getGeotaxId(), geo.getDescription()))
+                    .collect(Collectors.toList());
         }
         return Collections.emptyList();
     }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -20,10 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -279,12 +276,15 @@ public class OnboardingInstitutionStrategyFactory {
         List<InstitutionGeographicTaxonomies> geographicTaxonomies = geographicTaxonomieDtos.stream()
                     .map(InstitutionGeographicTaxonomies::getCode)
                     .map(institutionService::retrieveGeoTaxonomies)
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
                     .map(geo -> new InstitutionGeographicTaxonomies(geo.getGeotaxId(), geo.getDescription()))
                     .collect(Collectors.toList());
 
         if (geographicTaxonomies.size() != geographicTaxonomieDtos.size()) {
-            throw new ResourceNotFoundException(String.format(CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getMessage(), geographicTaxonomieDtos),
+            log.error(String.format(CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getMessage(), geographicTaxonomieDtos),
                     CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getCode());
+            return List.of();
         }
 
         return geographicTaxonomies;

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -643,7 +643,7 @@ class InstitutionServiceImplTest {
      * Method under test: {@link InstitutionService#updateInstitution(String, InstitutionUpdate, String)}
      */
     @Test
-    void testUpdateInstitution6() {
+    void updateInstitution_shouldThrowExceptionIfGeotaxNotFound() {
 
         when(partyRegistryProxyConnector.getExtByCode(any()))
                 .thenThrow(new ResourceNotFoundException("An error occurred", "Code"));
@@ -672,7 +672,7 @@ class InstitutionServiceImplTest {
         institutionUpdate.setSupportPhone("6625550144");
         institutionUpdate.setTaxCode("Tax Code");
         institutionUpdate.setZipCode("21654");
-        assertThrows(ResourceNotFoundException.class,
+        assertThrows(MsCoreException.class,
                 () -> institutionServiceImpl.updateInstitution("42", institutionUpdate, "42"));
         verify(partyRegistryProxyConnector).getExtByCode(any());
         verify(userService).checkIfInstitutionUser(any(), any());
@@ -1294,7 +1294,9 @@ class InstitutionServiceImplTest {
         geographicTaxonomies.setProvinceAbbreviation("Province Abbreviation");
         geographicTaxonomies.setRegionId("us-east-2");
         when(partyRegistryProxyConnector.getExtByCode(any())).thenReturn(geographicTaxonomies);
-        assertSame(geographicTaxonomies, institutionServiceImpl.retrieveGeoTaxonomies("Code"));
+        Optional<GeographicTaxonomies> optionalGeographicTaxonomies = institutionServiceImpl.retrieveGeoTaxonomies("Code");
+        assertTrue(optionalGeographicTaxonomies.isPresent());
+        assertSame(geographicTaxonomies,optionalGeographicTaxonomies.get());
         verify(partyRegistryProxyConnector).getExtByCode(any());
     }
 
@@ -1302,11 +1304,10 @@ class InstitutionServiceImplTest {
      * Method under test: {@link InstitutionServiceImpl#retrieveGeoTaxonomies(String)}
      */
     @Test
-    void testGetGeoTaxonomies2() {
+    void getGeoTaxonomies_whenGeoTaxIsEmpty() {
         when(partyRegistryProxyConnector.getExtByCode(any()))
-                .thenThrow(new ResourceNotFoundException("An error occurred", "Code"));
-        assertThrows(ResourceNotFoundException.class, () -> institutionServiceImpl.retrieveGeoTaxonomies("Code"));
-        verify(partyRegistryProxyConnector).getExtByCode(any());
+                .thenThrow(new ResourceNotFoundException("",""));
+        assertTrue(institutionServiceImpl.retrieveGeoTaxonomies("Code").isEmpty());
     }
 
     /**

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_INTEROP;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -68,12 +69,20 @@ class OnboardingInstitutionStrategyTest {
         DataProtectionOfficer dataProtectionOfficer = TestUtils.createSimpleDataProtectionOfficer();
         PaymentServiceProvider paymentServiceProvider = TestUtils.createSimplePaymentServiceProvider();
 
+        InstitutionGeographicTaxonomies geographicTaxonomies = new InstitutionGeographicTaxonomies();
+        geographicTaxonomies.setDesc("desc");
+        geographicTaxonomies.setCode("code");
+
+        InstitutionGeographicTaxonomies geoTaxNotFound = new InstitutionGeographicTaxonomies();
+        geographicTaxonomies.setDesc("notFound");
+        geographicTaxonomies.setCode("notFound");
+
         InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
         institutionUpdate.setBusinessRegisterPlace("Business Register Place");
         institutionUpdate.setDataProtectionOfficer(dataProtectionOfficer);
         institutionUpdate.setDescription("description");
         institutionUpdate.setDigitalAddress("digitalAddress");
-        institutionUpdate.setGeographicTaxonomies(List.of(new InstitutionGeographicTaxonomies()));
+        institutionUpdate.setGeographicTaxonomies(List.of(geographicTaxonomies,geoTaxNotFound));
         institutionUpdate.setInstitutionType(InstitutionType.PG);
         institutionUpdate.setPaymentServiceProvider(paymentServiceProvider);
         institutionUpdate.setSupportPhone("4105551212");
@@ -98,11 +107,6 @@ class OnboardingInstitutionStrategyTest {
         onboardingRequest.setSignContract(true);
         onboardingRequest.setUsers(userToOnboardList);
 
-
-        InstitutionGeographicTaxonomies geographicTaxonomies = new InstitutionGeographicTaxonomies();
-        geographicTaxonomies.setDesc("desc");
-        geographicTaxonomies.setCode("code");
-
         Onboarding onboarding = new Onboarding();
         onboarding.setProductId("43");
         onboarding.setStatus(RelationshipState.PENDING);
@@ -123,7 +127,11 @@ class OnboardingInstitutionStrategyTest {
 
         SelfCareUser selfCareUser = mock(SelfCareUser.class);
 
-        when(institutionService.retrieveGeoTaxonomies(any())).thenReturn(new GeographicTaxonomies());
+        when(institutionService.retrieveGeoTaxonomies(geographicTaxonomies.getCode()))
+                .thenReturn(Optional.of(new GeographicTaxonomies()));
+
+        when(institutionService.retrieveGeoTaxonomies(geoTaxNotFound.getCode()))
+                .thenReturn(Optional.empty());
         Token token = new Token();
         token.setId("token");
         when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(new OnboardingRollback());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Added FeignErrorDecoder for handling error on proxy client
Added fault tollerance about getting geotax on onboarding

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Onboarding must not be fail if geotax is missing

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Try to call POST /onboarding/institution with institutionUpdate.geographicTaxonomyCodes wrong (for example "HELLO"), onboarding must be done

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.