### PR TITLE
[SELC-3291] Fix: getInstitutions API performs two different queries based on the parameters

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
@@ -18,8 +18,6 @@ public interface InstitutionConnector {
 
     void deleteById(String id);
 
-    List<Institution> findByTaxCodeSubunitCodeAndOrigin(String taxtCode, String subunitCode, String origin, String originId);
-
     Boolean existsByTaxCodeAndSubunitCodeAndProductAndStatusList(String taxtCode, Optional<String> subunitCode, Optional<String> productId, List<RelationshipState> validRelationshipStates);
 
     Optional<Institution> findByExternalId(String externalId);
@@ -59,4 +57,6 @@ public interface InstitutionConnector {
     List<Institution> findBrokers(String productId, InstitutionType type);
 
     List<Institution> findByTaxCodeSubunitCode(String taxCode, String subunitCode);
+
+    List<Institution> findByOriginOriginId(String origin, String originId);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
@@ -56,7 +56,7 @@ public interface InstitutionConnector {
 
     List<Institution> findBrokers(String productId, InstitutionType type);
 
-    List<Institution> findByTaxCodeSubunitCode(String taxCode, String subunitCode);
+    List<Institution> findByTaxCodeAndSubunitCode(String taxCode, String subunitCode);
 
-    List<Institution> findByOriginOriginId(String origin, String originId);
+    List<Institution> findByOriginAndOriginId(String origin, String originId);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
@@ -54,6 +54,7 @@ public enum GenericError {
     GET_INSTITUTION_ATTRIBUTES_ERROR("0022", "Error while getting party attributes"),
     GET_INSTITUTION_BY_GEOTAXONOMY_ERROR("0053", "Error while searching institutions related to given geoTaxonomies"),
     GET_INSTITUTION_BY_PRODUCTID_ERROR("0053", "Error while searching institutions related to given productId"),
+    GET_INSTITUTIONS_REQUEST_ERROR("0054", "Invalid request parameters sent. Allowed filters combinations taxCode and subunit or origin and originId"),
     VERIFY_USER_ERROR("0000", "Error while searching institutions related to given productId"),
     GET_USER_ERROR("0000", "Error while searching user given UserID"),
     GENERIC_ERROR("0000", "Generic Error");

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -315,7 +315,7 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     }
 
     @Override
-    public List<Institution> findByTaxCodeSubunitCode(String taxCode, String subunitCode) {
+    public List<Institution> findByTaxCodeAndSubunitCode(String taxCode, String subunitCode) {
         return repository.find(Query.query(Criteria.where(InstitutionEntity.Fields.taxCode.name()).is(taxCode)
                                 .and(InstitutionEntity.Fields.subunitCode.name()).is(subunitCode)
                         ),
@@ -325,7 +325,7 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     }
 
     @Override
-    public List<Institution> findByOriginOriginId(String origin, String originId) {
+    public List<Institution> findByOriginAndOriginId(String origin, String originId) {
         return repository.find(Query.query(CriteriaBuilder.builder()
                                 .isIfNotNull(InstitutionEntity.Fields.origin.name(), origin)
                                 .isIfNotNull(InstitutionEntity.Fields.originId.name(), originId)

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -249,20 +249,6 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     }
 
     @Override
-    public List<Institution> findByTaxCodeSubunitCodeAndOrigin(String taxCode, String subunitCode, String origin, String originId) {
-        return repository.find(Query.query(CriteriaBuilder.builder()
-                                .isIfNotNull(InstitutionEntity.Fields.taxCode.name(), taxCode)
-                                .isIfNotNull(InstitutionEntity.Fields.subunitCode.name(), subunitCode)
-                                .isIfNotNull(InstitutionEntity.Fields.origin.name(), origin)
-                                .isIfNotNull(InstitutionEntity.Fields.originId.name(), originId)
-                                .build()
-                        ),
-                        InstitutionEntity.class).stream()
-                .map(institutionMapper::convertToInstitution)
-                .collect(Collectors.toList());
-    }
-
-    @Override
     public Boolean existsByTaxCodeAndSubunitCodeAndProductAndStatusList(String taxtCode, Optional<String> optSubunitCode,
                                                                         Optional<String> optProductId, List<RelationshipState> validRelationshipStates) {
 
@@ -330,7 +316,24 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
 
     @Override
     public List<Institution> findByTaxCodeSubunitCode(String taxCode, String subunitCode) {
-        return findByTaxCodeSubunitCodeAndOrigin(taxCode, subunitCode, null, null);
+        return repository.find(Query.query(Criteria.where(InstitutionEntity.Fields.taxCode.name()).is(taxCode)
+                                .and(InstitutionEntity.Fields.subunitCode.name()).is(subunitCode)
+                        ),
+                        InstitutionEntity.class).stream()
+                .map(institutionMapper::convertToInstitution)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Institution> findByOriginOriginId(String origin, String originId) {
+        return repository.find(Query.query(CriteriaBuilder.builder()
+                                .isIfNotNull(InstitutionEntity.Fields.origin.name(), origin)
+                                .isIfNotNull(InstitutionEntity.Fields.originId.name(), originId)
+                                .build()
+                        ),
+                        InstitutionEntity.class).stream()
+                .map(institutionMapper::convertToInstitution)
+                .collect(Collectors.toList());
     }
 
     private Query constructQueryWithSearchMode(List<String> geo, SearchMode searchMode) {

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -825,14 +825,14 @@ class InstitutionConnectorImplTest {
     }
 
     @Test
-    void findByTaxCodeAndSubunitCode() {
+    void findByOriginOriginId() {
         InstitutionEntity institutionEntity = new InstitutionEntity();
 
         when(institutionRepository.find(any(), any()))
                 .thenReturn(List.of(institutionEntity));
 
         List<Institution> onboardings = institutionConnectorImpl
-                .findByTaxCodeSubunitCode("example", "example");
+                .findByOriginOriginId("example", "example");
 
         assertFalse(onboardings.isEmpty());
     }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -661,7 +661,7 @@ class InstitutionConnectorImplTest {
                 .thenReturn(List.of(institutionEntity));
 
         List<Institution> onboardings = institutionConnectorImpl
-                .findByTaxCodeSubunitCodeAndOrigin("example", "example", "example", "example");
+                .findByTaxCodeSubunitCode("example", "example");
 
         assertFalse(onboardings.isEmpty());
     }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -661,7 +661,7 @@ class InstitutionConnectorImplTest {
                 .thenReturn(List.of(institutionEntity));
 
         List<Institution> onboardings = institutionConnectorImpl
-                .findByTaxCodeSubunitCode("example", "example");
+                .findByTaxCodeAndSubunitCode("example", "example");
 
         assertFalse(onboardings.isEmpty());
     }
@@ -832,7 +832,7 @@ class InstitutionConnectorImplTest {
                 .thenReturn(List.of(institutionEntity));
 
         List<Institution> onboardings = institutionConnectorImpl
-                .findByOriginOriginId("example", "example");
+                .findByOriginAndOriginId("example", "example");
 
         assertFalse(onboardings.isEmpty());
     }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -6,10 +6,7 @@ import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.*;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
-import it.pagopa.selfcare.mscore.constant.CustomError;
-import it.pagopa.selfcare.mscore.constant.Origin;
-import it.pagopa.selfcare.mscore.constant.RelationshipState;
-import it.pagopa.selfcare.mscore.constant.SearchMode;
+import it.pagopa.selfcare.mscore.constant.*;
 import it.pagopa.selfcare.mscore.core.mapper.InstitutionMapper;
 import it.pagopa.selfcare.mscore.core.strategy.CreateInstitutionStrategy;
 import it.pagopa.selfcare.mscore.core.strategy.factory.CreateInstitutionStrategyFactory;
@@ -112,7 +109,16 @@ public class InstitutionServiceImpl implements InstitutionService {
 
     @Override
     public List<Institution> getInstitutions(String taxCode, String subunitCode, String origin, String originId) {
-        return institutionConnector.findByTaxCodeSubunitCodeAndOrigin(taxCode, subunitCode, origin, originId);
+        if(StringUtils.hasText(taxCode) && (StringUtils.hasText(origin) || StringUtils.hasText(originId))) {
+            throw new InvalidRequestException(GenericError.GET_INSTITUTIONS_REQUEST_ERROR.getMessage(), GenericError.GET_INSTITUTIONS_REQUEST_ERROR.getCode());
+        }
+
+        if(StringUtils.hasText(taxCode)) {
+            return institutionConnector.findByTaxCodeSubunitCode(taxCode, subunitCode);
+        } else {
+            return institutionConnector.findByOriginOriginId(origin, originId);
+        }
+
     }
 
     @Override

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -114,16 +114,16 @@ public class InstitutionServiceImpl implements InstitutionService {
         }
 
         if(StringUtils.hasText(taxCode)) {
-            return institutionConnector.findByTaxCodeSubunitCode(taxCode, subunitCode);
+            return institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
         } else {
-            return institutionConnector.findByOriginOriginId(origin, originId);
+            return institutionConnector.findByOriginAndOriginId(origin, originId);
         }
 
     }
 
     @Override
     public List<Institution> getInstitutions(String taxCode, String subunitCode) {
-        return institutionConnector.findByTaxCodeSubunitCode(taxCode, subunitCode);
+        return institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
     }
 
     @Override

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyCommon.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyCommon.java
@@ -20,7 +20,7 @@ public class CreateInstitutionStrategyCommon {
 
     protected void checkIfAlreadyExistsByTaxCodeAndSubunitCode(String taxCode, String subunitCode) {
 
-        List<Institution> institutions = institutionConnector.findByTaxCodeSubunitCode(taxCode, subunitCode);
+        List<Institution> institutions = institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
         if (!institutions.isEmpty())
             throw new ResourceConflictException(String
                     .format(CustomError.CREATE_INSTITUTION_IPA_CONFLICT.getMessage(), taxCode, subunitCode),

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPda.java
@@ -8,32 +8,37 @@ import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.core.mapper.InstitutionMapper;
 import it.pagopa.selfcare.mscore.core.strategy.input.CreateInstitutionStrategyInput;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
+import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
 import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.institution.*;
 import it.pagopa.selfcare.mscore.utils.MaskDataUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.mscore.constant.GenericError.CREATE_INSTITUTION_ERROR;
 
 @Slf4j
 @Component
-public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommon implements CreateInstitutionStrategy {
+public class CreateInstitutionStrategyPda implements CreateInstitutionStrategy {
 
     private final PartyRegistryProxyConnector partyRegistryProxyConnector;
 
     private final InstitutionMapper institutionMapper;
+
+    private final InstitutionConnector institutionConnector;
 
     private String injectionInstitutionType;
 
     public CreateInstitutionStrategyPda(PartyRegistryProxyConnector partyRegistryProxyConnector,
                                         InstitutionConnector institutionConnector,
                                         InstitutionMapper institutionMapper) {
-        super(institutionConnector);
+        this.institutionConnector = institutionConnector;
         this.partyRegistryProxyConnector = partyRegistryProxyConnector;
         this.institutionMapper = institutionMapper;
     }
@@ -128,6 +133,23 @@ public class CreateInstitutionStrategyPda extends CreateInstitutionStrategyCommo
         newInstitution.setAttributes(List.of(attributes));
 
         return newInstitution;
+    }
+
+    private void checkIfAlreadyExistsByTaxCodeAndSubunitCode(String taxCode, String subunitCode) {
+        /*
+            When subunitCode is null method findByTaxCodeSubunitCode retrieves also institutions with subunitCode.
+            We need to filter with !StringUtils.hasText(institution.getSubunitCode()) to ignore AO/UOO institutions because we are looking for
+            parent institutions.
+        */
+        List<Institution> institutions = institutionConnector.findByTaxCodeSubunitCode(taxCode, subunitCode)
+                .stream()
+                .filter(institution -> !StringUtils.hasText(institution.getSubunitCode()))
+                .collect(Collectors.toList());
+
+        if (!institutions.isEmpty())
+            throw new ResourceConflictException(String
+                    .format(CustomError.CREATE_INSTITUTION_IPA_CONFLICT.getMessage(), taxCode, subunitCode),
+                    CustomError.CREATE_INSTITUTION_CONFLICT.getCode());
     }
 
     public void setInjectionInstitutionType(String injectionInstitutionType) {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -292,19 +292,19 @@ class InstitutionServiceImplTest {
     @Test
     void testGetInstitutionsWithTaxCodeSubunitCode() {
         List<Institution> institutionList = new ArrayList<>();
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any())).thenReturn(institutionList);
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any())).thenReturn(institutionList);
         List<Institution> institutions = institutionServiceImpl.getInstitutions("id", "id", null, null);
         assertTrue(institutions.isEmpty());
-        Mockito.verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        Mockito.verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
     }
 
     @Test
     void testGetInstitutionsWithOriginOriginId() {
         List<Institution> institutionList = new ArrayList<>();
-        when(institutionConnector.findByOriginOriginId(any(), any())).thenReturn(institutionList);
+        when(institutionConnector.findByOriginAndOriginId(any(), any())).thenReturn(institutionList);
         List<Institution> institutions = institutionServiceImpl.getInstitutions(null, null, "id", "id");
         assertTrue(institutions.isEmpty());
-        Mockito.verify(institutionConnector).findByOriginOriginId(any(), any());
+        Mockito.verify(institutionConnector).findByOriginAndOriginId(any(), any());
     }
 
     @Test
@@ -1547,13 +1547,13 @@ class InstitutionServiceImplTest {
 
         Institution institution = new Institution();
         institution.setId("id");
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any())).thenReturn(List.of(institution));
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any())).thenReturn(List.of(institution));
         List<Institution> institutions = institutionServiceImpl.getInstitutions("1111111", null);
         assertNotNull(institutions);
         assertFalse(institutions.isEmpty());
         assertNotNull(institutions.get(0));
         assertEquals(institutions.get(0).getId(), institution.getId());
-        verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
 
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -289,11 +290,26 @@ class InstitutionServiceImplTest {
     }
 
     @Test
-    void testGetInstitutions() {
+    void testGetInstitutionsWithTaxCodeSubunitCode() {
         List<Institution> institutionList = new ArrayList<>();
-        when(institutionConnector.findByTaxCodeSubunitCodeAndOrigin(any(), any(), any(), any())).thenReturn(institutionList);
-        List<Institution> institutions = institutionServiceImpl.getInstitutions("id", "id", "id", "id");
+        when(institutionConnector.findByTaxCodeSubunitCode(any(), any())).thenReturn(institutionList);
+        List<Institution> institutions = institutionServiceImpl.getInstitutions("id", "id", null, null);
         assertTrue(institutions.isEmpty());
+        Mockito.verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+    }
+
+    @Test
+    void testGetInstitutionsWithOriginOriginId() {
+        List<Institution> institutionList = new ArrayList<>();
+        when(institutionConnector.findByOriginOriginId(any(), any())).thenReturn(institutionList);
+        List<Institution> institutions = institutionServiceImpl.getInstitutions("id", "id", null, null);
+        assertTrue(institutions.isEmpty());
+        Mockito.verify(institutionConnector).findByOriginOriginId(any(), any());
+    }
+
+    @Test
+    void testGetInstitutionsFails() {
+        assertThrows(InvalidRequestException.class, () -> institutionServiceImpl.getInstitutions("id", "id", "id", "id"));
     }
 
     /**

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -302,7 +302,7 @@ class InstitutionServiceImplTest {
     void testGetInstitutionsWithOriginOriginId() {
         List<Institution> institutionList = new ArrayList<>();
         when(institutionConnector.findByOriginOriginId(any(), any())).thenReturn(institutionList);
-        List<Institution> institutions = institutionServiceImpl.getInstitutions("id", "id", null, null);
+        List<Institution> institutions = institutionServiceImpl.getInstitutions(null, null, "id", "id");
         assertTrue(institutions.isEmpty());
         Mockito.verify(institutionConnector).findByOriginOriginId(any(), any());
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPdaTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyPdaTest.java
@@ -86,7 +86,7 @@ public class CreateInstitutionStrategyPdaTest {
         institutionToReturn.setDescription("test");
 
         //Given
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of(new Institution()));
 
 
@@ -96,7 +96,7 @@ public class CreateInstitutionStrategyPdaTest {
                         .taxCode("test")
                         .build()));
 
-        verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
     }
 
     /**
@@ -110,7 +110,7 @@ public class CreateInstitutionStrategyPdaTest {
         institutionToReturn.setDescription("test");
 
         //Given
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
@@ -126,7 +126,7 @@ public class CreateInstitutionStrategyPdaTest {
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
 
-        verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
         verify(partyRegistryProxyConnector).getCategory(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
     }
@@ -146,7 +146,7 @@ public class CreateInstitutionStrategyPdaTest {
         nationalRegistriesProfessionalAddress.setAddress("test");
 
         //Given
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getInstitutionById(any())).thenThrow(new MsCoreException("NOT_FOUND", "404"));
@@ -162,7 +162,7 @@ public class CreateInstitutionStrategyPdaTest {
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
 
-        verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
         verify(partyRegistryProxyConnector).getLegalAddress(any());
     }
@@ -182,7 +182,7 @@ public class CreateInstitutionStrategyPdaTest {
         nationalRegistriesProfessionalAddress.setAddress("test");
 
         //Given
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getInstitutionById(any())).thenThrow(new ResourceNotFoundException("NOT_FOUND", "404"));
@@ -198,7 +198,7 @@ public class CreateInstitutionStrategyPdaTest {
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
 
-        verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
         verify(partyRegistryProxyConnector).getLegalAddress(any());
     }
@@ -218,7 +218,7 @@ public class CreateInstitutionStrategyPdaTest {
         nationalRegistriesProfessionalAddress.setAddress("test");
 
         //Given
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getInstitutionById(any())).thenThrow(new MsCoreException("NOT_FOUND", "404"));
@@ -229,7 +229,7 @@ public class CreateInstitutionStrategyPdaTest {
                 .createInstitution(CreateInstitutionStrategyInput.builder()
                         .taxCode("test")
                         .build()));
-        verify(institutionConnector).findByTaxCodeSubunitCode(any(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
         verify(partyRegistryProxyConnector).getLegalAddress(any());
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -97,7 +97,7 @@ class CreateInstitutionStrategyTest {
     @Test
     void shouldThrowExceptionOnCreateInstitutionFromIpaIfAlreadyExists() {
 
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of(new Institution()));
         assertThrows(ResourceConflictException.class, () -> strategyFactory.createInstitutionStrategyIpa()
                 .createInstitution(CreateInstitutionStrategyInput.builder().subunitType(InstitutionPaSubunitType.AOO)
@@ -108,7 +108,7 @@ class CreateInstitutionStrategyTest {
     @Test
     void shouldThrowExceptionOnCreateInstitutionIfAlreadyExists() {
 
-        when(institutionConnector.findByTaxCodeSubunitCode(any(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(any(), any()))
                 .thenReturn(List.of(new Institution()));
         assertThrows(ResourceConflictException.class, () -> strategyFactory.createInstitutionStrategy(new Institution())
                 .createInstitution(CreateInstitutionStrategyInput.builder()
@@ -190,7 +190,7 @@ class CreateInstitutionStrategyTest {
     void shouldCreateInstitution() {
         //Given
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
-        when(institutionConnector.findByTaxCodeSubunitCode(anyString(), any()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(anyString(), any()))
                 .thenReturn(List.of());
 
         Institution institution = TestUtils.dummyInstitutionGsp();
@@ -213,7 +213,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getSubunitType()).isNull();
 
         verify(institutionConnector).save(any());
-        verify(institutionConnector).findByTaxCodeSubunitCode(anyString(), any());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), any());
     }
 
     /**
@@ -223,7 +223,7 @@ class CreateInstitutionStrategyTest {
     void shouldCreateInstitutionFromIpaAoo() {
         //Given
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
-        when(institutionConnector.findByTaxCodeSubunitCode(anyString(), anyString()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(anyString(), anyString()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
@@ -250,7 +250,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getParentDescription()).isEqualTo(dummyInstitutionProxyInfo.getDescription());
 
         verify(institutionConnector, times(2)).save(any());
-        verify(institutionConnector).findByTaxCodeSubunitCode(anyString(), anyString());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), anyString());
         verify(partyRegistryProxyConnector).getCategory(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
     }
@@ -264,7 +264,7 @@ class CreateInstitutionStrategyTest {
         UnitaOrganizzativa dummyUnitaOrganizzativa = dummyUnitaOrganizzativa();
 
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
-        when(institutionConnector.findByTaxCodeSubunitCode(anyString(), anyString()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(anyString(), anyString()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
@@ -292,7 +292,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getPaAttributes().getAooParentCode()).isEqualTo(dummyUnitaOrganizzativa.getCodiceUniAoo());
 
         verify(institutionConnector, times(2)).save(any());
-        verify(institutionConnector).findByTaxCodeSubunitCode(anyString(), anyString());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), anyString());
         verify(partyRegistryProxyConnector).getCategory(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
     }
@@ -306,7 +306,7 @@ class CreateInstitutionStrategyTest {
         UnitaOrganizzativa dummyUnitaOrganizzativa = dummyUnitaOrganizzativa();
 
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
-        when(institutionConnector.findByTaxCodeSubunitCode(anyString(), anyString()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(anyString(), anyString()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
@@ -335,7 +335,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getPaAttributes().getAooParentCode()).isEqualTo(dummyUnitaOrganizzativa.getCodiceUniAoo());
 
         verify(institutionConnector, times(1)).save(any());
-        verify(institutionConnector).findByTaxCodeSubunitCode(anyString(), anyString());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), anyString());
         verify(partyRegistryProxyConnector).getCategory(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
     }
@@ -351,7 +351,7 @@ class CreateInstitutionStrategyTest {
         institutionToReturn.setDescription("test");
 
         //Given
-        when(institutionConnector.findByTaxCodeSubunitCode(anyString(), anyString()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(anyString(), anyString()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
@@ -368,7 +368,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getId()).isEqualTo(institutionToReturn.getId());
         assertThat(actual.getDescription()).isEqualTo(institutionToReturn.getDescription());
 
-        verify(institutionConnector).findByTaxCodeSubunitCode(anyString(), anyString());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), anyString());
         verify(partyRegistryProxyConnector).getCategory(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
     }
@@ -386,7 +386,7 @@ class CreateInstitutionStrategyTest {
         dummyUnitaOrganizzativa.setMail1("example@pec.it");
 
         when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
-        when(institutionConnector.findByTaxCodeSubunitCode(anyString(), anyString()))
+        when(institutionConnector.findByTaxCodeAndSubunitCode(anyString(), anyString()))
                 .thenReturn(List.of());
 
         when(partyRegistryProxyConnector.getCategory(any(), any())).thenReturn(dummyCategoryProxyInfo);
@@ -413,7 +413,7 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getPaAttributes()).isNull();
 
         verify(institutionConnector, times(2)).save(any());
-        verify(institutionConnector).findByTaxCodeSubunitCode(anyString(), anyString());
+        verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), anyString());
         verify(partyRegistryProxyConnector).getCategory(any(), any());
         verify(partyRegistryProxyConnector).getInstitutionById(any());
     }


### PR DESCRIPTION
#### List of Changes

In getInstitutions API added check to perform different queries based on presence of taxCode or origin informations

#### Motivation and Context

The previous logic, in an attempt to include more filter possibilities, did not use null-valued fields in the query. Now the queries also contemplate null values and are divided and orchestrated according to the query parameters

#### How Has This Been Tested?
local environment

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.