### PR TITLE
[BugFix\SELC-3385] bugfix: add send user event notification to autoOnboarding approval strategy

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -44,7 +44,7 @@ public class OnboardingInstitutionStrategyFactory {
     private final InstitutionService institutionService;
     private final CoreConfig coreConfig;
     private final FileStorageConnector fileStorageConnector;
-
+    private final UserEventService userEventService;
     private final NotificationService notificationService;
 
     public OnboardingInstitutionStrategyFactory(OnboardingDao onboardingDao,
@@ -52,7 +52,7 @@ public class OnboardingInstitutionStrategyFactory {
                                                 UserService userService,
                                                 InstitutionService institutionService,
                                                 CoreConfig coreConfig,
-                                                NotificationService notificationService, FileStorageConnector fileStorageConnector) {
+                                                NotificationService notificationService, FileStorageConnector fileStorageConnector, UserEventService userEventService) {
         this.onboardingDao = onboardingDao;
         this.contractService = contractService;
         this.userService = userService;
@@ -60,6 +60,7 @@ public class OnboardingInstitutionStrategyFactory {
         this.coreConfig = coreConfig;
         this.notificationService = notificationService;
         this.fileStorageConnector = fileStorageConnector;
+        this.userEventService = userEventService;
     }
 
     public OnboardingInstitutionStrategy retrieveOnboardingInstitutionStrategy(InstitutionType institutionType, String productId, Institution institution) {
@@ -253,7 +254,7 @@ public class OnboardingInstitutionStrategyFactory {
 
                 //[TODO https://pagopa.atlassian.net/wiki/spaces/SCP/pages/710901785/RFC+Proposta+per+gestione+asincrona+degli+eventi]
                 contractService.sendDataLakeNotification(strategyInput.getOnboardingRollback().getUpdatedInstitution(), strategyInput.getOnboardingRollback().getToken(), QueueEvent.ADD);
-
+                userEventService.sendLegalTokenUserNotification(strategyInput.getOnboardingRollback().getToken());
             } catch (Exception e) {
                 onboardingDao.rollbackSecondStep(strategyInput.getToUpdate(), strategyInput.getToDelete(), strategyInput.getInstitution().getId(),
                         strategyInput.getOnboardingRollback().getToken(), strategyInput.getOnboardingRollback().getOnboarding(), strategyInput.getOnboardingRollback().getProductMap());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -46,6 +46,8 @@ class OnboardingInstitutionStrategyTest {
     @Mock
     private ContractService contractService;
     @Mock
+    private UserEventService userEventService;
+    @Mock
     private UserService userService;
     @Mock
     private NotificationService notificationService;
@@ -60,7 +62,7 @@ class OnboardingInstitutionStrategyTest {
     @BeforeEach
     void beforeAll() {
         strategyFactory = new OnboardingInstitutionStrategyFactory(onboardingDao,
-                contractService,userService, institutionService, coreConfig, notificationService, fileStorageConnector);
+                contractService,userService, institutionService, coreConfig, notificationService, fileStorageConnector, userEventService);
     }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added userEventNotification service in onboarding autoApproval

#### Motivation and Context

So far the autoApproval only sent the onboarded institution notification to the dataLake, and no notification were sent for the users into the dedicated queue.

#### How Has This Been Tested?

deployed from branch and tested by doing a manual onboarding

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.