### PR TITLE
[SELC-3248] bug: added new institutionId check for user binding

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingDao.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingDao.java
@@ -226,17 +226,18 @@ public class OnboardingDao {
                 institution.getDescription(),
                 institution.getParentDescription(),
                 List.of(product));
-        relationshipExistAndDelete(onboardedUser, productId);
+        relationshipExistAndDelete(onboardedUser, productId, institution.getId());
         userConnector.findAndUpdate(onboardedUser, user.getId(), institution.getId(), product, binding);
         response.add(new RelationshipInfo(institution, user.getId(), product));
         return product;
     }
 
-    private void relationshipExistAndDelete(OnboardedUser onboardedUser, String productId){
+    private void relationshipExistAndDelete(OnboardedUser onboardedUser, String productId, String institutionId){
         List<OnboardedProduct> products = onboardedUser.getBindings().stream()
                 .flatMap(userBinding -> userBinding.getProducts().stream()
                         .filter(userProduct -> userProduct.getProductId().equalsIgnoreCase(productId)
-                        && !userProduct.getStatus().equals(RelationshipState.DELETED)))
+                        && !userProduct.getStatus().equals(RelationshipState.DELETED)
+                        && userBinding.getInstitutionId().equals(institutionId)))
                 .collect(Collectors.toList());
         if(!products.isEmpty()) {
             products.stream().forEach(singleProduct -> updateUserProductState(onboardedUser, singleProduct.getRelationshipId(), RelationshipState.DELETED));


### PR DESCRIPTION
#### List of Changes

Added check on instutiton identifier to avoid update of status on previous onboarded product.

#### Motivation and Context

This fix was made because the introduction of the new user onboarding API had a bug:

- when a user was registered for a product "X" on an institution "X" if the same user had another onboarding on the same product "X" but institution "Y" it was eliminated

#### How Has This Been Tested?

I have run microservice locally and test the api for user onboarding.