### PR TITLE
[SELC - 3099] fix: implemented new logic for onboarding user

### DIFF
--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
@@ -1645,19 +1645,46 @@ class OnboardingDaoTest {
         assertTrue(onboardingDao.onboardOperator(new Institution(), "productId", List.of(user)).isEmpty());
     }
 
-
     @Test
-    void testOnboardOperator1() {
+    void testOnboardOperator12() {
+        Institution institution = TestUtils.dummyInstitution();
         OnboardedUser onboardedUser = TestUtils.dummyOnboardedUser();
         UserBinding userBinding = TestUtils.dummyUserBinding();
         OnboardedProduct onboardedProduct = TestUtils.dummyOnboardedProduct();
-        onboardedProduct.setProductId("42");
-        userBinding.setProducts(List.of(onboardedProduct));
+        onboardedProduct.setProductId("productId");
+        onboardedProduct.setRole(PartyRole.OPERATOR);
+        onboardedProduct.setProductRole("api");
+        OnboardedProduct onboardedProduct1 = TestUtils.dummyOnboardedProduct();
+        userBinding.setProducts(List.of(onboardedProduct, onboardedProduct1));
+        userBinding.setInstitutionId("institutionId");
         onboardedUser.setBindings(List.of(userBinding));
         UserToOnboard user = new UserToOnboard();
         user.setId("id");
+        user.setRole(PartyRole.DELEGATE);
+        user.setProductRole("admin");
         when(userConnector.findById(any())).thenReturn(onboardedUser);
-        assertFalse(onboardingDao.onboardOperator(new Institution(), "productId", List.of(user)).isEmpty());
+        assertFalse(onboardingDao.onboardOperator(institution, "productId", List.of(user)).isEmpty());
+    }
+
+    @Test
+    void testOnboardOperator1() {
+        Institution institution = TestUtils.dummyInstitution();
+        OnboardedUser onboardedUser = TestUtils.dummyOnboardedUser();
+        UserBinding userBinding = TestUtils.dummyUserBinding();
+        OnboardedProduct onboardedProduct = TestUtils.dummyOnboardedProduct();
+        onboardedProduct.setProductId("productId");
+        onboardedProduct.setRole(PartyRole.OPERATOR);
+        onboardedProduct.setProductRole("api");
+        OnboardedProduct onboardedProduct1 = TestUtils.dummyOnboardedProduct();
+        userBinding.setProducts(List.of(onboardedProduct, onboardedProduct1));
+        userBinding.setInstitutionId("institutionId");
+        onboardedUser.setBindings(List.of(userBinding));
+        UserToOnboard user = new UserToOnboard();
+        user.setId("id");
+        user.setRole(PartyRole.OPERATOR);
+        user.setProductRole("api");
+        when(userConnector.findById(any())).thenReturn(onboardedUser);
+        assertFalse(onboardingDao.onboardOperator(institution, "productId", List.of(user)).isEmpty());
     }
 
     /**

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingDaoTest.java
@@ -1646,7 +1646,7 @@ class OnboardingDaoTest {
     }
 
     @Test
-    void testOnboardOperator12() {
+    void testOnboardOperatorAndDeleteDifferentRole() {
         Institution institution = TestUtils.dummyInstitution();
         OnboardedUser onboardedUser = TestUtils.dummyOnboardedUser();
         UserBinding userBinding = TestUtils.dummyUserBinding();
@@ -1667,7 +1667,28 @@ class OnboardingDaoTest {
     }
 
     @Test
-    void testOnboardOperator1() {
+    void testOnboardOperatorAndKeepSameRoleWithDifferentProductRole() {
+        Institution institution = TestUtils.dummyInstitution();
+        OnboardedUser onboardedUser = TestUtils.dummyOnboardedUser();
+        UserBinding userBinding = TestUtils.dummyUserBinding();
+        OnboardedProduct onboardedProduct = TestUtils.dummyOnboardedProduct();
+        onboardedProduct.setProductId("productId");
+        onboardedProduct.setRole(PartyRole.OPERATOR);
+        onboardedProduct.setProductRole("api");
+        OnboardedProduct onboardedProduct1 = TestUtils.dummyOnboardedProduct();
+        userBinding.setProducts(List.of(onboardedProduct, onboardedProduct1));
+        userBinding.setInstitutionId("institutionId");
+        onboardedUser.setBindings(List.of(userBinding));
+        UserToOnboard user = new UserToOnboard();
+        user.setId("id");
+        user.setRole(PartyRole.OPERATOR);
+        user.setProductRole("security");
+        when(userConnector.findById(any())).thenReturn(onboardedUser);
+        assertFalse(onboardingDao.onboardOperator(institution, "productId", List.of(user)).isEmpty());
+    }
+
+    @Test
+    void testOnboardOperatorAndDeleteSameRole() {
         Institution institution = TestUtils.dummyInstitution();
         OnboardedUser onboardedUser = TestUtils.dummyOnboardedUser();
         UserBinding userBinding = TestUtils.dummyUserBinding();


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

the logic has been added in the method shared between the APIs used to onboard a user on the frontend side and via direct call

#### Motivation and Context

This change was necessary because when a frontend user added another user with the OPERATOR role, if this user was already registered as an operator but with a different productRole it was eliminated

#### How Has This Been Tested?

the API call was made locally trying to cover all the cases, the unit tests were implemented

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.