### PR TITLE
Added taxCode and institutionType to getDelegationsAPI

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -743,6 +743,16 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "description" : "Mode (full or normal) to retreieve institution's delegations",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "FULL", "NORMAL" ]
+          }
         } ],
         "responses" : {
           "200" : {
@@ -4943,7 +4953,14 @@
           "institutionRootName" : {
             "type" : "string"
           },
+          "institutionType" : {
+            "type" : "string",
+            "enum" : [ "GSP", "PA", "PG", "PSP", "PT", "SCP" ]
+          },
           "productId" : {
+            "type" : "string"
+          },
+          "taxCode" : {
             "type" : "string"
           },
           "type" : {

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.api;
 
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 
 import java.util.List;
@@ -7,8 +8,7 @@ import java.util.List;
 public interface DelegationConnector {
 
     Delegation save(Delegation delegation);
-
     boolean checkIfExists(Delegation delegation);
+    List<Delegation> find(String from, String to, String productId, GetDelegationsMode mode);
 
-    List<Delegation> find(String from, String to, String productId);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GetDelegationsMode.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GetDelegationsMode.java
@@ -1,0 +1,8 @@
+package it.pagopa.selfcare.mscore.constant;
+
+public enum GetDelegationsMode {
+
+    FULL,
+    NORMAL;
+
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/DelegationInstitution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/DelegationInstitution.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.model.delegation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import it.pagopa.selfcare.mscore.constant.DelegationType;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,16 +12,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class DelegationInstitution {
-
-    private String id;
-    private String from;
-    private String institutionFromName;
-    private String institutionToName;
-    private String institutionFromRootName;
-    private DelegationType type;
-    private String to;
-    private String productId;
+public class DelegationInstitution extends Delegation {
     private List<Institution> institutions;
 
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/DelegationInstitution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/DelegationInstitution.java
@@ -2,16 +2,18 @@ package it.pagopa.selfcare.mscore.model.delegation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
-import it.pagopa.selfcare.mscore.constant.InstitutionType;
+import it.pagopa.selfcare.mscore.model.institution.Institution;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class Delegation {
+public class DelegationInstitution {
 
     private String id;
     private String from;
@@ -21,7 +23,6 @@ public class Delegation {
     private DelegationType type;
     private String to;
     private String productId;
-    private InstitutionType institutionType;
-    private String taxCode;
+    private List<Institution> institutions;
 
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
@@ -3,8 +3,15 @@ package it.pagopa.selfcare.mscore.connector.dao;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.connector.dao.model.DelegationEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapper;
+import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationInstitutionMapper;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationInstitution;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.GraphLookupOperation;
+import org.springframework.data.mongodb.core.aggregation.MatchOperation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
@@ -21,11 +28,17 @@ public class DelegationConnectorImpl implements DelegationConnector {
 
     private final DelegationRepository repository;
     private final DelegationEntityMapper delegationMapper;
+    private final DelegationInstitutionMapper delegationInstitutionMapper;
+    private final MongoTemplate mongoTemplate;
 
     public DelegationConnectorImpl(DelegationRepository repository,
-                                   DelegationEntityMapper delegationMapper) {
+                                   DelegationEntityMapper delegationMapper,
+                                   MongoTemplate mongoTemplate,
+                                   DelegationInstitutionMapper delegationInstitutionMapper) {
         this.repository = repository;
         this.delegationMapper = delegationMapper;
+        this.mongoTemplate = mongoTemplate;
+        this.delegationInstitutionMapper = delegationInstitutionMapper;
     }
 
     @Override
@@ -47,7 +60,8 @@ public class DelegationConnectorImpl implements DelegationConnector {
     }
 
     @Override
-    public List<Delegation> find(String from, String to, String productId) {
+    public List<Delegation> find(String from, String to, String productId, GetDelegationsMode mode) {
+
         Criteria criteria = new Criteria();
 
         List<Criteria> criterias = new ArrayList<>();
@@ -57,6 +71,22 @@ public class DelegationConnectorImpl implements DelegationConnector {
             criterias.add(Criteria.where(DelegationEntity.Fields.to.name()).is(to));
         if(Objects.nonNull(productId))
             criterias.add(Criteria.where(DelegationEntity.Fields.productId.name()).is(productId));
+
+        if(GetDelegationsMode.FULL.equals(mode)) {
+
+            GraphLookupOperation.GraphLookupOperationBuilder lookup = Aggregation.graphLookup("Institution")
+                    .startWith(Objects.nonNull(from) ? "from" : "to")
+                    .connectFrom(Objects.nonNull(from) ? "from" : "to")
+                    .connectTo("_id");
+
+            MatchOperation matchOperation = new MatchOperation(new Criteria().andOperator(criterias.toArray(new Criteria[criterias.size()])));
+            Aggregation aggregation = Aggregation.newAggregation(matchOperation, lookup.as("institutions"));
+
+            List<DelegationInstitution> result = mongoTemplate.aggregate(aggregation, "Delegations", DelegationInstitution.class).getMappedResults();
+            return result.stream()
+                    .map(delegationInstitutionMapper::convertToDelegation)
+                    .collect(Collectors.toList());
+        }
 
         return repository.find(Query.query(criteria.andOperator(criterias)), DelegationEntity.class).stream()
                 .map(delegationMapper::convertToDelegation)

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
@@ -1,0 +1,29 @@
+package it.pagopa.selfcare.mscore.connector.dao.model.mapper;
+
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
+import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationInstitution;
+import it.pagopa.selfcare.mscore.model.institution.Institution;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface DelegationInstitutionMapper {
+
+    @Mapping(source = "institutions", target = "taxCode", qualifiedByName = "setTaxCode")
+    @Mapping(source = "institutions", target = "institutionType", qualifiedByName = "setInstitutionType")
+    Delegation convertToDelegation(DelegationInstitution delegation);
+
+    @Named("setTaxCode")
+    default String setTaxCode(List<Institution> institutionList) {
+        return institutionList.get(0).getTaxCode();
+    }
+
+    @Named("setInstitutionType")
+    default InstitutionType setInstitutionType(List<Institution> institutionList) {
+        return institutionList.get(0).getInstitutionType();
+    }
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
@@ -19,11 +19,11 @@ public interface DelegationInstitutionMapper {
 
     @Named("setTaxCode")
     default String setTaxCode(List<Institution> institutionList) {
-        return institutionList.get(0).getTaxCode();
+        return !institutionList.isEmpty() ? institutionList.get(0).getTaxCode() : null;
     }
 
     @Named("setInstitutionType")
     default InstitutionType setInstitutionType(List<Institution> institutionList) {
-        return institutionList.get(0).getInstitutionType();
+        return !institutionList.isEmpty() ? institutionList.get(0).getInstitutionType() : null;
     }
 }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
@@ -3,16 +3,24 @@ package it.pagopa.selfcare.mscore.connector.dao;
 import it.pagopa.selfcare.mscore.connector.dao.model.DelegationEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapper;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapperImpl;
+import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationInstitutionMapper;
+import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationInstitutionMapperImpl;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationInstitution;
+import it.pagopa.selfcare.mscore.model.institution.Institution;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.Spy;
+import org.mockito.*;
+import org.mockito.internal.matchers.Any;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
@@ -21,8 +29,8 @@ import java.util.Optional;
 import static it.pagopa.selfcare.mscore.constant.GenericError.CREATE_DELEGATION_ERROR;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ContextConfiguration(classes = {DelegationConnectorImpl.class})
 @ExtendWith(MockitoExtension.class)
@@ -34,8 +42,14 @@ class DelegationConnectorImplTest {
     @Mock
     private DelegationRepository delegationRepository;
 
+    @Mock
+    private MongoTemplate mongoTemplate;
+
     @Spy
     private DelegationEntityMapper delegationMapper = new DelegationEntityMapperImpl();
+
+    @Spy
+    private DelegationInstitutionMapper delegationInstitutionMapper = new DelegationInstitutionMapperImpl();
 
     @Test
     void testSaveDelegation() {
@@ -82,12 +96,12 @@ class DelegationConnectorImplTest {
         delegationEntity.setInstitutionFromName("setInstitutionFromName");
         delegationEntity.setInstitutionFromRootName("setInstitutionFromRootName");
 
+        //When
         when(delegationRepository.find(any(), any())).
                 thenReturn(List.of(delegationEntity));
 
-        //When
         List<Delegation> response = delegationConnectorImpl.find(delegationEntity.getFrom(),
-                delegationEntity.getTo(), delegationEntity.getProductId());
+                delegationEntity.getTo(), delegationEntity.getProductId(), GetDelegationsMode.NORMAL);
 
         //Then
         assertNotNull(response);
@@ -101,6 +115,48 @@ class DelegationConnectorImplTest {
         assertEquals(actual.getFrom(), delegationEntity.getFrom());
         assertEquals(actual.getInstitutionFromName(), delegationEntity.getInstitutionFromName());
         assertEquals(actual.getInstitutionFromRootName(), delegationEntity.getInstitutionFromRootName());
+    }
+
+    @Test
+    void find_shouldGetData_fullMode() {
+        //Given
+        Institution institution = new Institution();
+        institution.setTaxCode("taxCode");
+        institution.setInstitutionType(InstitutionType.PT);
+        DelegationInstitution delegationEntity = new DelegationInstitution();
+        delegationEntity.setId("id");
+        delegationEntity.setProductId("productId");
+        delegationEntity.setType(DelegationType.PT);
+        delegationEntity.setTo("To");
+        delegationEntity.setFrom("From");
+        delegationEntity.setInstitutionFromName("setInstitutionFromName");
+        delegationEntity.setInstitutionFromRootName("setInstitutionFromRootName");
+        delegationEntity.setInstitutions(List.of(institution));
+
+        AggregationResults<Object> results = mock(AggregationResults.class);
+        when(results.getMappedResults()).thenReturn(List.of(delegationEntity));
+
+        //When
+        when(mongoTemplate.aggregate(any(Aggregation.class), anyString(),  any())).
+                thenReturn(results);
+
+        List<Delegation> response = delegationConnectorImpl.find(delegationEntity.getFrom(),
+                delegationEntity.getTo(), delegationEntity.getProductId(), GetDelegationsMode.FULL);
+
+        //Then
+        assertNotNull(response);
+        assertFalse(response.isEmpty());
+        Delegation actual = response.get(0);
+
+        assertEquals(actual.getId(), delegationEntity.getId());
+        assertEquals(actual.getType(), delegationEntity.getType());
+        assertEquals(actual.getProductId(), delegationEntity.getProductId());
+        assertEquals(actual.getTo(), delegationEntity.getTo());
+        assertEquals(actual.getFrom(), delegationEntity.getFrom());
+        assertEquals(actual.getInstitutionFromName(), delegationEntity.getInstitutionFromName());
+        assertEquals(actual.getInstitutionFromRootName(), delegationEntity.getInstitutionFromRootName());
+        assertEquals(actual.getTaxCode(), delegationEntity.getInstitutions().get(0).getTaxCode());
+        assertEquals(actual.getInstitutionType(), delegationEntity.getInstitutions().get(0).getInstitutionType());
     }
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.core;
 
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 
 import java.util.List;
@@ -8,6 +9,6 @@ public interface DelegationService {
 
     Delegation createDelegation(Delegation delegation);
     boolean checkIfExists(Delegation delegation);
+    List<Delegation> getDelegations(String from, String to, String productId, GetDelegationsMode mode);
 
-    List<Delegation> getDelegations(String from, String to, String productId);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
@@ -39,7 +40,7 @@ public class DelegationServiceImpl implements DelegationService {
     }
 
     @Override
-    public List<Delegation> getDelegations(String from, String to, String productId) {
-        return delegationConnector.find(from, to, productId);
+    public List<Delegation> getDelegations(String from, String to, String productId, GetDelegationsMode mode) {
+        return delegationConnector.find(from, to, productId, mode);
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
@@ -79,11 +80,11 @@ class DelegationServiceImplTest {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId");
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId", GetDelegationsMode.NORMAL);
         //Then
-        verify(delegationConnector).find(any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import it.pagopa.selfcare.mscore.constant.GenericError;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.core.DelegationService;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
@@ -73,12 +74,14 @@ public class DelegationController {
                                                                    @ApiParam("${swagger.mscore.institutions.model.institutionId}")
                                                                    @RequestParam(name = "brokerId", required = false) String brokerId,
                                                                    @ApiParam("${swagger.mscore.product.model.id}")
-                                                                   @RequestParam(name = "productId", required = false) String productId) {
+                                                                   @RequestParam(name = "productId", required = false) String productId,
+                                                                   @ApiParam("${swagger.mscore.institutions.delegations.mode}")
+                                                                   @RequestParam(name = "mode", required = false) GetDelegationsMode mode) {
 
         if(Objects.isNull(institutionId) && Objects.isNull(brokerId))
             throw new InvalidRequestException("institutionId or brokerId must not be null!!", GenericError.GENERIC_ERROR.getCode());
 
-        return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId).stream()
+        return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId, mode).stream()
                 .map(delegationMapper::toDelegationResponse)
                 .collect(Collectors.toList()));
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.web.model.delegation;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
+import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import lombok.Data;
 
 @Data
@@ -16,5 +17,7 @@ public class DelegationResponse {
     private DelegationType type;
     private String brokerId;
     private String productId;
+    private String taxCode;
+    private InstitutionType institutionType;
 
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -69,4 +69,5 @@ swagger.mscore.delegation.create=Create an association between institution id an
 swagger.mscore.users.products=Retrieves products info and role which the user is enabled
 swagger.mscore.users.delete.products=Delete logically the association institution and product
 swagger.mscore.institutions.delegations=Retrieve institution's delegations
+swagger.mscore.institutions.delegations.mode=Mode (full or normal) to retreieve institution's delegations
 swagger.mscore.institutions.brokers=Retrieve institution brokers

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
@@ -160,6 +160,45 @@ class DelegationControllerTest {
         verifyNoMoreInteractions(delegationService);
     }
 
+    /**
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, GetDelegationsMode)}
+     */
+    @Test
+    void getDelegations_shouldGetData_nullMode() throws Exception {
+        // Given
+        Delegation expectedDelegation = dummyDelegation();
+
+        when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId(), null))
+                .thenReturn(List.of(expectedDelegation));
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}", expectedDelegation.getFrom(),
+                        expectedDelegation.getTo(), expectedDelegation.getProductId());
+        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andReturn();
+
+        List<DelegationResponse> response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.size()).isEqualTo(1);
+        DelegationResponse actual = response.get(0);
+        assertThat(actual.getId()).isEqualTo(expectedDelegation.getId());
+        assertThat(actual.getInstitutionName()).isEqualTo(expectedDelegation.getInstitutionFromName());
+        assertThat(actual.getBrokerId()).isEqualTo(expectedDelegation.getTo());
+        assertThat(actual.getProductId()).isEqualTo(expectedDelegation.getProductId());
+        assertThat(actual.getInstitutionId()).isEqualTo(expectedDelegation.getFrom());
+        assertThat(actual.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
+
+        verify(delegationService, times(1))
+                .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId(), null);
+        verifyNoMoreInteractions(delegationService);
+    }
+
     private Delegation dummyDelegation() {
         Delegation delegation = new Delegation();
         delegation.setFrom("from");

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.web.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.core.DelegationService;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 import it.pagopa.selfcare.mscore.web.model.delegation.DelegationRequest;
@@ -121,19 +122,19 @@ class DelegationControllerTest {
     }
 
     /**
-     * Method under test: {@link InstitutionController#findFromProduct(String, Integer, Integer)}
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, GetDelegationsMode)}
      */
     @Test
     void getDelegations_shouldGetData() throws Exception {
         // Given
         Delegation expectedDelegation = dummyDelegation();
 
-        when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId()))
+        when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId(), GetDelegationsMode.NORMAL))
                 .thenReturn(List.of(expectedDelegation));
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}", expectedDelegation.getFrom(),
-                        expectedDelegation.getTo(), expectedDelegation.getProductId());
+                .get("/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}&mode={mode}", expectedDelegation.getFrom(),
+                        expectedDelegation.getTo(), expectedDelegation.getProductId(), GetDelegationsMode.NORMAL);
         MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
                 .build()
                 .perform(requestBuilder)
@@ -155,7 +156,7 @@ class DelegationControllerTest {
         assertThat(actual.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
 
         verify(delegationService, times(1))
-                .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId());
+                .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId(), GetDelegationsMode.NORMAL);
         verifyNoMoreInteractions(delegationService);
     }
 


### PR DESCRIPTION
#### List of Changes

Added taxCode and institutionType to getDelegations API

#### Motivation and Context

This change was requested by backoffice pagoPA team in order to manage taxCode of institutions retrieved by partner's id

#### How Has This Been Tested?

I have tested the api **/delegations** running ms-core microservice locally.
