### PR TITLE
[SELC-3478] feat: Add API to trigger the scheduler

### DIFF
--- a/app/src/main/resources/config/core-config.properties
+++ b/app/src/main/resources/config/core-config.properties
@@ -60,6 +60,6 @@ mscore.aruba.delegatedUser=${ARUBA_SIGN_SERVICE_IDENTITY_DELEGATED_USER}
 mscore.aruba.delegatedPassword=${ARUBA_SIGN_SERVICE_IDENTITY_DELEGATED_PASSWORD}
 mscore.aruba.delegatedDomain=${ARUBA_SIGN_SERVICE_IDENTITY_DELEGATED_DOMAIN}
 scheduler.threads.max-number=${THREADS_SCHEDULE_MAX_NUMBER:1}
-scheduler.fixed-delay.delay=${SCHEDULER_FIXED_DELAY:600000}
+scheduler.fixed-delay.delay=${SCHEDULER_FIXED_DELAY:20000}
 scheduler.regenerate-kafka-queue-config.name=${SCHEDULER_REGENERATE_KAFKA_QUEUE_CONFIG_NAME:KafkaScheduler}
 scheduler.regenerate-kafka-queue.enabled=${SCHEDULER_REGENERATE_KAFKA_QUEUE_ENABLED:false}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -296,7 +296,7 @@ public class ContractService {
         InstitutionToNotify toNotify = new InstitutionToNotify();
         toNotify.setInstitutionType(institution.getInstitutionType());
         toNotify.setDescription(institution.getDescription());
-        toNotify.setDigitalAddress(institution.getDigitalAddress());
+        toNotify.setDigitalAddress(institution.getDigitalAddress() == null? coreConfig.getInstitutionAlternativeEmail(): institution.getDigitalAddress());
         toNotify.setAddress(institution.getAddress());
         toNotify.setTaxCode(institution.getTaxCode());
         toNotify.setOrigin(institution.getOrigin());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/SchedulerService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/SchedulerService.java
@@ -1,105 +1,10 @@
 package it.pagopa.selfcare.mscore.core;
 
-import it.pagopa.selfcare.mscore.api.ConfigConnector;
-import it.pagopa.selfcare.mscore.api.InstitutionConnector;
-import it.pagopa.selfcare.mscore.api.TokenConnector;
-import it.pagopa.selfcare.mscore.constant.RelationshipState;
-import it.pagopa.selfcare.mscore.core.config.SchedulerConfig;
-import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
-import it.pagopa.selfcare.mscore.model.Config;
-import it.pagopa.selfcare.mscore.model.QueueEvent;
-import it.pagopa.selfcare.mscore.model.institution.Institution;
-import it.pagopa.selfcare.mscore.model.onboarding.Token;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-
-import java.time.OffsetDateTime;
-import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
-@Service
-@Slf4j
-public class SchedulerService {
+public interface SchedulerService {
 
-    public static final int TOKEN_PAGE_SIZE = 100;
-    private final ContractService contractService;
-
-    private final TokenConnector tokenConnector;
-    private final InstitutionConnector institutionConnector;
-    private final ConfigConnector configConnector;
-
-    private final SchedulerConfig schedulerConfig;
-
-    @Autowired
-    public SchedulerService(ContractService contractService,
-                            SchedulerConfig schedulerConfig,
-                            TokenConnector tokenConnector,
-                            InstitutionConnector institutionConnector,
-                            ConfigConnector configConnector) {
-        log.info("Initializing {}...", SchedulerService.class.getSimpleName());
-        this.contractService = contractService;
-        this.schedulerConfig = schedulerConfig;
-        this.tokenConnector = tokenConnector;
-        this.institutionConnector = institutionConnector;
-        this.configConnector = configConnector;
-    }
-
-
-    @Scheduled(fixedDelayString = "${scheduler.fixed-delay.delay}")
-    public void regenerateQueueNotifications() {
-        log.trace("regenerateQueueNotifications start");
-
-        if (schedulerConfig.getRegnerateKafkaQueueEnabled()) {
-
-            Config regenerateQueueConfiguration = configConnector.findAndUpdate(schedulerConfig.getRegenerateKafkaQueueConfigName());
-
-            //To regenerate all the message on the kafka queue, you need to modify the Config entity, set value of the "enableKafkaScheduler" field to true, directly on mongoDB and if needs be you can also modify the value of "productFilter"
-            if (regenerateQueueConfiguration != null) {
-                log.debug("Regenerating notifications on queue with product filter {}", retrieveProductFilter(regenerateQueueConfiguration.getProductFilter()));
-
-                boolean nextPage = true;
-                int page = Math.max(regenerateQueueConfiguration.getFirstPage(), 0);
-                int lastPage = Math.max(regenerateQueueConfiguration.getLastPage(), page);
-                log.debug("[KAFKA] SCHEDULER START PAGE {} LAST PAGE {}", page, lastPage);
-
-                do {
-                    List<Token> tokens = tokenConnector.findByStatusAndProductId(EnumSet.of(RelationshipState.ACTIVE, RelationshipState.DELETED), regenerateQueueConfiguration.getProductFilter(), page, TOKEN_PAGE_SIZE);
-                    log.debug("[KAFKA] TOKEN NUMBER {} PAGE {}", tokens.size(), page);
-
-                    sendDataLakeNotifications(tokens);
-
-                    page += 1;
-                    if (tokens.size() < TOKEN_PAGE_SIZE || page > lastPage) {
-                        nextPage = false;
-                        log.debug("[KAFKA] TOKEN TOTAL NUMBER {}", page * TOKEN_PAGE_SIZE + tokens.size());
-                    }
-
-                } while (nextPage);
-            }
-        }
-
-        log.info("Next scheduled check at {}", OffsetDateTime.now().plusSeconds(schedulerConfig.getFixedDelay() / 1000));
-        log.trace("regenerateQueueNotifications end");
-    }
-
-    private String retrieveProductFilter(String productFilter) {
-        return productFilter == null || productFilter.isBlank() ? "null" : productFilter;
-    }
-
-    private void sendDataLakeNotifications(List<Token> tokens) {
-        tokens.forEach(token -> {
-            try {
-                Institution institution = institutionConnector.findById(token.getInstitutionId());
-                contractService.sendDataLakeNotification(institution, token, QueueEvent.ADD);
-                if (!token.getStatus().equals(RelationshipState.ACTIVE)) {
-                    contractService.sendDataLakeNotification(institution, token, QueueEvent.UPDATE);
-                }
-            } catch (ResourceNotFoundException exception) {
-                log.error("Error while fetching institution for token {}, {}", token.getId(), exception.getMessage());
-            }
-        });
-    }
+    void startScheduler(Optional<Integer> size, List<String> productsFilter);
 
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/SchedulerServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/SchedulerServiceImpl.java
@@ -1,0 +1,106 @@
+package it.pagopa.selfcare.mscore.core;
+
+import it.pagopa.selfcare.mscore.api.ConfigConnector;
+import it.pagopa.selfcare.mscore.api.InstitutionConnector;
+import it.pagopa.selfcare.mscore.api.TokenConnector;
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
+import it.pagopa.selfcare.mscore.core.config.SchedulerConfig;
+import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
+import it.pagopa.selfcare.mscore.model.QueueEvent;
+import it.pagopa.selfcare.mscore.model.institution.Institution;
+import it.pagopa.selfcare.mscore.model.onboarding.Token;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class SchedulerServiceImpl implements SchedulerService{
+
+    public static final int TOKEN_PAGE_SIZE = 100;
+    private final ContractService contractService;
+    private Optional<Integer> token_page_size_api = Optional.empty();
+
+    private final TokenConnector tokenConnector;
+    private final InstitutionConnector institutionConnector;
+    private final ConfigConnector configConnector;
+    private Optional<List<String>> productsFilter;
+
+    private final SchedulerConfig schedulerConfig;
+
+    @Autowired
+    public SchedulerServiceImpl(ContractService contractService,
+                                SchedulerConfig schedulerConfig,
+                                TokenConnector tokenConnector,
+                                InstitutionConnector institutionConnector,
+                                ConfigConnector configConnector) {
+        log.info("Initializing {}...", SchedulerServiceImpl.class.getSimpleName());
+        this.contractService = contractService;
+        this.schedulerConfig = schedulerConfig;
+        this.tokenConnector = tokenConnector;
+        this.institutionConnector = institutionConnector;
+        this.configConnector = configConnector;
+    }
+
+
+    @Scheduled(fixedDelayString = "${scheduler.fixed-delay.delay}")
+    public void regenerateQueueNotifications() {
+        log.trace("regenerateQueueNotifications start");
+
+
+            if (schedulerConfig.getSendOldEvent() && productsFilter.isPresent()) {
+                for (String productId: productsFilter.get()) {
+                    log.debug("Regenerating notifications on queue with product filter {}", productId);
+
+                    boolean nextPage = true;
+                    int page = 0;
+                    do {
+                        List<Token> tokens = tokenConnector.findByStatusAndProductId(EnumSet.of(RelationshipState.ACTIVE, RelationshipState.DELETED), productId, page, token_page_size_api.orElse(TOKEN_PAGE_SIZE));
+                        log.debug("[KAFKA] TOKEN NUMBER {} PAGE {}", tokens.size(), page);
+
+                        sendDataLakeNotifications(tokens);
+
+                        page += 1;
+                        if (tokens.size() < TOKEN_PAGE_SIZE) {
+                            nextPage = false;
+                            log.debug("[KAFKA] TOKEN TOTAL NUMBER {}", page * TOKEN_PAGE_SIZE + tokens.size());
+                        }
+
+                    } while (nextPage);
+                }
+                token_page_size_api = Optional.empty();
+                schedulerConfig.setScheduler(false);
+            }
+
+        log.info("Next scheduled check at {}", OffsetDateTime.now().plusSeconds(schedulerConfig.getFixedDelay() / 1000));
+        log.trace("regenerateQueueNotifications end");
+    }
+
+    private void sendDataLakeNotifications(List<Token> tokens) {
+        tokens.forEach(token -> {
+            try {
+                Institution institution = institutionConnector.findById(token.getInstitutionId());
+                contractService.sendDataLakeNotification(institution, token, QueueEvent.ADD);
+                if (!token.getStatus().equals(RelationshipState.ACTIVE)) {
+                    contractService.sendDataLakeNotification(institution, token, QueueEvent.UPDATE);
+                }
+            } catch (ResourceNotFoundException exception) {
+                log.error("Error while fetching institution for token {}, {}", token.getId(), exception.getMessage());
+            }
+        });
+    }
+
+    @Override
+    public void startScheduler(Optional<Integer> size, List<String> productsFilter) {
+        this.token_page_size_api = size;
+        this.productsFilter = Optional.of(productsFilter);
+        schedulerConfig.setScheduler(true);
+
+    }
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/config/SchedulerConfig.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/config/SchedulerConfig.java
@@ -34,7 +34,16 @@ public class SchedulerConfig implements SchedulingConfigurer {
         taskRegistrar.setTaskScheduler(taskScheduler);
     }
 
-    public Long getFixedDelay() {
+    private boolean sendOldEvent;
+    public boolean getSendOldEvent() {
+        return sendOldEvent;
+    }
+
+    public void setScheduler(boolean sendOldEvent) {
+        this.sendOldEvent = sendOldEvent;
+    }
+
+    public Long getFixedDelay(){
         return fixedDelay;
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/SchedulerServiceTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/SchedulerServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
 class SchedulerServiceTest {
 
     @InjectMocks
-    private SchedulerService scheduler;
+    private SchedulerServiceImpl scheduler;
     @Mock
     private ContractService contractService;
     @Mock

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/SchedulerController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/SchedulerController.java
@@ -1,0 +1,33 @@
+package it.pagopa.selfcare.mscore.web.controller;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import it.pagopa.selfcare.mscore.core.SchedulerService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@Slf4j
+@RequestMapping("/scheduler")
+@Api(tags = "scheduler")
+public class SchedulerController {
+
+    private final SchedulerService schedulerService;
+
+    public SchedulerController(SchedulerService schedulerService) {
+        this.schedulerService = schedulerService;
+    }
+    @ApiOperation(value = "", notes = "${swagger.external-interceptor.scheduler.api.start}")
+    @PostMapping(value = "")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public void start(@RequestParam(name = "size", required = false) Optional<Integer> size,
+                      @RequestParam(name = "productsFilter") List<String> productsFilter){
+
+        log.trace("Scheduler Started");
+        schedulerService.startScheduler(size, productsFilter);
+    }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

The previous mechanism for triggering the scheduler by conf collection in DB will be dropped for this API

#### Motivation and Context

The triggering via dB had the issue that if the ms didn't had the security context populated, the service wouldn't authenticate to the other microservices it needed to call. By using the api we will pass a token to the service so that it would be able to authenticate itself with the oter microservices

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.