### PR TITLE
SELC-3256 Added API institution/from-infocamere/

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
@@ -8,6 +8,7 @@ public enum GenericError {
     INSTITUTION_MANAGER_ERROR("0042", "Error while retrieving institution having externalId %s"),
     INSTITUTION_BILLING_ERROR("0044", "Error while retrieving institution having externalId %s"),
     CREATE_INSTITUTION_ERROR("0037", "Error while creating requested institution"),
+    INSTITUTION_INFOCAMERE_NOTFOUND("0039", "Institution %s not found on INFOCAMERE"),
     ONBOARDING_OPERATION_ERROR("0017", "Error while performing onboarding operation"),
     CREATE_DELEGATION_ERROR("0027", "Error while creating requested delegation"),
     ONBOARDING_VERIFICATION_ERROR("0015", "Error while verifying onboarding"),

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -37,6 +37,8 @@ public interface InstitutionService {
 
     Institution createInstitutionFromIvass(Institution institution);
 
+    Institution createInstitutionFromInfocamere(Institution institution);
+
     Institution createInstitutionRaw(Institution institution, String externalId);
 
     Institution createPgInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -175,6 +175,13 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
+    public Institution createInstitutionFromInfocamere(Institution institution) {
+        CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyInfocamere(institution);
+        return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
+                .taxCode(institution.getTaxCode())
+                .build());
+    }
+    @Override
     public Institution createInstitutionByExternalId(String externalId) {
         checkIfAlreadyExists(externalId);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyInfocamere.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyInfocamere.java
@@ -1,0 +1,80 @@
+package it.pagopa.selfcare.mscore.core.strategy;
+
+import it.pagopa.selfcare.mscore.api.InstitutionConnector;
+import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;
+import it.pagopa.selfcare.mscore.constant.Origin;
+import it.pagopa.selfcare.mscore.core.strategy.input.CreateInstitutionStrategyInput;
+import it.pagopa.selfcare.mscore.exception.MsCoreException;
+import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.mscore.model.institution.*;
+import it.pagopa.selfcare.mscore.utils.MaskDataUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+
+import static it.pagopa.selfcare.mscore.constant.GenericError.*;
+
+@Slf4j
+@Component
+public class CreateInstitutionStrategyInfocamere extends CreateInstitutionStrategyCommon implements CreateInstitutionStrategy {
+
+    private final PartyRegistryProxyConnector partyRegistryProxyConnector;
+
+    private Institution institution;
+
+    public CreateInstitutionStrategyInfocamere(PartyRegistryProxyConnector partyRegistryProxyConnector,
+                                               InstitutionConnector institutionConnector) {
+        super(institutionConnector);
+        this.partyRegistryProxyConnector = partyRegistryProxyConnector;
+    }
+
+
+    @Override
+    public Institution createInstitution(CreateInstitutionStrategyInput strategyInput) {
+        checkIfAlreadyExistsByTaxCodeAndSubunitCode(strategyInput.getTaxCode(), strategyInput.getSubunitCode());
+
+        try {
+            NationalRegistriesProfessionalAddress professionalAddress = partyRegistryProxyConnector.getLegalAddress(strategyInput.getTaxCode());
+            getInstitutionFromInfocamere(strategyInput.getTaxCode(), strategyInput.getDescription(), professionalAddress);
+        } catch(MsCoreException ex) {
+            if(ex.getCode().equalsIgnoreCase(String.valueOf(HttpStatus.NOT_FOUND.value()))) {
+                log.warn(String.format(INSTITUTION_INFOCAMERE_NOTFOUND.getMessage(), MaskDataUtils.maskString(strategyInput.getTaxCode())));
+                getInstitutionRaw(strategyInput);
+            } else {
+                throw ex;
+            }
+        } catch (ResourceNotFoundException ex) {
+            log.warn(String.format(INSTITUTION_INFOCAMERE_NOTFOUND.getMessage(), MaskDataUtils.maskString(strategyInput.getTaxCode())));
+            getInstitutionRaw(strategyInput);
+        }
+
+        try {
+            return institutionConnector.save(institution);
+        } catch (Exception e) {
+            throw new MsCoreException(CREATE_INSTITUTION_ERROR.getMessage(), CREATE_INSTITUTION_ERROR.getCode());
+        }
+    }
+
+    private void getInstitutionRaw(CreateInstitutionStrategyInput strategyInput) {
+        institution.setExternalId(getExternalId(strategyInput));
+        institution.setOriginId("SELC_" + institution.getExternalId());
+        institution.setCreatedAt(OffsetDateTime.now());
+    }
+
+    private void getInstitutionFromInfocamere(String taxCode, String description, NationalRegistriesProfessionalAddress professionalAddress) {
+        institution.setAddress(professionalAddress.getAddress());
+        institution.setZipCode(professionalAddress.getZipCode());
+        institution.setTaxCode(taxCode);
+        institution.setDescription(description);
+        institution.setExternalId(taxCode);
+        institution.setOrigin(Origin.INFOCAMERE.getValue());
+        institution.setOriginId(taxCode);
+        institution.setCreatedAt(OffsetDateTime.now());
+    }
+
+    public void setInstitution(Institution institution) {
+        this.institution = institution;
+    }
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/CreateInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/CreateInstitutionStrategyFactory.java
@@ -50,4 +50,11 @@ public class CreateInstitutionStrategyFactory {
         strategy.setInjectionInstitutionType(injectionInstitutionType);
         return strategy;
     }
+
+    public CreateInstitutionStrategy createInstitutionStrategyInfocamere(Institution institution) {
+        CreateInstitutionStrategyInfocamere strategy =  new CreateInstitutionStrategyInfocamere(partyRegistryProxyConnector, institutionConnector);
+        strategy.setInstitution(institution);
+        return strategy;
+    }
+
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -333,6 +333,14 @@ class InstitutionServiceImplTest {
 
 
 
+    @Test
+    void testCreateInstitutionFromInfocamere() {
+        when(createInstitutionStrategyFactory.createInstitutionStrategyInfocamere(any())).thenReturn(createInstitutionStrategy);
+        when(createInstitutionStrategy.createInstitution(any())).thenReturn(new Institution());
+        Institution institution = institutionServiceImpl.createInstitutionFromInfocamere(new Institution());
+        assertNotNull(institution);
+    }
+
     /**
      * Method under test: {@link InstitutionServiceImpl#getInstitutionsByProductId(String, Integer, Integer)}
      */

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
@@ -30,6 +30,10 @@ public class TestUtils {
         return dummyInstitution(InstitutionType.PT);
     }
 
+    public static Institution dummyInstitutionPg() {
+        return dummyInstitution(InstitutionType.PG);
+    }
+
     private static Institution dummyInstitution(InstitutionType institutionType) {
 
         Billing billing = new Billing();

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -183,6 +183,26 @@ public class InstitutionController {
     }
 
     /**
+     * The function create an institution retriving values from INFOCAMERE
+     *
+     * @param institutionRequest InstitutionRequest
+     * @return InstitutionResponse
+     * * Code: 201, Message: successful operation, DataType: InstitutionResponse
+     * * Code: 404, Message: Institution data not found on Ipa, DataType: Problem
+     * * Code: 400, Message: Bad Request, DataType: Problem
+     * * Code: 409, Message: Institution conflict, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.CREATED)
+    @ApiOperation(value = "${swagger.mscore.institution.create.from-infocamere}", notes = "${swagger.mscore.institution.create.from-infocamere}")
+    @PostMapping(value = "/from-infocamere/")
+    public ResponseEntity<InstitutionResponse> createInstitutionFromInfocamere(@RequestBody @Valid InstitutionRequest institutionRequest) {
+        CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
+
+        Institution saved = institutionService.createInstitutionFromInfocamere(InstitutionMapperCustom.toInstitution(institutionRequest, null));
+        return ResponseEntity.status(HttpStatus.CREATED).body(institutionResourceMapper.toInstitutionResponse(saved));
+    }
+
+    /**
      * The function persist PA institution
      *
      * @param externalId String

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -9,6 +9,7 @@ swagger.mscore.external.institution.relationships=returns the relationships rela
 swagger.mscore.institutions=Gets institutions filtering by taxCode and/or subunitCode
 swagger.mscore.institution.create.from-ipa=create an institution from ipa registry
 swagger.mscore.institution.create.from-ivass=create an institution from ivass CSV
+swagger.mscore.institution.create.from-infocamere=create an institution from infocamere registry
 swagger.mscore.institutions.findFromProduct=Gets institutions filtering onboardings by product id
 swagger.mscore.institution=Gets the corresponding institution using internal institution id
 swagger.mscore.institution.PA.create=create an institution (PA) using external institution id fetching data from party-registry

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -417,6 +417,35 @@ class InstitutionControllerTest {
     }
 
     /**
+     * Method under test: {@link InstitutionController#createInstitutionFromInfocamere(InstitutionRequest)}}
+     */
+    @Test
+    void shouldCreateInstitutionFromInfocamere() throws Exception {
+        // Given
+        InstitutionRequest institutionRequest = new InstitutionRequest();
+        institutionRequest.setAddress("42 Main St");
+        institutionRequest.setInstitutionType(InstitutionType.PG);
+        institutionRequest.setTaxCode("42");
+        institutionRequest.setExternalId("42");
+        String content = objectMapper.writeValueAsString(institutionRequest);
+
+        Institution institution = TestUtils.createSimpleInstitutionPA();
+
+        when(institutionService.createInstitutionFromInfocamere(any())).thenReturn(institution);
+
+        //Then
+        MockHttpServletRequestBuilder requestBuilder = post("/institutions/from-infocamere/")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(content);
+        ResultActions actualPerformResult = MockMvcBuilders.standaloneSetup(institutionController)
+                .build()
+                .perform(requestBuilder);
+        actualPerformResult.andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andExpect(MockMvcResultMatchers.content().string("{\"id\":\"42\",\"externalId\":\"42\",\"origin\":\"MOCK\",\"originId\":\"Ipa Code\",\"description\":\"The characteristics of someone or something\",\"institutionType\":\"PA\",\"digitalAddress\":\"42 Main St\",\"address\":\"42 Main St\",\"zipCode\":\"21654\",\"taxCode\":\"Tax Code\",\"geographicTaxonomies\":[],\"attributes\":[],\"onboarding\":[],\"paymentServiceProvider\":{\"abiCode\":\"Abi Code\",\"businessRegisterNumber\":\"42\",\"legalRegisterNumber\":\"42\",\"legalRegisterName\":\"Legal Register Name\",\"vatNumberGroup\":true},\"dataProtectionOfficer\":{\"address\":\"42 Main St\",\"email\":\"jane.doe@example.org\",\"pec\":\"Pec\"},\"rea\":\"Rea\",\"shareCapital\":\"Share Capital\",\"imported\":false}"));
+    }
+
+    /**
      * Method under test: {@link InstitutionController#createInstitutionFromIpa(InstitutionFromIpaPost)}}
      */
     @Test


### PR DESCRIPTION
#### List of Changes
 Added API institution/from-infocamere/ and relative institution strategy to create institution with origin infocamere

#### Motivation and Context

We needed this new API to handle correctly the flow of institution creation from infocamere. This API sets the origin INFOCAMERE if can find a legal address on the registry, otherwise it allows to set origin to the caller.

#### How Has This Been Tested?

local environment

#### Screenshots (if appropriate):


#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.