### PR TITLE
[SELC-3452] fix: persist user mail institution

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserRegistryConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserRegistryConnector.java
@@ -10,4 +10,5 @@ public interface UserRegistryConnector {
 
     User persistUserUsingPatch(String name, String familyName, String fiscalCode, String email, String institutionId);
 
+    User persistUserWorksContractUsingPatch(String fiscalCode, String email, String institutionId);
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/UserRegistryConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/UserRegistryConnectorImpl.java
@@ -77,5 +77,23 @@ public class UserRegistryConnectorImpl implements UserRegistryConnector {
         return userMapper.fromUserId(result);
     }
 
+    @Override
+    public User persistUserWorksContractUsingPatch(String fiscalCode, String email, String institutionId) {
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "persistUserByFiscalCode fiscalCode = {}", fiscalCode);
+        Assert.hasText(fiscalCode, "A fiscalCode is required");
+        UserId result = restClient._saveUsingPATCH(SaveUserDto.builder()
+                        .fiscalCode(fiscalCode)
+                        .workContacts(Map.of(institutionId, WorkContactResource.builder()
+                                .email(CertifiableFieldResourceOfstring.builder()
+                                        .value(email)
+                                        .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE)
+                                        .build())
+                                .build()))
+                        .build())
+                .getBody();
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "persistUserByFiscalCode result = {}", result);
+        return userMapper.fromUserId(result);
+    }
+
 
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/UserRegistryConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/UserRegistryConnectorImplTest.java
@@ -83,6 +83,27 @@ class UserRegistryConnectorImplTest {
         verify(userRegistryRestClient)._saveUsingPATCH(saveUserDto);
     }
 
+    @Test
+    void persistUserWorksContractUsingPatch() {
+        UUID id = UUID.randomUUID();
+        UserId userId = new UserId();
+        userId.setId(id);
+        ResponseEntity<UserId> userIdResponseEntity = ResponseEntity.ok(userId);
+        when(userRegistryRestClient._saveUsingPATCH(any())).thenReturn(userIdResponseEntity);
+        User user = userRegistryConnector.persistUserWorksContractUsingPatch( "fiscalCode", "email","institutionId");
+        assertEquals(user.getId(), id.toString());
+        SaveUserDto saveUserDto = SaveUserDto.builder()
+                .fiscalCode("fiscalCode")
+                .workContacts(Map.of("institutionId", WorkContactResource.builder()
+                        .email(CertifiableFieldResourceOfstring.builder()
+                                .value("email")
+                                .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE)
+                                .build())
+                        .build()))
+                .build();
+        verify(userRegistryRestClient)._saveUsingPATCH(saveUserDto);
+    }
+
 
 }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -328,9 +328,10 @@ public class OnboardingServiceImpl implements OnboardingService {
         try {
             userRegistry = userService.retrieveUserFromUserRegistryByFiscalCode(user.getTaxCode());
             //We must save mail institution if it is not found on WorkContracts
-            if(Objects.isNull(userRegistry.getWorkContacts()) || !userRegistry.getWorkContacts().containsKey(institutionId))
-                throw new ResourceNotFoundException("WorkContract not found!", "0000");
-        } catch (FeignException.NotFound | ResourceNotFoundException e) {
+            if(Objects.isNull(userRegistry.getWorkContacts()) || !userRegistry.getWorkContacts().containsKey(institutionId)) {
+                userRegistry = userService.persistWorksContractToUserRegistry(user.getTaxCode(), user.getEmail(), institutionId);
+            }
+        } catch (FeignException.NotFound e) {
             userRegistry = userService.persistUserRegistry(user.getName(), user.getSurname(), user.getTaxCode(), user.getEmail(), institutionId);
         }
         user.setId(userRegistry.getId());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserService.java
@@ -33,6 +33,8 @@ public interface UserService {
 
     User persistUserRegistry(String name, String familyName, String fiscalCode, String email, String institutionId);
 
+    User persistWorksContractToUserRegistry(String fiscalCode, String email, String institutionId);
+
     List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter);
 
     void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserServiceImpl.java
@@ -113,6 +113,11 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    public User persistWorksContractToUserRegistry(String fiscalCode, String email, String institutionId) {
+        return userRegistryConnector.persistUserWorksContractUsingPatch(fiscalCode ,email , institutionId);
+    }
+
+    @Override
     public List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter) {
         return userConnector.findUserInstitutionAggregation(filter);
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -754,7 +754,7 @@ class OnboardingServiceImplTest {
         when(institutionService.getInstitutions(request.getInstitutionTaxCode(), null)).thenReturn(List.of(new Institution()));
         when(productConnector.getProductValidById(request.getProductId())).thenReturn(new Product());
         when(userService.retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode())).thenReturn(new User());
-        when(userService.persistUserRegistry(any(), any(), any(), any(), any())).thenReturn(new User());
+        when(userService.persistWorksContractToUserRegistry(any(), any(), any())).thenReturn(new User());
 
         onboardingServiceImpl.onboardingUsers(request, null, null);
 
@@ -775,7 +775,7 @@ class OnboardingServiceImplTest {
         when(institutionService.getInstitutions(request.getInstitutionTaxCode(), null)).thenReturn(List.of(new Institution()));
         when(productConnector.getProductValidById(request.getProductId())).thenReturn(new Product());
         when(userService.retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode())).thenReturn(new User());
-        when(userService.persistUserRegistry(any(), any(), any(), any(), any())).thenReturn(new User());
+        when(userService.persistWorksContractToUserRegistry(any(), any(), any())).thenReturn(new User());
 
         onboardingServiceImpl.onboardingUsers(request, null, null);
 
@@ -1547,7 +1547,7 @@ class OnboardingServiceImplTest {
         when(institutionConnector.findAndUpdate(any(), any(), any(), any())).thenReturn(institution);
 
         when(userService.retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode())).thenReturn(dummyUser());
-        when(userService.persistUserRegistry(any(), any(), any(), any(),any())).thenReturn(user);
+        when(userService.persistWorksContractToUserRegistry(any(), any(), any())).thenReturn(user);
 
         onboardingServiceImpl.persistOnboarding(institution.getId(), productId, pricingPlan, new Billing(), userToOnboards);
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserServiceImplTest.java
@@ -510,5 +510,13 @@ class UserServiceImplTest {
         when(userRegistryConnector.persistUserUsingPatch(any(), any(), any(), any(), any())).thenReturn(user);
         Assertions.assertDoesNotThrow(() -> userServiceImpl.persistUserRegistry("name", "familyName", "fiscalCode", "email", "institutionId"));
     }
+
+    @Test
+    void persistWorksContractToUserRegistry() {
+        User user = new User();
+        user.setId("fiscalCode");
+        when(userRegistryConnector.persistUserWorksContractUsingPatch("fiscalCode", "email", "institutionId")).thenReturn(user);
+        Assertions.assertDoesNotThrow(() -> userServiceImpl.persistWorksContractToUserRegistry( "fiscalCode", "email", "institutionId"));
+    }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Fix of this [PR](https://github.com/pagopa/selfcare-ms-core/pull/324).

- Persist only institution mail to pdv when it is not found on worksContract


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

 fillUserIdAndCreateIfNotExist persist name,familyName and worksContract users using patch. Persisting name and familyName cause errors when we have to persist only institution mail. So we introduce a new method for persisting just mail to worksContract.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.