### PR TITLE
add new method in azureBlobClient to retrieve contract as pdf file

### DIFF
--- a/app/src/main/resources/config/azure-storage-config.properties
+++ b/app/src/main/resources/config/azure-storage-config.properties
@@ -4,3 +4,4 @@ blob-storage.checkout-template-container=${STORAGE_TEMPLATE_URL}/resources/templ
 blob-storage.endpoint-suffix = ${STORAGE_ENDPOINT}
 blob-storage.account-name = ${STORAGE_CREDENTIAL_ID}
 blob-storage.contract-path = parties/docs/
+blob-storage.connection-string = ${BLOB_STORAGE_CONN_STRING:UseDevelopmentStorage=true;}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/FileStorageConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/FileStorageConnector.java
@@ -4,7 +4,6 @@ import it.pagopa.selfcare.mscore.model.onboarding.ResourceResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
-import java.io.IOException;
 
 public interface FileStorageConnector {
 
@@ -16,5 +15,5 @@ public interface FileStorageConnector {
 
     void removeContract(String fileName, String tokenId);
 
-    File getFileAsPdf(String contractTemplate) throws IOException;
+    File getFileAsPdf(String contractTemplate);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/FileStorageConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/FileStorageConnector.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.mscore.model.onboarding.ResourceResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.IOException;
 
 public interface FileStorageConnector {
 
@@ -15,5 +16,5 @@ public interface FileStorageConnector {
 
     void removeContract(String fileName, String tokenId);
 
-    File getFileAsPdf(String contractTemplate);
+    File getFileAsPdf(String contractTemplate) throws IOException;
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/FileStorageConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/FileStorageConnector.java
@@ -3,6 +3,8 @@ package it.pagopa.selfcare.mscore.api;
 import it.pagopa.selfcare.mscore.model.onboarding.ResourceResponse;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.File;
+
 public interface FileStorageConnector {
 
     ResourceResponse getFile(String fileName);
@@ -12,4 +14,6 @@ public interface FileStorageConnector {
     String uploadContract(String id, MultipartFile contract);
 
     void removeContract(String fileName, String tokenId);
+
+    File getFileAsPdf(String contractTemplate);
 }

--- a/connector/azure-storage/src/main/java/it/pagopa/selfcare/mscore/connector/azure_storage/AzureBlobClient.java
+++ b/connector/azure-storage/src/main/java/it/pagopa/selfcare/mscore/connector/azure_storage/AzureBlobClient.java
@@ -96,6 +96,7 @@ class AzureBlobClient implements FileStorageConnector {
 
     @Override
     public File getFileAsPdf(String contractTemplate){
+        log.info("START - getFileAsPdf for template: {}", contractTemplate);
         try{
             final CloudBlobContainer blobContainer = blobClient.getContainerReference(azureStorageConfig.getContainer());
             final CloudBlockBlob blob = blobContainer.getBlockBlobReference(contractTemplate);
@@ -112,6 +113,7 @@ class AzureBlobClient implements FileStorageConnector {
             // Close the streams
             blobInputStream.close();
             fileOutputStream.close();
+            log.info("END - getFileAsPdf");
             return downloadedFile;
         } catch (StorageException | URISyntaxException | IOException e) {
             log.error(String.format(ERROR_DURING_DOWNLOAD_FILE.getMessage(), contractTemplate), e);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -10,7 +10,6 @@ import it.pagopa.selfcare.mscore.core.strategy.input.OnboardingInstitutionStrate
 import it.pagopa.selfcare.mscore.core.util.OnboardingInstitutionUtils;
 import it.pagopa.selfcare.mscore.core.util.TokenUtils;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
-import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.QueueEvent;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
@@ -20,12 +19,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_DOWNLOAD_FILE;
 import static it.pagopa.selfcare.mscore.constant.ProductId.*;
 
 @Component
@@ -173,11 +170,7 @@ public class OnboardingInstitutionStrategyFactory {
             String productId = strategyInput.getOnboardingRequest().getProductId();
             File pdf = null;
             if (productId.equals(PROD_FD.getValue()) || productId.equals(PROD_FD_GARANTITO.getValue())) {
-                try {
                     pdf = fileStorageConnector.getFileAsPdf(strategyInput.getOnboardingRequest().getContract().getPath());
-                } catch (IOException e) {
-                    throw new MsCoreException(ERROR_DURING_DOWNLOAD_FILE.getMessage(), ERROR_DURING_DOWNLOAD_FILE.getCode());
-                }
             } else {
                 pdf = contractService.createContractPDF(contractTemplate, manager, delegates, strategyInput.getInstitution(), strategyInput.getOnboardingRequest(), strategyInput.getInstitutionUpdateGeographicTaxonomies(), strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType());
             }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -173,7 +173,7 @@ public class OnboardingInstitutionStrategyFactory {
             String productId = strategyInput.getOnboardingRequest().getProductId();
             File pdf = null;
             if (productId.equals(PROD_FD.getValue()) || productId.equals(PROD_FD_GARANTITO.getValue())) {
-                pdf = fileStorageConnector.getFileAsPdf(strategyInput.getOnboardingRequest().getContractFilePath());
+                pdf = fileStorageConnector.getFileAsPdf(strategyInput.getOnboardingRequest().getContract().getPath());
             } else {
                 pdf = contractService.createContractPDF(contractTemplate, manager, delegates, strategyInput.getInstitution(), strategyInput.getOnboardingRequest(), strategyInput.getInstitutionUpdateGeographicTaxonomies(), strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType());
             }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -10,6 +10,7 @@ import it.pagopa.selfcare.mscore.core.strategy.input.OnboardingInstitutionStrate
 import it.pagopa.selfcare.mscore.core.util.OnboardingInstitutionUtils;
 import it.pagopa.selfcare.mscore.core.util.TokenUtils;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
+import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.QueueEvent;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
@@ -19,10 +20,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_DOWNLOAD_FILE;
 import static it.pagopa.selfcare.mscore.constant.ProductId.*;
 
 @Component
@@ -170,7 +173,11 @@ public class OnboardingInstitutionStrategyFactory {
             String productId = strategyInput.getOnboardingRequest().getProductId();
             File pdf = null;
             if (productId.equals(PROD_FD.getValue()) || productId.equals(PROD_FD_GARANTITO.getValue())) {
-                pdf = fileStorageConnector.getFileAsPdf(strategyInput.getOnboardingRequest().getContract().getPath());
+                try {
+                    pdf = fileStorageConnector.getFileAsPdf(strategyInput.getOnboardingRequest().getContract().getPath());
+                } catch (IOException e) {
+                    throw new MsCoreException(ERROR_DURING_DOWNLOAD_FILE.getMessage(), ERROR_DURING_DOWNLOAD_FILE.getCode());
+                }
             } else {
                 pdf = contractService.createContractPDF(contractTemplate, manager, delegates, strategyInput.getInstitution(), strategyInput.getOnboardingRequest(), strategyInput.getInstitutionUpdateGeographicTaxonomies(), strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType());
             }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -17,6 +17,8 @@ import it.pagopa.selfcare.mscore.model.user.UserToOnboard;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -549,6 +551,67 @@ class OnboardingInstitutionStrategyTest {
         when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
         when(contractService.extractTemplate(any())).thenReturn("template");
         when(contractService.createContractPDF(any(), any(), any(), any(), any(), any(), any())).thenReturn(File.createTempFile("file",".txt"));
+        assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.PA, onboardingRequest.getProductId(), institution)
+                .onboardingInstitution(onboardingRequest, mock(SelfCareUser.class)));
+    }
+    @ParameterizedTest()
+    @ValueSource(strings = {"prod-fd", "prod-fd-garantito"})
+    void testOnboardingProdFD(String productId) throws IOException {
+
+        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
+
+        Token token = new Token();
+        token.setChecksum("Checksum");
+        token.setDeletedAt(null);
+        token.setContractSigned("Contract Signed");
+        token.setContractTemplate("Contract Template");
+        token.setCreatedAt(null);
+        token.setExpiringDate(null);
+        token.setId("42");
+        token.setInstitutionId("42");
+        token.setInstitutionUpdate(institutionUpdate);
+        token.setProductId(productId);
+        token.setStatus(RelationshipState.PENDING);
+        token.setType(TokenType.INSTITUTION);
+        token.setUpdatedAt(null);
+        token.setUsers(new ArrayList<>());
+
+        Billing billing = new Billing();
+        billing.setPublicServices(true);
+        billing.setRecipientCode(
+                "START - checkIfProductAlreadyOnboarded for institution having externalId: {} and productId: {}");
+        billing.setVatNumber("42");
+
+        Institution institution = new Institution();
+        institution.setOrigin("selc");
+        institution.setInstitutionType(InstitutionType.PA);
+
+        Billing billing1 = TestUtils.createSimpleBilling();
+        Contract contract = TestUtils.createSimpleContract();
+
+        InstitutionUpdate institutionUpdate1 = new InstitutionUpdate();
+
+        OnboardingRequest onboardingRequest = new OnboardingRequest();
+        onboardingRequest.setBillingRequest(billing1);
+        onboardingRequest.setContract(contract);
+        onboardingRequest.setInstitutionExternalId("42");
+        onboardingRequest.setInstitutionUpdate(institutionUpdate1);
+        onboardingRequest.setPricingPlan("Pricing Plan");
+        onboardingRequest.setProductId(productId);
+        onboardingRequest.setProductName("Product Name");
+        onboardingRequest.setSignContract(true);
+        onboardingRequest.setTokenType(TokenType.INSTITUTION);
+        UserToOnboard userToOnboard = new UserToOnboard();
+        userToOnboard.setId("id");
+        userToOnboard.setRole(PartyRole.MANAGER);
+        onboardingRequest.setUsers(List.of(userToOnboard));
+        OnboardingRollback onboardingRollback = new OnboardingRollback();
+        Token token1 =new Token();
+        token1.setId("id");
+        onboardingRollback.setToken(token1);
+        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
+        when(contractService.extractTemplate(any())).thenReturn("template");
+        when(fileStorageConnector.getFileAsPdf(any())).thenReturn(File.createTempFile("file",".pdf"));
         assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.PA, onboardingRequest.getProductId(), institution)
                 .onboardingInstitution(onboardingRequest, mock(SelfCareUser.class)));
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.core.strategy;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
+import it.pagopa.selfcare.mscore.api.FileStorageConnector;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.constant.InstitutionType;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
@@ -46,6 +47,9 @@ class OnboardingInstitutionStrategyTest {
     private UserService userService;
     @Mock
     private NotificationService notificationService;
+
+    @Mock
+    private FileStorageConnector fileStorageConnector;
     @Mock
     private InstitutionService institutionService;
     @Mock
@@ -54,7 +58,7 @@ class OnboardingInstitutionStrategyTest {
     @BeforeEach
     void beforeAll() {
         strategyFactory = new OnboardingInstitutionStrategyFactory(onboardingDao,
-                contractService,userService, institutionService, coreConfig, notificationService);
+                contractService,userService, institutionService, coreConfig, notificationService, fileStorageConnector);
     }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Prod FD has a pdf file as contract, implemented a new method in azure client to retreive the pdf and attach it to the confirmation mail

#### Motivation and Context

Prod FD wont use a customizable contract, it has a pdf file that just has to be signed.

#### How Has This Been Tested?

Started application locally and did an onboarding procedure and verified the mail

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.