### PR TITLE
Added rootParent node into InstitutionResponse

### DIFF
--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionResponse.java
@@ -26,6 +26,7 @@ public class InstitutionResponse {
     private List<OnboardedProductResponse> onboarding;
     private PaymentServiceProviderResponse paymentServiceProvider;
     private DataProtectionOfficerResponse dataProtectionOfficer;
+    private RootParentResponse rootParent;
     private String rea;
     private String shareCapital;
     private String businessRegisterPlace;
@@ -34,8 +35,6 @@ public class InstitutionResponse {
     private boolean imported;
     private String subunitCode;
     private String subunitType;
-    private String parentDescription;
-    private String rootParentId;
     private String aooParentCode;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/RootParentResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/RootParentResponse.java
@@ -1,0 +1,12 @@
+package it.pagopa.selfcare.mscore.web.model.institution;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RootParentResponse {
+    private String description;
+    private String id;
+
+}

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
@@ -3,13 +3,29 @@ package it.pagopa.selfcare.mscore.web.model.mapper;
 
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.web.model.institution.InstitutionResponse;
+import it.pagopa.selfcare.mscore.web.model.institution.RootParentResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.springframework.util.StringUtils;
 
 @Mapper(componentModel = "spring")
 public interface InstitutionResourceMapper {
 
     @Mapping(target = "aooParentCode", source = "paAttributes.aooParentCode")
+    @Mapping(target = "rootParent", source = ".", qualifiedByName = "setRootParent")
     InstitutionResponse toInstitutionResponse(Institution institution);
+
+    @Named("setRootParent")
+    static RootParentResponse setRootParent(Institution institution) {
+        if(StringUtils.hasText(institution.getRootParentId())){
+            RootParentResponse rootParentResponse = new RootParentResponse();
+            rootParentResponse.setId(institution.getRootParentId());
+            rootParentResponse.setDescription(institution.getParentDescription());
+            return rootParentResponse;
+        }
+        return null;
+    }
+
 
 }

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -132,6 +132,7 @@ class InstitutionControllerTest {
         institution.setSubunitCode("example");
         institution.setSubunitType(InstitutionPaSubunitType.UO.name());
         institution.setParentDescription("parentDescription");
+        institution.setRootParentId("rootParentId");
 
         when(institutionService.getInstitutions(any(), any()))
                 .thenReturn(List.of(institution));
@@ -145,7 +146,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
                 .andExpect(MockMvcResultMatchers.content()
                         .string(
-                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\",\"parentDescription\":\"parentDescription\"}]}"));
+                                "{\"institutions\":[{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"example\",\"subunitType\":\"UO\"}]}"));
     }
 
     @Test
@@ -248,6 +249,7 @@ class InstitutionControllerTest {
         institution.setSubunitCode(institutionFromIpaPost.getSubunitCode());
         institution.setSubunitType(institutionFromIpaPost.getSubunitType().name());
         institution.setParentDescription("parentDescription");
+        institution.setRootParentId("rootParentId");
 
         when(institutionService.createInstitutionFromIpa(any(), any(), any())).thenReturn(institution);
 
@@ -260,7 +262,7 @@ class InstitutionControllerTest {
                 .perform(requestBuilder);
         actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"1234\",\"subunitType\":\"AOO\",\"parentDescription\":\"parentDescription\"}"));
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rootParent\":{\"description\":\"parentDescription\",\"id\":\"rootParentId\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false,\"subunitCode\":\"1234\",\"subunitType\":\"AOO\"}"));
     }
 
     /**


### PR DESCRIPTION
#### List of Changes

Added rootParent node into InstitutionResponse to wrap all information about EC into specific object

#### Motivation and Context

It has been decided to move the construction of this node into microservice and remove from infra's policy.

#### How Has This Been Tested?

I have run ms-core microservice locally and test institutions/{id} api and /institutions?taxCode={taxCode}&subunitCode={subunitCode}
