### PR TITLE
[SELC-3450] feat: added user states as parameter in API getInstitutionProducstInfo

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -4989,6 +4989,16 @@
           "schema" : {
             "type" : "string"
           }
+        }, {
+          "name" : "states",
+          "in" : "query",
+          "description" : "List of Relationship state for filter products",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
         } ],
         "responses" : {
           "200" : {

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
@@ -274,7 +274,7 @@ public class UserConnectorImpl implements UserConnector {
     }
 
     @Override
-    public List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter){
+    public List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter) {
         List<UserInstitutionAggregationEntity> userInstitutionAggregationEntities =
                 repository.findUserInstitutionAggregation(filter, UserInstitutionAggregationEntity.class);
         return userInstitutionAggregationEntities.stream()

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
@@ -17,7 +17,7 @@ public interface OnboardingService {
 
     List<OnboardingInfo> getOnboardingInfo(String institutionId, String institutionExternalId, String[] states, String userId);
 
-    List<OnboardingInfo> getOnboardingInfo(String institutionId, String userId);
+    List<OnboardingInfo> getOnboardingInfo(String institutionId, String userId, String[] states);
 
     void onboardingInstitution(OnboardingRequest request, SelfCareUser principal);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -123,8 +123,8 @@ public class OnboardingServiceImpl implements OnboardingService {
     }
 
     @Override
-    public List<OnboardingInfo> getOnboardingInfo(String institutionId, String userId) {
-        return this.getOnboardingInfo(institutionId, null, null, userId);
+    public List<OnboardingInfo> getOnboardingInfo(String institutionId, String userId, String[] states) {
+        return this.getOnboardingInfo(institutionId, null, states, userId);
     }
 
     @Override

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -158,9 +158,11 @@ public class UserController {
     public ResponseEntity<OnboardingInfoResponse> getInstitutionProductsInfo(@ApiParam("${swagger.mscore.relationship.relationshipId}")
                                                                              @PathVariable("userId") String userId,
                                                                              @ApiParam("${swagger.mscore.institutions.model.institutionId}")
-                                                                             @RequestParam(value = "institutionId", required = false) String institutionId) {
+                                                                             @RequestParam(value = "institutionId", required = false) String institutionId,
+                                                                             @ApiParam("${swagger.mscore.institutions.model.relationshipState}")
+                                                                             @RequestParam(value = "states", required = false) String[] states) {
         CustomExceptionMessage.setCustomMessage(GenericError.GETTING_ONBOARDING_INFO_ERROR);
-        List<OnboardingInfo> onboardingInfoList = onboardingService.getOnboardingInfo(institutionId, userId);
+        List<OnboardingInfo> onboardingInfoList = onboardingService.getOnboardingInfo(institutionId, userId, states);
         OnboardingInfoResponse onboardingInfoResponse = OnboardingMapper.toOnboardingInfoResponse(userId, onboardingInfoList);
         log.debug("onboardingInfo result = {}", onboardingInfoResponse);
         return ResponseEntity.ok().body(onboardingInfoResponse);

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/UserControllerTest.java
@@ -284,7 +284,7 @@ class UserControllerTest {
 
 
     /**
-     * Method under test: {@link UserController#getInstitutionProductsInfo(String, String)}
+     * Method under test: {@link UserController#getInstitutionProductsInfo(String, String, String[])}
      */
     @Test
     void testGetInstitutionProductsInfo() throws Exception {
@@ -306,7 +306,7 @@ class UserControllerTest {
         institution.setOnboarding(List.of(onboarding));
         onboardingInfo.setInstitution(institution);
 
-        when(onboardingService.getOnboardingInfo(anyString(), anyString())).thenReturn(List.of(onboardingInfo));
+        when(onboardingService.getOnboardingInfo(anyString(), anyString(), any())).thenReturn(List.of(onboardingInfo));
 
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                 .get("/users/id/institution-products?institutionId=test")


### PR DESCRIPTION
#### List of Changes

Added user statuses as request parameter in API getInstitutionProducstInfo

#### Motivation and Context

This development was necessary to allow external api microservice, through ms-core,  to retrieve information about all onboarding linked to an user, eventually filtering by user status

#### How Has This Been Tested?

I have run ms-core microservice and tested the API **/users/{id}/institution-products**

