### PR TITLE
[SELC-3256] Fix: added description for infocamere institution strategy

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -186,6 +186,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyInfocamere(institution);
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(institution.getTaxCode())
+                .description(institution.getDescription())
                 .build());
     }
     @Override

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -360,7 +360,7 @@ public class InstitutionServiceImpl implements InstitutionService {
     @Override
     public List<Institution> findInstitutionsByGeoTaxonomies(String geoTaxonomies, SearchMode searchMode) {
         List<String> geo = Arrays.stream(geoTaxonomies.split(","))
-                .filter(StringUtils::hasText).collect(Collectors.toList());
+                .filter(StringUtils::hasText).toList();
         validateGeoTaxonomies(geo, searchMode);
         return institutionConnector.findByGeotaxonomies(geo, searchMode);
     }


### PR DESCRIPTION
#### List of Changes

Added description to CreateInfocamereStrategyInput.

#### Motivation and Context

When we call API onboarding/institution to onboard pnpg institution, field description is required on Institution collection to persist institutionName in bindings objects in User collection.

#### How Has This Been Tested?

local environment

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.