### PR TITLE
[SELC - 3116] implemented onboarding logic for PT

### DIFF
--- a/app/src/main/resources/config/core-config.properties
+++ b/app/src/main/resources/config/core-config.properties
@@ -31,6 +31,8 @@ mscore.mail-template.placeholders.onboarding.rejectTokenPlaceholder = ${MAIL_ONB
 mscore.mail-template.placeholders.onboarding.adminLink = ${SELFCARE_ADMIN_NOTIFICATION_URL}
 
 mscore.mail-template.placeholders.onboarding.notificationPath = ${MAIL_TEMPLATE_NOTIFICATION_PATH}
+mscore.mail-template.placeholders.onboarding.registrationRequestPath = ${MAIL_TEMPLATE_REGISTRATION_REQUEST_PT_PATH}
+mscore.mail-template.placeholders.onboarding.registrationNotificationAdminPath = ${MAIL_TEMPLATE_REGISTRATION_NOTIFICATION_ADMIN_PATH}
 mscore.mail-template.placeholders.onboarding.notificationAdminEmail = ${ADDRESS_EMAIL_NOTIFICATION_ADMIN}
 mscore.mail-template.placeholders.onboarding.notificationProductName = productName
 mscore.mail-template.placeholders.onboarding.notificationRequesterName = requesterName

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/config/MailTemplateConfig.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/config/MailTemplateConfig.java
@@ -45,4 +45,7 @@ public class MailTemplateConfig {
     private String rejectProductName;
     private String rejectOnboardingUrlPlaceholder;
     private String rejectOnboardingUrlValue;
+
+    private String registrationRequestPath;
+    private String registrationNotificationAdminPath;
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationService.java
@@ -25,5 +25,5 @@ public interface NotificationService {
 
     void sendMailForDelegation(String institutionName, String productId, String partnerId);
 
-    void sendMailToPT(User user, Institution institution, OnboardingRequest onboardingRequest, String id);
+    void sendMailToPT(User user, Institution institution, OnboardingRequest onboardingRequest);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationService.java
@@ -24,4 +24,6 @@ public interface NotificationService {
     void sendRejectMail(File logo, Institution institution, Product product);
 
     void sendMailForDelegation(String institutionName, String productId, String partnerId);
+
+    void sendMailToPT(User user, Institution institution, OnboardingRequest onboardingRequest, String id);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationService.java
@@ -19,11 +19,13 @@ public interface NotificationService {
 
     void sendMailForApprove(User user, OnboardingRequest request, String token);
 
+    void sendMailForRegistrationNotificationApprove(User user, OnboardingRequest request, String token);
+
     void sendCompletedEmail(List<User> managers, Institution institution, Product product, File logo);
 
     void sendRejectMail(File logo, Institution institution, Product product);
 
     void sendMailForDelegation(String institutionName, String productId, String partnerId);
 
-    void sendMailToPT(User user, Institution institution, OnboardingRequest onboardingRequest);
+    void sendMailForRegistration(User user, Institution institution, OnboardingRequest onboardingRequest);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
@@ -96,8 +96,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     public void sendMailForApprove(User user, OnboardingRequest request, String token) {
-        Map<String, String> mailParameters;
-        mailParameters = mailParametersMapper.getOnboardingMailNotificationParameter(user, request, token);
+        Map<String, String> mailParameters = mailParametersMapper.getOnboardingMailNotificationParameter(user, request, token);
         log.debug(MAIL_PARAMETER_LOG, mailParameters);
         List<String> destinationMail = mailParametersMapper.getOnboardingNotificationAdminEmail();
         log.info(DESTINATION_MAIL_LOG, destinationMail);
@@ -107,8 +106,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     public void sendMailForRegistrationNotificationApprove(User user, OnboardingRequest request, String token) {
-        Map<String, String> mailParameters;
-        mailParameters = mailParametersMapper.getOnboardingMailNotificationParameter(user, request, token);
+        Map<String, String> mailParameters = mailParametersMapper.getOnboardingMailNotificationParameter(user, request, token);
         log.debug(MAIL_PARAMETER_LOG, mailParameters);
         List<String> destinationMail = mailParametersMapper.getOnboardingNotificationAdminEmail();
         log.info(DESTINATION_MAIL_LOG, destinationMail);
@@ -117,8 +115,7 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     public void sendMailForRegistration(User user, Institution institution, OnboardingRequest request) {
-        Map<String, String> mailParameters;
-        mailParameters = mailParametersMapper.getRegistrationRequestParameter(user, request);
+        Map<String, String> mailParameters = mailParametersMapper.getRegistrationRequestParameter(user, request);
         log.debug(MAIL_PARAMETER_LOG, mailParameters);
         List<String> destinationMail = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
                 ? coreConfig.getDestinationMails() : List.of(institution.getDigitalAddress());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.mscore.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.*;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.config.MailTemplateConfig;
@@ -101,8 +102,24 @@ public class NotificationServiceImpl implements NotificationService {
         log.debug(MAIL_PARAMETER_LOG, mailParameters);
         List<String> destinationMail = mailParametersMapper.getOnboardingNotificationAdminEmail();
         log.info(DESTINATION_MAIL_LOG, destinationMail);
-        emailConnector.sendMail(mailParametersMapper.getOnboardingNotificationPath(), destinationMail, null, request.getProductName(), mailParameters, null);
+        if (!InstitutionType.PT.equals(request.getInstitutionUpdate().getInstitutionType())) {
+            emailConnector.sendMail(mailParametersMapper.getOnboardingNotificationPath(), destinationMail, null, request.getProductName(), mailParameters, null);
+        } else {
+            emailConnector.sendMail(mailParametersMapper.getRegistrationNotificationAdminPath(), destinationMail, null, request.getProductName(), mailParameters, null);
+        }
         log.info("onboarding-complete-email-notification Email successful sent");
+
+    }
+
+    public void sendMailToPT(User user,Institution institution, OnboardingRequest request, String token) {
+        Map<String, String> mailParameters;
+        mailParameters = mailParametersMapper.getRegistrationRequestParameter(user, request, token);
+        log.debug(MAIL_PARAMETER_LOG, mailParameters);
+        List<String> destinationMail = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
+                ? coreConfig.getDestinationMails() : List.of(institution.getDigitalAddress());
+        log.info(DESTINATION_MAIL_LOG, destinationMail);
+        emailConnector.sendMail(mailParametersMapper.getRegistrationRequestPath(), destinationMail, null, request.getProductName(), mailParameters, null);
+        log.info("registration-request-email Email successful sent");
 
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.core;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.*;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.config.MailTemplateConfig;
@@ -102,16 +101,22 @@ public class NotificationServiceImpl implements NotificationService {
         log.debug(MAIL_PARAMETER_LOG, mailParameters);
         List<String> destinationMail = mailParametersMapper.getOnboardingNotificationAdminEmail();
         log.info(DESTINATION_MAIL_LOG, destinationMail);
-        if (!InstitutionType.PT.equals(request.getInstitutionUpdate().getInstitutionType())) {
-            emailConnector.sendMail(mailParametersMapper.getOnboardingNotificationPath(), destinationMail, null, request.getProductName(), mailParameters, null);
-        } else {
-            emailConnector.sendMail(mailParametersMapper.getRegistrationNotificationAdminPath(), destinationMail, null, request.getProductName(), mailParameters, null);
-        }
+        emailConnector.sendMail(mailParametersMapper.getOnboardingNotificationPath(), destinationMail, null, request.getProductName(), mailParameters, null);
         log.info("onboarding-complete-email-notification Email successful sent");
 
     }
 
-    public void sendMailToPT(User user,Institution institution, OnboardingRequest request) {
+    public void sendMailForRegistrationNotificationApprove(User user, OnboardingRequest request, String token) {
+        Map<String, String> mailParameters;
+        mailParameters = mailParametersMapper.getOnboardingMailNotificationParameter(user, request, token);
+        log.debug(MAIL_PARAMETER_LOG, mailParameters);
+        List<String> destinationMail = mailParametersMapper.getOnboardingNotificationAdminEmail();
+        log.info(DESTINATION_MAIL_LOG, destinationMail);
+        emailConnector.sendMail(mailParametersMapper.getRegistrationNotificationAdminPath(), destinationMail, null, request.getProductName(), mailParameters, null);
+        log.info("onboarding-registration-email-notification Email successful sent");
+    }
+
+    public void sendMailForRegistration(User user, Institution institution, OnboardingRequest request) {
         Map<String, String> mailParameters;
         mailParameters = mailParametersMapper.getRegistrationRequestParameter(user, request);
         log.debug(MAIL_PARAMETER_LOG, mailParameters);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
@@ -111,9 +111,9 @@ public class NotificationServiceImpl implements NotificationService {
 
     }
 
-    public void sendMailToPT(User user,Institution institution, OnboardingRequest request, String token) {
+    public void sendMailToPT(User user,Institution institution, OnboardingRequest request) {
         Map<String, String> mailParameters;
-        mailParameters = mailParametersMapper.getRegistrationRequestParameter(user, request, token);
+        mailParameters = mailParametersMapper.getRegistrationRequestParameter(user, request);
         log.debug(MAIL_PARAMETER_LOG, mailParameters);
         List<String> destinationMail = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
                 ? coreConfig.getDestinationMails() : List.of(institution.getDigitalAddress());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -219,7 +219,7 @@ public class OnboardingInstitutionStrategyFactory {
                 User user = userService.retrieveUserFromUserRegistry(strategyInput.getPrincipal().getId(), EnumSet.allOf(User.Fields.class));
                     notificationService.sendMailForApprove(user, strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
                     if(InstitutionType.PT.equals(strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType())){
-                        notificationService.sendMailToPT(user, strategyInput.getInstitution(), strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
+                        notificationService.sendMailToPT(user, strategyInput.getInstitution(), strategyInput.getOnboardingRequest());
                     }
             } catch (Exception e) {
                 onboardingDao.rollbackSecondStep(strategyInput.getToUpdate(), strategyInput.getToDelete(), strategyInput.getInstitution().getId(),

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -217,9 +217,11 @@ public class OnboardingInstitutionStrategyFactory {
         return strategyInput -> {
             try {
                 User user = userService.retrieveUserFromUserRegistry(strategyInput.getPrincipal().getId(), EnumSet.allOf(User.Fields.class));
+                if(!InstitutionType.PT.equals(strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType())) {
                     notificationService.sendMailForApprove(user, strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
-                    if(InstitutionType.PT.equals(strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType())){
-                        notificationService.sendMailToPT(user, strategyInput.getInstitution(), strategyInput.getOnboardingRequest());
+                } else {
+                    notificationService.sendMailForRegistration(user, strategyInput.getInstitution(), strategyInput.getOnboardingRequest());
+                    notificationService.sendMailForRegistrationNotificationApprove(user, strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
                     }
             } catch (Exception e) {
                 onboardingDao.rollbackSecondStep(strategyInput.getToUpdate(), strategyInput.getToDelete(), strategyInput.getInstitution().getId(),

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -217,7 +217,10 @@ public class OnboardingInstitutionStrategyFactory {
         return strategyInput -> {
             try {
                 User user = userService.retrieveUserFromUserRegistry(strategyInput.getPrincipal().getId(), EnumSet.allOf(User.Fields.class));
-                notificationService.sendMailForApprove(user, strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
+                    notificationService.sendMailForApprove(user, strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
+                    if(InstitutionType.PT.equals(strategyInput.getOnboardingRequest().getInstitutionUpdate().getInstitutionType())){
+                        notificationService.sendMailToPT(user, strategyInput.getInstitution(), strategyInput.getOnboardingRequest(), strategyInput.getOnboardingRollback().getToken().getId());
+                    }
             } catch (Exception e) {
                 onboardingDao.rollbackSecondStep(strategyInput.getToUpdate(), strategyInput.getToDelete(), strategyInput.getInstitution().getId(),
                         strategyInput.getOnboardingRollback().getToken(), strategyInput.getOnboardingRollback().getOnboarding(), strategyInput.getOnboardingRollback().getProductMap());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapper.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapper.java
@@ -54,7 +54,7 @@ public class MailParametersMapper {
         return map;
     }
 
-    public Map<String, String> getRegistrationRequestParameter(User user, OnboardingRequest request, String token) {
+    public Map<String, String> getRegistrationRequestParameter(User user, OnboardingRequest request) {
         Map<String, String> map = new HashMap<>();
         if(user.getName()!=null) {
             map.put(mailTemplateConfig.getNotificationRequesterName(), user.getName());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapper.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapper.java
@@ -54,6 +54,20 @@ public class MailParametersMapper {
         return map;
     }
 
+    public Map<String, String> getRegistrationRequestParameter(User user, OnboardingRequest request, String token) {
+        Map<String, String> map = new HashMap<>();
+        if(user.getName()!=null) {
+            map.put(mailTemplateConfig.getNotificationRequesterName(), user.getName());
+        }
+        if(user.getFamilyName()!=null) {
+            map.put(mailTemplateConfig.getNotificationRequesterSurname(), user.getFamilyName());
+        }
+        if(request.getInstitutionUpdate()!=null) {
+            map.put(mailTemplateConfig.getInstitutionDescription(), request.getInstitutionUpdate().getDescription());
+        }
+        return map;
+    }
+
     public Map<String, String> getDelegationNotificationParameter(String institutionName, String productName) {
         Map<String, String> map = new HashMap<>();
         map.put(mailTemplateConfig.getNotificationProductName(), productName);
@@ -63,6 +77,14 @@ public class MailParametersMapper {
 
     public String getOnboardingNotificationPath() {
         return mailTemplateConfig.getNotificationPath();
+    }
+
+    public String getRegistrationRequestPath() {
+        return mailTemplateConfig.getRegistrationRequestPath();
+    }
+
+    public String getRegistrationNotificationAdminPath() {
+        return mailTemplateConfig.getRegistrationNotificationAdminPath();
     }
 
     public String getDelegationNotificationPath() {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
@@ -144,6 +144,13 @@ class NotificationServiceImplTest {
     }
 
     @Test
+    void sendMailToPT(){
+        Institution institution =  new Institution();
+        institution.setDigitalAddress("42");
+        Assertions.assertDoesNotThrow(() -> notificationService.sendMailToPT(new User(), institution , new OnboardingRequest(), "token"));
+    }
+
+    @Test
     void sendNotificationDelegationMail() {
         Product product = new Product();
         product.setTitle("test");

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
@@ -147,7 +147,7 @@ class NotificationServiceImplTest {
     void sendMailToPT(){
         Institution institution =  new Institution();
         institution.setDigitalAddress("42");
-        Assertions.assertDoesNotThrow(() -> notificationService.sendMailToPT(new User(), institution , new OnboardingRequest(), "token"));
+        Assertions.assertDoesNotThrow(() -> notificationService.sendMailToPT(new User(), institution , new OnboardingRequest()));
     }
 
     @Test

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.*;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.config.MailTemplateConfig;
@@ -9,6 +10,7 @@ import it.pagopa.selfcare.mscore.core.util.MailParametersMapper;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.CertifiedField;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
+import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
 import it.pagopa.selfcare.mscore.model.institution.WorkContact;
 import it.pagopa.selfcare.mscore.model.onboarding.MailTemplate;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
@@ -125,7 +127,20 @@ class NotificationServiceImplTest {
 
     @Test
     void sendMailForApprove(){
-        Assertions.assertDoesNotThrow(() -> notificationService.sendMailForApprove(new User(), new OnboardingRequest(), "token"));
+        OnboardingRequest onboardingRequest =  new OnboardingRequest();
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setInstitutionType(InstitutionType.GSP);
+        onboardingRequest.setInstitutionUpdate(institutionUpdate);
+        Assertions.assertDoesNotThrow(() -> notificationService.sendMailForApprove(new User(), onboardingRequest, "token"));
+    }
+
+    @Test
+    void sendMailForApprovePT(){
+        OnboardingRequest onboardingRequest =  new OnboardingRequest();
+        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
+        institutionUpdate.setInstitutionType(InstitutionType.PT);
+        onboardingRequest.setInstitutionUpdate(institutionUpdate);
+        Assertions.assertDoesNotThrow(() -> notificationService.sendMailForApprove(new User(), onboardingRequest, "token"));
     }
 
     @Test

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
@@ -135,19 +135,19 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void sendMailForApprovePT(){
+    void sendMailForRegistrationNotificationApprove(){
         OnboardingRequest onboardingRequest =  new OnboardingRequest();
         InstitutionUpdate institutionUpdate = new InstitutionUpdate();
         institutionUpdate.setInstitutionType(InstitutionType.PT);
         onboardingRequest.setInstitutionUpdate(institutionUpdate);
-        Assertions.assertDoesNotThrow(() -> notificationService.sendMailForApprove(new User(), onboardingRequest, "token"));
+        Assertions.assertDoesNotThrow(() -> notificationService.sendMailForRegistrationNotificationApprove(new User(), onboardingRequest, "token"));
     }
 
     @Test
-    void sendMailToPT(){
+    void sendMailForRegistration(){
         Institution institution =  new Institution();
         institution.setDigitalAddress("42");
-        Assertions.assertDoesNotThrow(() -> notificationService.sendMailToPT(new User(), institution , new OnboardingRequest()));
+        Assertions.assertDoesNotThrow(() -> notificationService.sendMailForRegistration(new User(), institution , new OnboardingRequest()));
     }
 
     @Test

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/TestUtils.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/TestUtils.java
@@ -6,10 +6,7 @@ import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.constant.TokenType;
 import it.pagopa.selfcare.mscore.model.CertifiedField;
 import it.pagopa.selfcare.mscore.model.institution.*;
-import it.pagopa.selfcare.mscore.model.onboarding.Contract;
-import it.pagopa.selfcare.mscore.model.onboarding.ContractImported;
-import it.pagopa.selfcare.mscore.model.onboarding.Token;
-import it.pagopa.selfcare.mscore.model.onboarding.TokenUser;
+import it.pagopa.selfcare.mscore.model.onboarding.*;
 import it.pagopa.selfcare.mscore.model.user.User;
 
 import java.util.ArrayList;
@@ -46,6 +43,19 @@ public class TestUtils {
         user.setRole(PartyRole.MANAGER);
         token.setUsers(List.of(user));
         return token;
+    }
+
+    public static OnboardingRequest dummyOnboardingRequest() {
+        OnboardingRequest onboardingRequest = new OnboardingRequest();
+        onboardingRequest.setInstitutionExternalId("42");
+        onboardingRequest.setPricingPlan("Pricing Plan");
+        onboardingRequest.setProductId("prod-io");
+        onboardingRequest.setProductName("Product Name");
+        onboardingRequest.setSignContract(true);
+        onboardingRequest.setTokenType(TokenType.INSTITUTION);
+        onboardingRequest.setBillingRequest(new Billing());
+        onboardingRequest.setUsers(new ArrayList<>());
+        return onboardingRequest;
     }
 
     public static InstitutionUpdate createSimpleInstitutionUpdate() {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -352,23 +352,6 @@ class OnboardingInstitutionStrategyTest {
     @Test
     void testOnboardingInstitutionGSP() throws IOException {
 
-        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
-
-        Token token = new Token();
-        token.setChecksum("Checksum");
-        token.setDeletedAt(null);
-        token.setContractSigned("Contract Signed");
-        token.setContractTemplate("Contract Template");
-        token.setCreatedAt(null);
-        token.setExpiringDate(null);
-        token.setId("42");
-        token.setInstitutionId("42");
-        token.setInstitutionUpdate(institutionUpdate);
-        token.setProductId("prod-io");
-        token.setStatus(RelationshipState.PENDING);
-        token.setType(TokenType.INSTITUTION);
-        token.setUpdatedAt(null);
-        token.setUsers(new ArrayList<>());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -386,14 +369,10 @@ class OnboardingInstitutionStrategyTest {
 
         InstitutionUpdate institutionUpdate1 = new InstitutionUpdate();
 
-        OnboardingRequest onboardingRequest = new OnboardingRequest();
+        OnboardingRequest onboardingRequest = TestUtils.dummyOnboardingRequest();
         onboardingRequest.setBillingRequest(billing1);
         onboardingRequest.setContract(contract);
-        onboardingRequest.setInstitutionExternalId("42");
         onboardingRequest.setInstitutionUpdate(institutionUpdate1);
-        onboardingRequest.setPricingPlan("Pricing Plan");
-        onboardingRequest.setProductId("prod-io");
-        onboardingRequest.setProductName("Product Name");
         onboardingRequest.setSignContract(true);
         onboardingRequest.setTokenType(TokenType.INSTITUTION);
         UserToOnboard userToOnboard = new UserToOnboard();
@@ -404,7 +383,6 @@ class OnboardingInstitutionStrategyTest {
         Token token1 =new Token();
         token1.setId("id");
         onboardingRollback.setToken(token1);
-        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
         when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
 
         assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.GSP, onboardingRequest.getProductId(), institution)
@@ -567,23 +545,6 @@ class OnboardingInstitutionStrategyTest {
     @Test
     void testOnboardingInstitutionPT() {
 
-        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
-
-        Token token = new Token();
-        token.setChecksum("Checksum");
-        token.setDeletedAt(null);
-        token.setContractSigned("Contract Signed");
-        token.setContractTemplate("Contract Template");
-        token.setCreatedAt(null);
-        token.setExpiringDate(null);
-        token.setId("42");
-        token.setInstitutionId("42");
-        token.setInstitutionUpdate(institutionUpdate);
-        token.setProductId("prod-io");
-        token.setStatus(RelationshipState.PENDING);
-        token.setType(TokenType.INSTITUTION);
-        token.setUpdatedAt(null);
-        token.setUsers(new ArrayList<>());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -599,19 +560,13 @@ class OnboardingInstitutionStrategyTest {
         Billing billing1 = TestUtils.createSimpleBilling();
         Contract contract = TestUtils.createSimpleContract();
 
-        InstitutionUpdate institutionUpdate1 = new InstitutionUpdate();
+        InstitutionUpdate institutionUpdate1 = TestUtils.createSimpleInstitutionUpdate();
         institutionUpdate1.setInstitutionType(InstitutionType.PT);
 
-        OnboardingRequest onboardingRequest = new OnboardingRequest();
+        OnboardingRequest onboardingRequest = TestUtils.dummyOnboardingRequest();
         onboardingRequest.setBillingRequest(billing1);
         onboardingRequest.setContract(contract);
-        onboardingRequest.setInstitutionExternalId("42");
         onboardingRequest.setInstitutionUpdate(institutionUpdate1);
-        onboardingRequest.setPricingPlan("Pricing Plan");
-        onboardingRequest.setProductId("prod-io");
-        onboardingRequest.setProductName("Product Name");
-        onboardingRequest.setSignContract(true);
-        onboardingRequest.setTokenType(TokenType.INSTITUTION);
         UserToOnboard userToOnboard = new UserToOnboard();
         userToOnboard.setId("id");
         userToOnboard.setRole(PartyRole.MANAGER);
@@ -620,7 +575,6 @@ class OnboardingInstitutionStrategyTest {
         Token token1 =new Token();
         token1.setId("id");
         onboardingRollback.setToken(token1);
-        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
         when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
 
         assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.PT, onboardingRequest.getProductId(), institution)

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -364,6 +364,71 @@ class OnboardingInstitutionStrategyTest {
         token.setId("42");
         token.setInstitutionId("42");
         token.setInstitutionUpdate(institutionUpdate);
+        token.setProductId("prod-io");
+        token.setStatus(RelationshipState.PENDING);
+        token.setType(TokenType.INSTITUTION);
+        token.setUpdatedAt(null);
+        token.setUsers(new ArrayList<>());
+
+        Billing billing = new Billing();
+        billing.setPublicServices(true);
+        billing.setRecipientCode(
+                "START - checkIfProductAlreadyOnboarded for institution having externalId: {} and productId: {}");
+        billing.setVatNumber("42");
+
+        Institution institution = new Institution();
+        institution.setOrigin("IPA");
+        institution.setBilling(billing);
+        institution.setInstitutionType(InstitutionType.GSP);
+
+        Billing billing1 = TestUtils.createSimpleBilling();
+        Contract contract = TestUtils.createSimpleContract();
+
+        InstitutionUpdate institutionUpdate1 = new InstitutionUpdate();
+
+        OnboardingRequest onboardingRequest = new OnboardingRequest();
+        onboardingRequest.setBillingRequest(billing1);
+        onboardingRequest.setContract(contract);
+        onboardingRequest.setInstitutionExternalId("42");
+        onboardingRequest.setInstitutionUpdate(institutionUpdate1);
+        onboardingRequest.setPricingPlan("Pricing Plan");
+        onboardingRequest.setProductId("prod-io");
+        onboardingRequest.setProductName("Product Name");
+        onboardingRequest.setSignContract(true);
+        onboardingRequest.setTokenType(TokenType.INSTITUTION);
+        UserToOnboard userToOnboard = new UserToOnboard();
+        userToOnboard.setId("id");
+        userToOnboard.setRole(PartyRole.MANAGER);
+        onboardingRequest.setUsers(List.of(userToOnboard));
+        OnboardingRollback onboardingRollback = new OnboardingRollback();
+        Token token1 =new Token();
+        token1.setId("id");
+        onboardingRollback.setToken(token1);
+        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
+        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
+
+        assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.GSP, onboardingRequest.getProductId(), institution)
+                .onboardingInstitution(onboardingRequest, mock(SelfCareUser.class)));
+    }
+
+    /**
+     *Method under test: {@link OnboardingServiceImpl#onboardingInstitution(OnboardingRequest, SelfCareUser)}
+     */
+    @Test
+    void testOnboardingInstitutionGSP2() throws IOException {
+
+        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
+
+        Token token = new Token();
+        token.setChecksum("Checksum");
+        token.setDeletedAt(null);
+        token.setContractSigned("Contract Signed");
+        token.setContractTemplate("Contract Template");
+        token.setCreatedAt(null);
+        token.setExpiringDate(null);
+        token.setId("42");
+        token.setInstitutionId("42");
+        token.setInstitutionUpdate(institutionUpdate);
         token.setProductId(PROD_INTEROP.getValue());
         token.setStatus(RelationshipState.PENDING);
         token.setType(TokenType.INSTITUTION);
@@ -493,6 +558,73 @@ class OnboardingInstitutionStrategyTest {
         assertThrows(InvalidRequestException.class,
                 () -> strategyFactory.retrieveOnboardingInstitutionStrategy(institutionUpdate.getInstitutionType(), onboardingRequest.getProductId(), institution)
                         .onboardingInstitution(onboardingRequest, mock(SelfCareUser.class)));
+
+    }
+
+    /**
+     * Method under test: {@link OnboardingServiceImpl#onboardingInstitution(OnboardingRequest, SelfCareUser)}
+     */
+    @Test
+    void testOnboardingInstitutionPT() {
+
+        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
+
+        Token token = new Token();
+        token.setChecksum("Checksum");
+        token.setDeletedAt(null);
+        token.setContractSigned("Contract Signed");
+        token.setContractTemplate("Contract Template");
+        token.setCreatedAt(null);
+        token.setExpiringDate(null);
+        token.setId("42");
+        token.setInstitutionId("42");
+        token.setInstitutionUpdate(institutionUpdate);
+        token.setProductId("prod-io");
+        token.setStatus(RelationshipState.PENDING);
+        token.setType(TokenType.INSTITUTION);
+        token.setUpdatedAt(null);
+        token.setUsers(new ArrayList<>());
+
+        Billing billing = new Billing();
+        billing.setPublicServices(true);
+        billing.setRecipientCode(
+                "START - checkIfProductAlreadyOnboarded for institution having externalId: {} and productId: {}");
+        billing.setVatNumber("42");
+
+        Institution institution = new Institution();
+        institution.setOrigin("IPA");
+        institution.setBilling(billing);
+        institution.setInstitutionType(InstitutionType.PT);
+
+        Billing billing1 = TestUtils.createSimpleBilling();
+        Contract contract = TestUtils.createSimpleContract();
+
+        InstitutionUpdate institutionUpdate1 = new InstitutionUpdate();
+        institutionUpdate1.setInstitutionType(InstitutionType.PT);
+
+        OnboardingRequest onboardingRequest = new OnboardingRequest();
+        onboardingRequest.setBillingRequest(billing1);
+        onboardingRequest.setContract(contract);
+        onboardingRequest.setInstitutionExternalId("42");
+        onboardingRequest.setInstitutionUpdate(institutionUpdate1);
+        onboardingRequest.setPricingPlan("Pricing Plan");
+        onboardingRequest.setProductId("prod-io");
+        onboardingRequest.setProductName("Product Name");
+        onboardingRequest.setSignContract(true);
+        onboardingRequest.setTokenType(TokenType.INSTITUTION);
+        UserToOnboard userToOnboard = new UserToOnboard();
+        userToOnboard.setId("id");
+        userToOnboard.setRole(PartyRole.MANAGER);
+        onboardingRequest.setUsers(List.of(userToOnboard));
+        OnboardingRollback onboardingRollback = new OnboardingRollback();
+        Token token1 =new Token();
+        token1.setId("id");
+        onboardingRollback.setToken(token1);
+        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
+        when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
+
+        assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.PT, onboardingRequest.getProductId(), institution)
+                .onboardingInstitution(onboardingRequest, mock(SelfCareUser.class)));
 
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapperTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapperTest.java
@@ -83,7 +83,7 @@ class MailParametersMapperTest {
         OnboardingRequest request = new OnboardingRequest();
         request.setProductId("productId");
         request.setInstitutionUpdate(new InstitutionUpdate());
-        Map<String, String> map = mailParametersMapper.getRegistrationRequestParameter(user, request, "");
+        Map<String, String> map = mailParametersMapper.getRegistrationRequestParameter(user, request);
         Assertions.assertNotNull(map);
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapperTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapperTest.java
@@ -70,6 +70,24 @@ class MailParametersMapperTest {
     }
 
     @Test
+    void getRegistrationRequestParameter(){
+        when(mailTemplateConfig.getUserName()).thenReturn("userName");
+        when(mailTemplateConfig.getUserSurname()).thenReturn("userSurname");
+        when(mailTemplateConfig.getInstitutionDescription()).thenReturn("institutionDescription");
+        when(mailTemplateConfig.getAdminLink()).thenReturn("institutionDescription");
+        User user = new User();
+        CertifiedField<String> certifiedField = new CertifiedField<>();
+        certifiedField.setValue("42");
+        user.setName(certifiedField);
+        user.setFamilyName(certifiedField);
+        OnboardingRequest request = new OnboardingRequest();
+        request.setProductId("productId");
+        request.setInstitutionUpdate(new InstitutionUpdate());
+        Map<String, String> map = mailParametersMapper.getRegistrationRequestParameter(user, request, "");
+        Assertions.assertNotNull(map);
+    }
+
+    @Test
     void getOnboardingNotificationPath(){
         when(mailTemplateConfig.getNotificationPath()).thenReturn("path");
         Assertions.assertNotNull(mailParametersMapper.getOnboardingNotificationPath());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapperTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/MailParametersMapperTest.java
@@ -82,6 +82,18 @@ class MailParametersMapperTest {
     }
 
     @Test
+    void getRegistrationRequestPath(){
+        when(mailTemplateConfig.getRegistrationRequestPath()).thenReturn("path");
+        Assertions.assertNotNull(mailParametersMapper.getRegistrationRequestPath());
+    }
+
+    @Test
+    void getRegistrationNotificationPath(){
+        when(mailTemplateConfig.getRegistrationNotificationAdminPath()).thenReturn("path");
+        Assertions.assertNotNull(mailParametersMapper.getRegistrationNotificationAdminPath());
+    }
+
+    @Test
     void getOnboardingCompletePath(){
         when(mailTemplateConfig.getCompletePath()).thenReturn("path");
         Assertions.assertNotNull(mailParametersMapper.getOnboardingCompletePath());


### PR DESCRIPTION

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added logic to send registration request mail to PT when PT want to onboard on SelfCare
- added logic to send registration notification mail to Admin PagoPA when PT make onboarding request

#### Motivation and Context

These new logics have been implemented as if the institution that wants to make an onboarding request is a PT it will not have to sign any contract, the PagoPA admin will simply accept this request and only then will it be able to navigate within the dashboard

#### How Has This Been Tested?

Tests were carried out locally. In particular, multiple onboarding requests were made for PT and non-PT institutions in order to verify that the other flow was also working correctly

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.