### PR TITLE
fix renamed attribute for SELC-3291

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -29,7 +29,7 @@ public interface InstitutionService {
 
     Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode);
 
-    Institution createInstitutionFromPda(Institution institution, String injestionInstitutionType);
+    Institution createInstitutionFromPda(Institution institution, String injectionInstitutionType);
 
     Institution createInstitutionByExternalId(String externalId);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -131,8 +131,8 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public Institution createInstitutionFromPda(Institution institution, String injestionInstitutionType) {
-        CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyPda(injestionInstitutionType);
+    public Institution createInstitutionFromPda(Institution institution, String injectionInstitutionType) {
+        CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyPda(injectionInstitutionType);
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(institution.getTaxCode())
                 .build());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
@@ -28,7 +28,7 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
 
     private final InstitutionMapper institutionMapper;
 
-    private String injestionInstitutionType;
+    private String injectionInstitutionType;
 
     public CreateInstitutionStrategyPda(PartyRegistryProxyConnector partyRegistryProxyConnector,
                                         InstitutionConnector institutionConnector,
@@ -100,7 +100,7 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
         newInstitution.setDescription(description);
         newInstitution.setExternalId(taxCode);
         newInstitution.setOrigin(Origin.INFOCAMERE.getValue());
-        if(injestionInstitutionType.equalsIgnoreCase(InstitutionType.PT.name())) {
+        if(injectionInstitutionType.equalsIgnoreCase(InstitutionType.PT.name())) {
             newInstitution.setInstitutionType(InstitutionType.PT);
         }else{
             newInstitution.setInstitutionType(InstitutionType.PG);
@@ -130,7 +130,7 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
         return newInstitution;
     }
 
-    public void setInjestionInstitutionType(String injestionInstitutionType) {
-        this.injestionInstitutionType = injestionInstitutionType;
+    public void setInjectionInstitutionType(String injectionInstitutionType) {
+        this.injectionInstitutionType = injectionInstitutionType;
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/CreateInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/CreateInstitutionStrategyFactory.java
@@ -45,9 +45,9 @@ public class CreateInstitutionStrategyFactory {
         return strategy;
     }
 
-    public CreateInstitutionStrategy createInstitutionStrategyPda(String injestionInstitutiontype) {
+    public CreateInstitutionStrategy createInstitutionStrategyPda(String injectionInstitutionType) {
         CreateInstitutionStrategyPda strategy = new CreateInstitutionStrategyPda(partyRegistryProxyConnector, institutionConnector, institutionMapper);
-        strategy.setInjestionInstitutionType(injestionInstitutiontype);
+        strategy.setInjectionInstitutionType(injectionInstitutionType);
         return strategy;
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -178,7 +178,7 @@ public class InstitutionController {
     public ResponseEntity<InstitutionResponse> createInstitutionFromPda(@RequestBody @Valid PdaInstitutionRequest institutionRequest) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
 
-        Institution saved = institutionService.createInstitutionFromPda(InstitutionMapperCustom.toInstitution(institutionRequest, null), institutionRequest.getInjestionInstitutionType());
+        Institution saved = institutionService.createInstitutionFromPda(InstitutionMapperCustom.toInstitution(institutionRequest, null), institutionRequest.getInjectionInstitutionType());
         return ResponseEntity.status(HttpStatus.CREATED).body(institutionResourceMapper.toInstitutionResponse(saved));
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/PdaInstitutionRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/PdaInstitutionRequest.java
@@ -7,8 +7,8 @@ import javax.validation.constraints.NotEmpty;
 @Data
 public class PdaInstitutionRequest {
 
-    @NotEmpty(message = "InjestionInstitutionType is required")
-    private String injestionInstitutionType;
+    @NotEmpty(message = "InjectionInstitutionType is required")
+    private String injectionInstitutionType;
 
     @NotEmpty(message = "TaxCode is required")
     private String taxCode;

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerPdaTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerPdaTest.java
@@ -48,7 +48,7 @@ public class InstitutionControllerPdaTest {
     void shouldCreateInstitutionFromPda() throws Exception {
         // Given
         PdaInstitutionRequest institutionRequest = new PdaInstitutionRequest();
-        institutionRequest.setInjestionInstitutionType("EC");
+        institutionRequest.setInjectionInstitutionType("EC");
         institutionRequest.setDescription("test ec");
         institutionRequest.setTaxCode("taxCode");
         String content = objectMapper.writeValueAsString(institutionRequest);


### PR DESCRIPTION
#### List of Changes

Renamed input attribute in request body for API /institutions/from-pda  

#### Motivation and Context

Old attribute name was wrong

#### How Has This Been Tested?

Local environment

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.