### PR TITLE
fix: remove slash for some institutions endpoint

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -1442,7 +1442,7 @@
         } ]
       }
     },
-    "/institutions/" : {
+    "/institutions" : {
       "get" : {
         "tags" : [ "Institution" ],
         "summary" : "Gets institutions filtering by taxCode and/or subunitCode",
@@ -1582,7 +1582,7 @@
         } ]
       }
     },
-    "/institutions/from-anac/" : {
+    "/institutions/from-anac" : {
       "post" : {
         "tags" : [ "Institution" ],
         "summary" : "${swagger.mscore.institution.create.from-anac}",
@@ -1644,7 +1644,7 @@
         } ]
       }
     },
-    "/institutions/from-infocamere/" : {
+    "/institutions/from-infocamere" : {
       "post" : {
         "tags" : [ "Institution" ],
         "summary" : "create an institution from infocamere registry",
@@ -1706,7 +1706,7 @@
         } ]
       }
     },
-    "/institutions/from-ipa/" : {
+    "/institutions/from-ipa" : {
       "post" : {
         "tags" : [ "Institution" ],
         "summary" : "create an institution from ipa registry",
@@ -1768,7 +1768,7 @@
         } ]
       }
     },
-    "/institutions/from-ivass/" : {
+    "/institutions/from-ivass" : {
       "post" : {
         "tags" : [ "Institution" ],
         "summary" : "create an institution from ivass CSV",
@@ -1830,7 +1830,7 @@
         } ]
       }
     },
-    "/institutions/from-pda/" : {
+    "/institutions/from-pda" : {
       "post" : {
         "tags" : [ "Institution" ],
         "summary" : "${swagger.mscore.institution.create.from-pda}",

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -74,7 +74,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institutions}", notes = "${swagger.mscore.institutions}")
-    @GetMapping(value = "/")
+    @GetMapping
     public ResponseEntity<InstitutionsResponse> getInstitutions(@ApiParam("${swagger.mscore.institutions.model.taxCode}")
                                                                 @RequestParam(value = "taxCode", required = false) String taxCode,
                                                                 @ApiParam("${swagger.mscore.institutions.model.subunitCode}")
@@ -111,7 +111,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "${swagger.mscore.institution.create.from-ipa}", notes = "${swagger.mscore.institution.create.from-ipa}")
-    @PostMapping(value = "/from-ipa/")
+    @PostMapping(value = "/from-ipa")
     public ResponseEntity<InstitutionResponse> createInstitutionFromIpa(@RequestBody @Valid InstitutionFromIpaPost institutionFromIpaPost) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
 
@@ -136,7 +136,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "${swagger.mscore.institution.create.from-anac}", notes = "${swagger.mscore.institution.create.from-anac}")
-    @PostMapping(value = "/from-anac/")
+    @PostMapping(value = "/from-anac")
     public ResponseEntity<InstitutionResponse> createInstitutionFromAnac(@RequestBody @Valid InstitutionRequest institution) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
         Institution saved = institutionService.createInstitutionFromAnac(InstitutionMapperCustom.toInstitution(institution, null));
@@ -155,7 +155,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "${swagger.mscore.institution.create.from-ivass}", notes = "${swagger.mscore.institution.create.from-ivass}")
-    @PostMapping(value = "/from-ivass/")
+    @PostMapping(value = "/from-ivass")
     public ResponseEntity<InstitutionResponse> createInstitutionFromIvass(@RequestBody @Valid InstitutionRequest institution) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
         Institution saved = institutionService.createInstitutionFromIvass(InstitutionMapperCustom.toInstitution(institution, null));
@@ -174,7 +174,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "${swagger.mscore.institution.create.from-pda}", notes = "${swagger.mscore.institution.create.from-ipa}")
-    @PostMapping(value = "/from-pda/")
+    @PostMapping(value = "/from-pda")
     public ResponseEntity<InstitutionResponse> createInstitutionFromPda(@RequestBody @Valid PdaInstitutionRequest institutionRequest) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
 
@@ -194,7 +194,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "${swagger.mscore.institution.create.from-infocamere}", notes = "${swagger.mscore.institution.create.from-infocamere}")
-    @PostMapping(value = "/from-infocamere/")
+    @PostMapping(value = "/from-infocamere")
     public ResponseEntity<InstitutionResponse> createInstitutionFromInfocamere(@RequestBody @Valid InstitutionRequest institutionRequest) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
 
@@ -235,7 +235,7 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.CREATED)
     @ApiOperation(value = "${swagger.mscore.institution.create}", notes = "${swagger.mscore.institution.create}")
-    @PostMapping(value = "/")
+    @PostMapping
     public ResponseEntity<InstitutionResponse> createInstitution(@RequestBody @Valid InstitutionRequest institution) {
         CustomExceptionMessage.setCustomMessage(GenericError.CREATE_INSTITUTION_ERROR);
         Institution saved = institutionService.createInstitution(InstitutionMapperCustom.toInstitution(institution, null));


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Remove slash for some /institutions endpoint

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Some endpoints of **/institutions** contain final slash that is irrelevant for reaching the endpoints. This breaks some rest client generator so we want to remove these slashes.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.