### PR TITLE
[SELC-3214] feat: added user status into node productInfo for onboarding user

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -7462,6 +7462,9 @@
           },
           "role" : {
             "type" : "string"
+          },
+          "status" : {
+            "type" : "string"
           }
         }
       },

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingMapper.java
@@ -71,6 +71,7 @@ public class OnboardingMapper {
         productInfo.setRole(product.getProductRole());
         productInfo.setId(product.getProductId());
         productInfo.setCreatedAt(product.getCreatedAt());
+        productInfo.setStatus(product.getStatus().name());
         institutionResponse.setState(product.getStatus().name());
         institutionResponse.setRole(product.getRole());
         institutionResponse.setProductInfo(productInfo);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/ProductInfo.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/ProductInfo.java
@@ -12,4 +12,5 @@ public class ProductInfo {
     private String id;
     private String role;
     private OffsetDateTime createdAt;
+    private String status;
 }


### PR DESCRIPTION
#### List of Changes

Added userStatus into productInfo node for getUserInfo API

#### Motivation and Context

This change was requested from support service in order to have info about status for onboarded product linked to an user

#### How Has This Been Tested?

I have run ms-core and external-api-backend microservices and tested the api getUserInfo