### PR TITLE
feat: added endpoint for delete logically user's association with institution and product

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -4432,6 +4432,80 @@
         } ]
       }
     },
+    "/users/{userId}/institutions/{institutionId}/products/{productId}" : {
+      "delete" : {
+        "tags" : [ "Persons" ],
+        "summary" : "Delete logically the association institution and product",
+        "description" : "Delete logically the association institution and product",
+        "operationId" : "deleteProductsUsingDELETE",
+        "parameters" : [ {
+          "name" : "userId",
+          "in" : "path",
+          "description" : "UserBinding's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "institutionId",
+          "in" : "path",
+          "description" : "The internal identifier of the institution",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "path",
+          "description" : "Product's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/users/{userId}/products" : {
       "get" : {
         "tags" : [ "Persons" ],

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserConnector.java
@@ -33,6 +33,8 @@ public interface UserConnector {
      */
     void findAndUpdateState(String userId, @Nullable String relationshipId, @Nullable Token token, RelationshipState state);
 
+    void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state);
+
     void findAndUpdate(OnboardedUser onboardedUser, String id, String institutionId, OnboardedProduct product, UserBinding bindings);
 
     OnboardedUser findOnboardedManager(String institutionId, String productId, List<RelationshipState> state);

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
@@ -115,13 +115,14 @@ public class UserConnectorImpl implements UserConnector {
 
     @Override
     public void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state) {
-        Query query = Query.query(Criteria.where(UserEntity.Fields.id.name()).is(userId)
-                .and(CURRENT_USER_BINDING + UserBinding.Fields.institutionId.name()).is(institutionId)
-                .and(constructQuery(CURRENT_ANY, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.productId.name())).is(productId)
-        );
+        Query query = Query.query(Criteria.where(UserEntity.Fields.id.name()).is(userId));
+
         Update update = new Update()
-                .set(constructQuery(CURRENT_ANY, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.status.name()), state)
-                .set(constructQuery(CURRENT_ANY, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.updatedAt.name()), OffsetDateTime.now());
+                .set(constructQuery(CURRENT_USER_BINDING_REF, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.status.name()), state)
+                .set(constructQuery(CURRENT_USER_BINDING_REF, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.updatedAt.name()), OffsetDateTime.now());
+
+        update.filterArray(Criteria.where(CURRENT_PRODUCT  + OnboardedProduct.Fields.productId.name()).is(productId));
+        update.filterArray(Criteria.where(CURRENT_USER_BINDING + UserBinding.Fields.institutionId.name()).is(institutionId));
 
         FindAndModifyOptions findAndModifyOptions = FindAndModifyOptions.options().upsert(false).returnNew(false);
         repository.findAndModify(query, update, findAndModifyOptions, UserEntity.class);

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
@@ -114,6 +114,20 @@ public class UserConnectorImpl implements UserConnector {
     }
 
     @Override
+    public void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state) {
+        Query query = Query.query(Criteria.where(UserEntity.Fields.id.name()).is(userId)
+                .and(CURRENT_USER_BINDING + UserBinding.Fields.institutionId.name()).is(institutionId)
+                .and(constructQuery(CURRENT_ANY, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.productId.name())).is(productId)
+        );
+        Update update = new Update()
+                .set(constructQuery(CURRENT_ANY, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.status.name()), state)
+                .set(constructQuery(CURRENT_ANY, UserBinding.Fields.products.name(), CURRENT_PRODUCT_REF, OnboardedProduct.Fields.updatedAt.name()), OffsetDateTime.now());
+
+        FindAndModifyOptions findAndModifyOptions = FindAndModifyOptions.options().upsert(false).returnNew(false);
+        repository.findAndModify(query, update, findAndModifyOptions, UserEntity.class);
+    }
+
+    @Override
     public void findAndUpdate(OnboardedUser onboardedUser, String userId, String institutionId, OnboardedProduct product, UserBinding bindings) {
         Query query = Query.query(Criteria.where(UserEntity.Fields.id.name()).is(userId));
         Update update = new Update();

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImplTest.java
@@ -594,6 +594,13 @@ class UserConnectorImplTest {
     }
 
     @Test
+    void findAndUpdateStateByInstitutionAndProduct() {
+        when(userRepository.findAndModify(any(), any(), any(), any()))
+                .thenReturn(new UserEntity());
+        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateByInstitutionAndProduct("42", "42", "productId", RelationshipState.PENDING));
+    }
+
+    @Test
     void testFindAndUpdate() {
         UserEntity userEntity = new UserEntity();
         userEntity.setBindings(new ArrayList<>());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserService.java
@@ -30,4 +30,6 @@ public interface UserService {
     User retrieveUserFromUserRegistry(String userId, EnumSet<User.Fields> fields);
 
     List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter);
+
+    void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserServiceImpl.java
@@ -91,4 +91,9 @@ public class UserServiceImpl implements UserService {
     public List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter) {
         return userConnector.findUserInstitutionAggregation(filter);
     }
+
+    @Override
+    public void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state) {
+        userConnector.findAndUpdateStateByInstitutionAndProduct(userId, institutionId, productId, state);
+    }
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserServiceImplTest.java
@@ -366,5 +366,13 @@ class UserServiceImplTest {
         filter.setUserId("id");
         Assertions.assertDoesNotThrow(() -> userServiceImpl.findUserInstitutionAggregation(filter));
     }
+
+    @Test
+    void findAndUpdateStateByInstitutionAndProduct() {
+
+        doNothing().when(userConnector).findAndUpdateStateByInstitutionAndProduct(anyString(),anyString(),anyString(),any());
+        Assertions.assertDoesNotThrow(() -> userServiceImpl
+                .findAndUpdateStateByInstitutionAndProduct("userId","institutionId","productId",RelationshipState.DELETED));
+    }
 }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.mscore.constant.GenericError;
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.OnboardingService;
 import it.pagopa.selfcare.mscore.core.UserRelationshipService;
 import it.pagopa.selfcare.mscore.core.UserService;
@@ -191,5 +192,33 @@ public class UserController {
                                 .map(userMapper::toInstitutionProducts)
                                 .collect(Collectors.toList()))
                 .build());
+    }
+
+
+
+    /**
+     * The function delete logically the association institution and product
+     *
+     * @param userId                String
+     * @param institutionId         String
+     * @param productId         String
+     * @return onboardingInfoResponse
+     * <p>
+     * * Code: 200, Message: successful operation, DataType: TokenId
+     * * Code: 400, Message: Invalid ID supplied, DataType: Problem
+     * * Code: 404, Message: Not found, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "${swagger.mscore.users.delete.products}", notes = "${swagger.mscore.users.delete.products}")
+    @DeleteMapping(value = "/users/{userId}/institutions/{institutionId}/products/{productId}")
+    public ResponseEntity<Void> deleteProducts(@ApiParam("${swagger.mscore.relationship.relationshipId}")
+                                                                    @PathVariable("userId") String userId,
+                                                                    @ApiParam("${swagger.mscore.institutions.model.institutionId}")
+                                                                    @PathVariable(value = "institutionId") String institutionId,
+                                                                    @ApiParam("${swagger.mscore.institutions.model.productId}")
+                                                                        @PathVariable(value = "productId") String productId) {
+
+        userService.findAndUpdateStateByInstitutionAndProduct(userId, institutionId, productId, RelationshipState.DELETED);
+        return ResponseEntity.ok().build();
     }
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -63,5 +63,6 @@ swagger.mscore.product.model.id=Product's unique identifier
 swagger.mscore.token.consume=Consume token onboarding request without digest verification 
 swagger.mscore.delegation.create=Create an association between institution id and technical partner
 swagger.mscore.users.products=Retrieves products info and role which the user is enabled
+swagger.mscore.users.delete.products=Delete logically the association institution and product
 swagger.mscore.institutions.delegations=Retrieve institution's delegations
 swagger.mscore.institutions.brokers=Retrieve institution brokers

--- a/web/src/main/resources/swagger/swagger_it.properties
+++ b/web/src/main/resources/swagger/swagger_it.properties
@@ -58,3 +58,4 @@ swagger.mscore.relationships.get=Il servizio restituisce una lista di relationsh
 swagger.mscore.delegation.create=Il servizio crea un'associazione tra l'ente ed il partner tecnologico
 swagger.mscore.users.products=Il servizio restituisce la lista dei prodotti con rispettivo ruolo di cui l'utente è abilitato
 swagger.mscore.institutions.delegations=Il servizio recupera la lista delle deleghe di una institution
+swagger.mscore.users.delete.products=Eliminazione logica dell'associazione product e institution con l'user

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/UserControllerTest.java
@@ -453,6 +453,29 @@ class UserControllerTest {
 
     }
 
+
+    /**
+     * Method under test: {@link UserController#deleteProducts(String, String, String)}
+     */
+    @Test
+    void deleteProducts() throws Exception {
+
+        final String userId = "userId";
+        final String institutionId = "institutionId";
+        final String productId = "productId";
+
+        doNothing().when(userService).findAndUpdateStateByInstitutionAndProduct(userId, institutionId, productId, RelationshipState.DELETED);
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .delete("/users/{userId}/institutions/{institutionId}/products/{productId}", userId, institutionId, productId)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        MockMvcBuilders.standaloneSetup(userController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
     private UserBinding dummyUserBinding(String institutionId) {
 
         UserBinding userBinding = new UserBinding();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Added endpoint for delete logically user's association with institution and product

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

As admin, I want to delete logically user's association with institution and product

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Try to call DELETE /users/{userId}/institutions/{institutionId}/products/{productId} on a record where status is ACTIVE

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.