### PR TITLE
fix: added relationShipState ACTIVE for case TOBEVALIDATE

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingDao.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingDao.java
@@ -415,7 +415,8 @@ public class OnboardingDao {
     private boolean isValidStateChangeForToken(RelationshipState fromState, RelationshipState toState) {
         switch (fromState) {
             case TOBEVALIDATED:
-                return RelationshipState.PENDING == toState || RelationshipState.REJECTED == toState || RelationshipState.DELETED == toState;
+                return RelationshipState.PENDING == toState || RelationshipState.REJECTED == toState || RelationshipState.DELETED == toState
+                        || RelationshipState.ACTIVE == toState;
             case PENDING:
                 return RelationshipState.ACTIVE == toState || RelationshipState.REJECTED == toState || RelationshipState.DELETED == toState;
             default:

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
@@ -782,46 +782,21 @@ class OnboardingDaoTest {
     @Test
     void testPersistForUpdate2() {
 
+        TokenConnector tokenConnector = mock(TokenConnector.class);
+        UserConnector userConnector = mock(UserConnector.class);
+        InstitutionConnector institutionConnector = mock(InstitutionConnector.class);
         ProductConnector productConnector = mock(ProductConnector.class);
-        OnboardingDao onboardingDao = new OnboardingDao(null, null, null, productConnector, new CoreConfig());
+        OnboardingDao onboardingDao = new OnboardingDao(institutionConnector, tokenConnector, userConnector, productConnector, new CoreConfig());
 
-        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
-        institutionUpdate.setAddress("42 Main St");
-        institutionUpdate.setBusinessRegisterPlace("Business Register Place");
-        institutionUpdate
-                .setDataProtectionOfficer(new DataProtectionOfficer("42 Main St", "jane.doe@example.org", "Pec"));
-        institutionUpdate.setDescription("The characteristics of someone or something");
-        institutionUpdate.setDigitalAddress("42 Main St");
-        institutionUpdate.setGeographicTaxonomies(new ArrayList<>());
-        institutionUpdate.setImported(true);
-        institutionUpdate.setInstitutionType(InstitutionType.PA);
-        institutionUpdate
-                .setPaymentServiceProvider(new PaymentServiceProvider("Abi Code", "42", "Legal Register Name", "42", true));
-        institutionUpdate.setRea("Rea");
-        institutionUpdate.setShareCapital("Share Capital");
-        institutionUpdate.setSupportEmail("jane.doe@example.org");
-        institutionUpdate.setSupportPhone("6625550144");
-        institutionUpdate.setTaxCode("Tax Code");
-        institutionUpdate.setZipCode("21654");
+        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdatePT();
 
-        Token token = new Token();
-        token.setChecksum("Checksum");
-        token.setDeletedAt(null);
-        token.setContractSigned("Contract Signed");
-        token.setContractTemplate("Contract Template");
-        token.setCreatedAt(null);
-        token.setExpiringDate(null);
-        token.setId("42");
-        token.setInstitutionId("42");
+
+        Token token = TestUtils.dummyToken();
         token.setInstitutionUpdate(institutionUpdate);
-        token.setProductId("42");
-        token.setType(TokenType.INSTITUTION);
-        token.setUpdatedAt(null);
-        token.setUsers(new ArrayList<>());
         token.setStatus(RelationshipState.TOBEVALIDATED);
         Institution institution = new Institution();
-        assertThrows(InvalidRequestException.class,
-                () -> onboardingDao.persistForUpdate(token, institution, RelationshipState.ACTIVE, "foo"));
+        assertDoesNotThrow(() ->
+                onboardingDao.persistForUpdate(token, institution, RelationshipState.ACTIVE, "foo"));
     }
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

added relationShipState ACTIVE for case TOBEVALIDATED

#### Motivation and Context

The current flow does not allow the PagoPA admin to approve the request. This is the only case where you switch from TOBEVALIDATED to ACTIVE, so this change is necessary

#### How Has This Been Tested?

Local tests have been carried out and requests have been approved in TOBEVALIDATED status

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.