### PR TITLE
[SELC-3358] Fix: set description when creating institution from infocamere in /from-pda/ API

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -141,6 +141,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyPda(injectionInstitutionType);
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(institution.getTaxCode())
+                .description(institution.getDescription())
                 .build());
     }
 


### PR DESCRIPTION


#### List of Changes

Added missing set description statement, which will allow to onboard institution properly from infocamere when using onboarding pda API

#### Motivation and Context

Without this set statement the institution is persisted without description field.

#### How Has This Been Tested?
local environment

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.