### PR TITLE
fix: verifyOnboarding adding criteria subunit is null

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -1579,6 +1579,68 @@
         } ]
       }
     },
+    "/institutions/from-infocamere/" : {
+      "post" : {
+        "tags" : [ "Institution" ],
+        "summary" : "create an institution from infocamere registry",
+        "description" : "create an institution from infocamere registry",
+        "operationId" : "createInstitutionFromInfocamereUsingPOST",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/InstitutionRequest"
+              }
+            }
+          }
+        },
+        "responses" : {
+          "201" : {
+            "description" : "Created",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InstitutionResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/institutions/from-ipa/" : {
       "post" : {
         "tags" : [ "Institution" ],

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/InstitutionConnector.java
@@ -20,7 +20,7 @@ public interface InstitutionConnector {
 
     List<Institution> findByTaxCodeSubunitCodeAndOrigin(String taxtCode, String subunitCode, String origin, String originId);
 
-    Boolean existsByTaxCodeAndSubunitCodeAndProductAndStatusList(String taxtCode, Optional<String> subunitCode, Optional<String> productId, List<RelationshipState> validRelationshipStates);
+    Boolean existsByTaxCodeAndSubunitCodeAndProductAndStatusList(String taxtCode, String subunitCode, Optional<String> productId, List<RelationshipState> validRelationshipStates);
 
     Optional<Institution> findByExternalId(String externalId);
 

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -263,11 +263,11 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
     }
 
     @Override
-    public Boolean existsByTaxCodeAndSubunitCodeAndProductAndStatusList(String taxtCode, Optional<String> optSubunitCode,
+    public Boolean existsByTaxCodeAndSubunitCodeAndProductAndStatusList(String taxCode, String subunitCode,
                                                                         Optional<String> optProductId, List<RelationshipState> validRelationshipStates) {
 
-        Criteria criteriaInstitution = Criteria.where(InstitutionEntity.Fields.taxCode.name()).is(taxtCode);
-        optSubunitCode.ifPresent(code -> criteriaInstitution.and(InstitutionEntity.Fields.subunitCode.name()).is(code));
+        Criteria criteriaInstitution = Criteria.where(InstitutionEntity.Fields.taxCode.name()).is(taxCode)
+                .and(InstitutionEntity.Fields.subunitCode.name()).is(subunitCode);
 
         Criteria criteriaOnboarding = Criteria.where(Onboarding.Fields.status.name()).in(validRelationshipStates);
         optProductId.ifPresent(productId -> criteriaOnboarding.and(Onboarding.Fields.productId.name()).is(productId));

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -672,7 +672,7 @@ class InstitutionConnectorImplTest {
         when(institutionRepository.exists(any(), any())).thenReturn(Boolean.TRUE);
 
         Boolean exists = institutionConnectorImpl.existsByTaxCodeAndSubunitCodeAndProductAndStatusList("example",
-                Optional.of("example"), Optional.of("example"), List.of());
+                "example", Optional.of("example"), List.of());
 
         assertTrue(exists);
     }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -97,7 +97,7 @@ public class OnboardingServiceImpl implements OnboardingService {
     @Override
     public void verifyOnboardingInfoSubunit(String taxCode, String subunitCode, String productId) {
         Boolean existsOnboardingValid = institutionConnector.existsByTaxCodeAndSubunitCodeAndProductAndStatusList(taxCode,
-                Optional.ofNullable(subunitCode), Optional.ofNullable(productId), UtilEnumList.VALID_RELATIONSHIP_STATES);
+                subunitCode, Optional.ofNullable(productId), UtilEnumList.VALID_RELATIONSHIP_STATES);
         if (Boolean.FALSE.equals(existsOnboardingValid)) {
             throw new ResourceNotFoundException(String.format(CustomError.INSTITUTION_NOT_ONBOARDED.getMessage(), taxCode, productId),
                     CustomError.INSTITUTION_NOT_ONBOARDED.getCode());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Set criteria subunit to null on verifyOnboarding method.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

verifyOnboarding REST API checks if any onboarding on that institution has already submitted. If it happens for a parent institution, query criteria set only taxcode ignoring subunit. This behaviour is wrong because in case of parent and child, where taxcode is the same, query retrieving both. Instead, query must consider that in case of parent the subunit is null. 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.