### PR TITLE
[SELC - 3013] zip archive compression of the pdf file of the contract

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
@@ -39,6 +39,7 @@ public enum GenericError {
 
     ERROR_DURING_DELETED_FILE("0000", "Error during deleted file %s"),
     ERROR_DURING_DOWNLOAD_FILE("0000", "Error during download file %s"),
+    ERROR_DURING_COMPRESS_FILE("0000", "Error compressing the file %s"),
     RETRIEVING_USER_RELATIONSHIP_ERROR("0023", "Error while retrieving user relationships"),
     ACTIVATE_RELATIONSHIP_ERROR("0024", "Error while activating relationship"),
     SUSPEND_RELATIONSHIP_ERROR("0025", "Error while suspending relationship"),

--- a/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
+++ b/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
@@ -2,8 +2,8 @@ package it.pagopa.selfcare.mscore.connector.email;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.mscore.api.EmailConnector;
-import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.api.FileStorageConnector;
+import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.onboarding.MailTemplate;
 import lombok.extern.slf4j.Slf4j;
@@ -12,12 +12,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
 
+import javax.activation.DataSource;
 import javax.mail.internet.MimeMessage;
+import javax.mail.util.ByteArrayDataSource;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_SEND_MAIL;
 
@@ -47,7 +54,6 @@ public class EmailConnectorImpl implements EmailConnector {
             log.info("START - sendMail to {}, for product {}", destinationMail, productName);
             String template = fileStorageConnector.getTemplateFile(templateName);
             MailTemplate mailTemplate = mapper.readValue(template, MailTemplate.class);
-
             String html = StringSubstitutor.replace(mailTemplate.getBody(), mailParameters);
             log.trace("sendMessage start");
             MimeMessage mimeMessage = mailSender.createMimeMessage();
@@ -59,7 +65,9 @@ public class EmailConnectorImpl implements EmailConnector {
             message.setTo(destinationMail.toArray(new String[0]));
             message.setText(html, true);
             if(pdf != null && StringUtils.hasText(fileName)) {
-                message.addAttachment(fileName, pdf);
+                byte[] bytes = zipBytes(fileName, pdf);
+                DataSource source = new ByteArrayDataSource(bytes, "application/zip");
+                message.addAttachment(fileName + ".zip", source);
                 log.info("sendMail to: {}, attached file: {}, for product {}", destinationMail, pdf.getName(), productName);
             }
             mailSender.send(mimeMessage);
@@ -70,5 +78,17 @@ public class EmailConnectorImpl implements EmailConnector {
         }
         log.trace("sendMessage end");
     }
+    public byte[] zipBytes(String filename, File pdf) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ZipOutputStream zos = new ZipOutputStream(baos);
+        ZipEntry entry = new ZipEntry(filename);
+        byte[] pdfToByte = FileCopyUtils.copyToByteArray(pdf);
+        zos.putNextEntry(entry);
+        zos.write(pdfToByte);
+        zos.closeEntry();
+        zos.close();
+        return baos.toByteArray();
+    }
+
 }
 

--- a/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
+++ b/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_COMPRESS_FILE;
 import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_SEND_MAIL;
 
 @Slf4j
@@ -78,17 +79,21 @@ public class EmailConnectorImpl implements EmailConnector {
         }
         log.trace("sendMessage end");
     }
-    public byte[] zipBytes(String filename, File pdf) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ZipOutputStream zos = new ZipOutputStream(baos);
-        ZipEntry entry = new ZipEntry(filename);
-        byte[] pdfToByte = FileCopyUtils.copyToByteArray(pdf);
-        zos.putNextEntry(entry);
-        zos.write(pdfToByte);
-        zos.closeEntry();
-        zos.close();
-        return baos.toByteArray();
-    }
-
+    public byte[] zipBytes(String filename, File pdf)  {
+            try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                 ZipOutputStream zos = new ZipOutputStream(baos)) {
+                ZipEntry entry = new ZipEntry(filename);
+                byte[] pdfToByte = FileCopyUtils.copyToByteArray(pdf);
+                zos.putNextEntry(entry);
+                zos.write(pdfToByte);
+                zos.closeEntry();
+                zos.close();
+                return baos.toByteArray();
+            } catch (IOException e) {
+                log.error(String.format(ERROR_DURING_COMPRESS_FILE.getMessage(), filename), e);
+                throw new MsCoreException(String.format(ERROR_DURING_COMPRESS_FILE.getMessage(), filename),
+                        ERROR_DURING_COMPRESS_FILE.getCode());
+            }
+        }
 }
 

--- a/connector/email/src/test/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImplTest.java
+++ b/connector/email/src/test/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImplTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.mscore.api.FileStorageConnector;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
-
 import it.pagopa.selfcare.mscore.model.onboarding.MailTemplate;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -17,10 +16,14 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.mail.internet.MimeMessage;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -43,9 +46,14 @@ class EmailConnectorImplTest {
     private CoreConfig coreConfig;
 
     @Test
-    void testSendMail() throws JsonProcessingException {
+    void testSendMail() throws IOException {
         when(fileStorageConnector.getTemplateFile(any())).thenReturn("templateFile");
         MailTemplate mailTemplate = new MailTemplate();
+        Path path = Files.createTempFile("contratto", ".pdf");
+        File pdf = new File(path.toUri());
+        String fileName = "text.pdf";
+        byte [] bytes = emailConnector.zipBytes(fileName, pdf);
+        assertNotNull(bytes);
         mailTemplate.setBody("body");
         mailTemplate.setSubject("subject");
         when(mapper.readValue("templateFile", MailTemplate.class)).thenReturn(mailTemplate);
@@ -55,7 +63,7 @@ class EmailConnectorImplTest {
         when(coreConfig.getSenderMail()).thenReturn("senderMail");
 
         ArrayList<String> destinationMail = new ArrayList<>();
-        File pdf = Paths.get(System.getProperty("java.io.tmpdir"), "test.txt").toFile();
+
         Assertions.assertDoesNotThrow(() -> emailConnector.sendMail("Template Name", destinationMail, pdf, "Product Name", new HashMap<>(), "foo.txt"));
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

compression of the pdf file in zip format before being attached to the email during the onboarding phase

#### Motivation and Context

This modification was necessary because, when the email arrived at the institutions containing the pdf file of the contract, it could happen that the digest of the file was modified by the institutions' protocol system. Compressing the PDF in zip format allows the file itself not to be compromised

#### How Has This Been Tested?

- a manual onboarding was carried out and it was verified that the extractable zip archive containing the contract in pdf format had arrived
- Some institutions that had presented the problem described above were selected and the contract was sent to a zip archive. Subsequently, the institutions extracted the contract, digitally signed and uploaded it correctly, completing the onboarding

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.