### PR TITLE
Added fields to getDelegations response

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -4941,6 +4941,12 @@
           "brokerName" : {
             "type" : "string"
           },
+          "brokerTaxCode" : {
+            "type" : "string"
+          },
+          "brokerType" : {
+            "type" : "string"
+          },
           "id" : {
             "type" : "string"
           },

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/Delegation.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/Delegation.java
@@ -23,5 +23,7 @@ public class Delegation {
     private String productId;
     private InstitutionType institutionType;
     private String taxCode;
+    private InstitutionType brokerType;
+    private String brokerTaxCode;
 
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
@@ -75,8 +75,8 @@ public class DelegationConnectorImpl implements DelegationConnector {
         if(GetDelegationsMode.FULL.equals(mode)) {
 
             GraphLookupOperation.GraphLookupOperationBuilder lookup = Aggregation.graphLookup("Institution")
-                    .startWith(Objects.nonNull(from) ? "from" : "to")
-                    .connectFrom(Objects.nonNull(from) ? "from" : "to")
+                    .startWith(Objects.nonNull(from) ? "to" : "from")
+                    .connectFrom(Objects.nonNull(from) ? "to" : "from")
                     .connectTo("_id");
 
             MatchOperation matchOperation = new MatchOperation(new Criteria().andOperator(criterias.toArray(new Criteria[criterias.size()])));
@@ -84,7 +84,9 @@ public class DelegationConnectorImpl implements DelegationConnector {
 
             List<DelegationInstitution> result = mongoTemplate.aggregate(aggregation, "Delegations", DelegationInstitution.class).getMappedResults();
             return result.stream()
-                    .map(delegationInstitutionMapper::convertToDelegation)
+                    .map(Objects.nonNull(from) ?
+                            delegationInstitutionMapper::convertToDelegationBroker :
+                            delegationInstitutionMapper::convertToDelegationInstitution)
                     .collect(Collectors.toList());
         }
 

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/DelegationInstitutionMapper.java
@@ -15,7 +15,11 @@ public interface DelegationInstitutionMapper {
 
     @Mapping(source = "institutions", target = "taxCode", qualifiedByName = "setTaxCode")
     @Mapping(source = "institutions", target = "institutionType", qualifiedByName = "setInstitutionType")
-    Delegation convertToDelegation(DelegationInstitution delegation);
+    Delegation convertToDelegationInstitution(DelegationInstitution delegation);
+
+    @Mapping(source = "institutions", target = "brokerTaxCode", qualifiedByName = "setTaxCode")
+    @Mapping(source = "institutions", target = "brokerType", qualifiedByName = "setInstitutionType")
+    Delegation convertToDelegationBroker(DelegationInstitution delegation);
 
     @Named("setTaxCode")
     default String setTaxCode(List<Institution> institutionList) {
@@ -24,6 +28,7 @@ public interface DelegationInstitutionMapper {
 
     @Named("setInstitutionType")
     default InstitutionType setInstitutionType(List<Institution> institutionList) {
-        return !institutionList.isEmpty() ? institutionList.get(0).getInstitutionType() : null;
+        return !institutionList.isEmpty()? institutionList.get(0).getInstitutionType() : null;
     }
+
 }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
@@ -14,13 +14,14 @@ import it.pagopa.selfcare.mscore.model.delegation.DelegationInstitution;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
-import org.mockito.internal.matchers.Any;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.aggregation.TypedAggregation;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.List;
@@ -35,6 +36,24 @@ import static org.mockito.Mockito.*;
 @ContextConfiguration(classes = {DelegationConnectorImpl.class})
 @ExtendWith(MockitoExtension.class)
 class DelegationConnectorImplTest {
+
+    static Institution dummyInstitution;
+    static DelegationInstitution dummyDelegationEntity;
+
+    static {
+        dummyInstitution = new Institution();
+        dummyInstitution.setTaxCode("taxCode");
+        dummyInstitution.setInstitutionType(InstitutionType.PT);
+        dummyDelegationEntity = new DelegationInstitution();
+        dummyDelegationEntity.setId("id");
+        dummyDelegationEntity.setProductId("productId");
+        dummyDelegationEntity.setType(DelegationType.PT);
+        dummyDelegationEntity.setTo("To");
+        dummyDelegationEntity.setFrom("From");
+        dummyDelegationEntity.setInstitutionFromName("setInstitutionFromName");
+        dummyDelegationEntity.setInstitutionFromRootName("setInstitutionFromRootName");
+        dummyDelegationEntity.setInstitutions(List.of(dummyInstitution));
+    }
 
     @InjectMocks
     private DelegationConnectorImpl delegationConnectorImpl;
@@ -86,7 +105,7 @@ class DelegationConnectorImplTest {
 
     @Test
     void find_shouldGetData() {
-        //Given
+
         DelegationEntity delegationEntity = new DelegationEntity();
         delegationEntity.setId("id");
         delegationEntity.setProductId("productId");
@@ -118,45 +137,61 @@ class DelegationConnectorImplTest {
     }
 
     @Test
-    void find_shouldGetData_fullMode() {
-        //Given
-        Institution institution = new Institution();
-        institution.setTaxCode("taxCode");
-        institution.setInstitutionType(InstitutionType.PT);
-        DelegationInstitution delegationEntity = new DelegationInstitution();
-        delegationEntity.setId("id");
-        delegationEntity.setProductId("productId");
-        delegationEntity.setType(DelegationType.PT);
-        delegationEntity.setTo("To");
-        delegationEntity.setFrom("From");
-        delegationEntity.setInstitutionFromName("setInstitutionFromName");
-        delegationEntity.setInstitutionFromRootName("setInstitutionFromRootName");
-        delegationEntity.setInstitutions(List.of(institution));
+    void getBrokersFullMode() {
 
+        //Given
         AggregationResults<Object> results = mock(AggregationResults.class);
-        when(results.getMappedResults()).thenReturn(List.of(delegationEntity));
+        when(results.getMappedResults()).thenReturn(List.of(dummyDelegationEntity));
 
         //When
         when(mongoTemplate.aggregate(any(Aggregation.class), anyString(),  any())).
                 thenReturn(results);
 
-        List<Delegation> response = delegationConnectorImpl.find(delegationEntity.getFrom(),
-                delegationEntity.getTo(), delegationEntity.getProductId(), GetDelegationsMode.FULL);
+        List<Delegation> response = delegationConnectorImpl.find(dummyDelegationEntity.getFrom(), null, dummyDelegationEntity.getProductId(), GetDelegationsMode.FULL);
 
         //Then
         assertNotNull(response);
         assertFalse(response.isEmpty());
         Delegation actual = response.get(0);
 
-        assertEquals(actual.getId(), delegationEntity.getId());
-        assertEquals(actual.getType(), delegationEntity.getType());
-        assertEquals(actual.getProductId(), delegationEntity.getProductId());
-        assertEquals(actual.getTo(), delegationEntity.getTo());
-        assertEquals(actual.getFrom(), delegationEntity.getFrom());
-        assertEquals(actual.getInstitutionFromName(), delegationEntity.getInstitutionFromName());
-        assertEquals(actual.getInstitutionFromRootName(), delegationEntity.getInstitutionFromRootName());
-        assertEquals(actual.getTaxCode(), delegationEntity.getInstitutions().get(0).getTaxCode());
-        assertEquals(actual.getInstitutionType(), delegationEntity.getInstitutions().get(0).getInstitutionType());
+        assertEquals(actual.getId(), dummyDelegationEntity.getId());
+        assertEquals(actual.getType(), dummyDelegationEntity.getType());
+        assertEquals(actual.getProductId(), dummyDelegationEntity.getProductId());
+        assertEquals(actual.getTo(), dummyDelegationEntity.getTo());
+        assertEquals(actual.getFrom(), dummyDelegationEntity.getFrom());
+        assertEquals(actual.getInstitutionFromName(), dummyDelegationEntity.getInstitutionFromName());
+        assertEquals(actual.getInstitutionFromRootName(), dummyDelegationEntity.getInstitutionFromRootName());
+        assertEquals(actual.getBrokerTaxCode(), dummyDelegationEntity.getInstitutions().get(0).getTaxCode());
+        assertEquals(actual.getBrokerType(), dummyDelegationEntity.getInstitutions().get(0).getInstitutionType());
+    }
+
+    @Test
+    void getInstitutionsFullMode() {
+
+        //Given
+        AggregationResults<Object> results = mock(AggregationResults.class);
+        when(results.getMappedResults()).thenReturn(List.of(dummyDelegationEntity));
+
+        //When
+        when(mongoTemplate.aggregate(any(Aggregation.class), anyString(),  any())).
+                thenReturn(results);
+
+        List<Delegation> response = delegationConnectorImpl.find(null, dummyDelegationEntity.getTo(), dummyDelegationEntity.getProductId(), GetDelegationsMode.FULL);
+
+        //Then
+        assertNotNull(response);
+        assertFalse(response.isEmpty());
+        Delegation actual = response.get(0);
+
+        assertEquals(actual.getId(), dummyDelegationEntity.getId());
+        assertEquals(actual.getType(), dummyDelegationEntity.getType());
+        assertEquals(actual.getProductId(), dummyDelegationEntity.getProductId());
+        assertEquals(actual.getTo(), dummyDelegationEntity.getTo());
+        assertEquals(actual.getFrom(), dummyDelegationEntity.getFrom());
+        assertEquals(actual.getInstitutionFromName(), dummyDelegationEntity.getInstitutionFromName());
+        assertEquals(actual.getInstitutionFromRootName(), dummyDelegationEntity.getInstitutionFromRootName());
+        assertEquals(actual.getTaxCode(), dummyDelegationEntity.getInstitutions().get(0).getTaxCode());
+        assertEquals(actual.getInstitutionType(), dummyDelegationEntity.getInstitutions().get(0).getInstitutionType());
     }
 
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
-import it.pagopa.selfcare.mscore.constant.CustomError;
 import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
@@ -87,6 +86,25 @@ class DelegationServiceImplTest {
         when(delegationConnector.find(any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
         List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId", GetDelegationsMode.NORMAL);
+        //Then
+        verify(delegationConnector).find(any(), any(), any(), any());
+
+        assertNotNull(response);
+        assertFalse(response.isEmpty());
+        assertEquals(delegation.getId(), response.get(0).getId());
+    }
+
+    /**
+     * Method under test: {@link DelegationServiceImpl#createDelegation(Delegation)}
+     */
+    @Test
+    void find_shouldGetData_fullMode() {
+        //Given
+        Delegation delegation = new Delegation();
+        delegation.setId("id");
+        when(delegationConnector.find(any(), any(), any(), any())).thenReturn(List.of(delegation));
+        //When
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", GetDelegationsMode.FULL);
         //Then
         verify(delegationConnector).find(any(), any(), any(), any());
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationResponse.java
@@ -12,12 +12,14 @@ public class DelegationResponse {
     private String id;
     private String institutionId;
     private String institutionName;
-    private String brokerName;
     private String institutionRootName;
     private DelegationType type;
-    private String brokerId;
     private String productId;
     private String taxCode;
     private InstitutionType institutionType;
+    private String brokerId;
+    private String brokerTaxCode;
+    private String brokerType;
+    private String brokerName;
 
 }


### PR DESCRIPTION
#### List of Changes

Added fields brokerTaxCode and brokerType to DelegationResponse. 

#### Motivation and Context

This change was necessary to manage this additional information in case of request populated with institutionId.

#### How Has This Been Tested?

I have run ms-core microservice locally and tested the specific API **/delegations** GET
