### PR TITLE
[SELC-3460] feat: added tag external-v2 for automatic generation of open-api

### DIFF
--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -715,7 +715,7 @@
     },
     "/delegations" : {
       "get" : {
-        "tags" : [ "support" ],
+        "tags" : [ "Delegation", "external-v2", "support" ],
         "summary" : "Retrieve institution's delegations",
         "description" : "Retrieve institution's delegations",
         "operationId" : "getDelegationsUsingGET",
@@ -1444,7 +1444,7 @@
     },
     "/institutions/" : {
       "get" : {
-        "tags" : [ "support" ],
+        "tags" : [ "Institution", "external-v2", "support" ],
         "summary" : "Gets institutions filtering by taxCode and/or subunitCode",
         "description" : "Gets institutions filtering by taxCode and/or subunitCode",
         "operationId" : "getInstitutionsUsingGET",
@@ -2244,7 +2244,7 @@
     },
     "/institutions/{id}" : {
       "get" : {
-        "tags" : [ "Institution" ],
+        "tags" : [ "Institution", "external-v2" ],
         "summary" : "Gets the corresponding institution using internal institution id",
         "description" : "Gets the corresponding institution using internal institution id",
         "operationId" : "retrieveInstitutionByIdUsingGET",
@@ -2639,7 +2639,7 @@
     },
     "/institutions/{institutionId}/onboardings" : {
       "get" : {
-        "tags" : [ "Institution" ],
+        "tags" : [ "Institution", "external-v2" ],
         "summary" : "${swagger.mscore.institution.info}",
         "description" : "${swagger.mscore.institution.info}",
         "operationId" : "getOnboardingsInstitutionUsingGET",
@@ -2776,7 +2776,7 @@
     },
     "/institutions/{institutionId}/users" : {
       "get" : {
-        "tags" : [ "support" ],
+        "tags" : [ "Institution", "support" ],
         "summary" : "getInstitutionUsers",
         "description" : "Retrieve institution's users",
         "operationId" : "getInstitutionUsersUsingGET",
@@ -4280,7 +4280,7 @@
     },
     "/onboarding/users" : {
       "post" : {
-        "tags" : [ "support" ],
+        "tags" : [ "Onboarding", "support" ],
         "summary" : "The service adds users to the registry if they are not present and associates them with the institution and product contained in the body",
         "description" : "The service adds users to the registry if they are not present and associates them with the institution and product contained in the body",
         "operationId" : "onboardingInstitutionUsersUsingPOST",
@@ -4485,7 +4485,7 @@
     },
     "/tokens/products/{productId}" : {
       "get" : {
-        "tags" : [ "Token" ],
+        "tags" : [ "Token", "external-v2" ],
         "summary" : "${swagger.mscore.tokens.findFromProduct}",
         "description" : "${swagger.mscore.tokens.findFromProduct}",
         "operationId" : "findFromProductUsingGET_1",
@@ -4901,7 +4901,7 @@
     },
     "/users/{id}" : {
       "get" : {
-        "tags" : [ "support" ],
+        "tags" : [ "Persons", "external-v2", "support" ],
         "summary" : "Retrieves user given userId and optional ProductId",
         "description" : "Retrieves user given userId and optional ProductId",
         "operationId" : "getUserInfoUsingGET",

--- a/app/src/main/resources/swagger/api-docs-v1.json
+++ b/app/src/main/resources/swagger/api-docs-v1.json
@@ -715,7 +715,7 @@
     },
     "/delegations" : {
       "get" : {
-        "tags" : [ "Delegation" ],
+        "tags" : [ "support" ],
         "summary" : "Retrieve institution's delegations",
         "description" : "Retrieve institution's delegations",
         "operationId" : "getDelegationsUsingGET",
@@ -1444,7 +1444,7 @@
     },
     "/institutions/" : {
       "get" : {
-        "tags" : [ "Institution" ],
+        "tags" : [ "support" ],
         "summary" : "Gets institutions filtering by taxCode and/or subunitCode",
         "description" : "Gets institutions filtering by taxCode and/or subunitCode",
         "operationId" : "getInstitutionsUsingGET",
@@ -2776,7 +2776,7 @@
     },
     "/institutions/{institutionId}/users" : {
       "get" : {
-        "tags" : [ "Institution" ],
+        "tags" : [ "support" ],
         "summary" : "getInstitutionUsers",
         "description" : "Retrieve institution's users",
         "operationId" : "getInstitutionUsersUsingGET",
@@ -4280,7 +4280,7 @@
     },
     "/onboarding/users" : {
       "post" : {
-        "tags" : [ "Onboarding" ],
+        "tags" : [ "support" ],
         "summary" : "The service adds users to the registry if they are not present and associates them with the institution and product contained in the body",
         "description" : "The service adds users to the registry if they are not present and associates them with the institution and product contained in the body",
         "operationId" : "onboardingInstitutionUsersUsingPOST",
@@ -4901,7 +4901,7 @@
     },
     "/users/{id}" : {
       "get" : {
-        "tags" : [ "Persons" ],
+        "tags" : [ "support" ],
         "summary" : "Retrieves user given userId and optional ProductId",
         "description" : "Retrieves user given userId and optional ProductId",
         "operationId" : "getUserInfoUsingGET",

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -3,6 +3,7 @@
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.core.DelegationService;
@@ -87,6 +88,7 @@ public class DelegationController {
      * * Code: 404, Message: Institution data not found, DataType: Problem
      * * Code: 400, Message: Bad Request, DataType: Problem
      */
+    @Tag(name = "support")
     @ApiOperation(value = "${swagger.mscore.institutions.delegations}", notes = "${swagger.mscore.institutions.delegations}")
     @GetMapping()
     public ResponseEntity<List<DelegationResponse>> getDelegations(@ApiParam("${swagger.mscore.institutions.model.institutionId}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -89,7 +89,7 @@ public class DelegationController {
      * * Code: 404, Message: Institution data not found, DataType: Problem
      * * Code: 400, Message: Bad Request, DataType: Problem
      */
-    @Tags({@Tag(name = "external-v2"), @Tag(name = "support")})
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "support"), @Tag(name = "Delegation")})
     @ApiOperation(value = "${swagger.mscore.institutions.delegations}", notes = "${swagger.mscore.institutions.delegations}")
     @GetMapping()
     public ResponseEntity<List<DelegationResponse>> getDelegations(@ApiParam("${swagger.mscore.institutions.model.institutionId}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.core.DelegationService;
@@ -88,7 +89,7 @@ public class DelegationController {
      * * Code: 404, Message: Institution data not found, DataType: Problem
      * * Code: 400, Message: Bad Request, DataType: Problem
      */
-    @Tag(name = "support")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "support")})
     @ApiOperation(value = "${swagger.mscore.institutions.delegations}", notes = "${swagger.mscore.institutions.delegations}")
     @GetMapping()
     public ResponseEntity<List<DelegationResponse>> getDelegations(@ApiParam("${swagger.mscore.institutions.model.institutionId}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
@@ -73,7 +74,7 @@ public class InstitutionController {
      * * Code: 400, Message: Bad Request, DataType: Problem
      * * Code: 404, Message: Products not found, DataType: Problem
      */
-    @Tag(name = "support")
+    @Tags({@Tag(name = "support"), @Tag(name = "external-v2")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institutions}", notes = "${swagger.mscore.institutions}")
     @GetMapping(value = "/")
@@ -362,6 +363,7 @@ public class InstitutionController {
      * * Code: 200, Message: successful operation, DataType: InstitutionResponse
      * * Code: 404, Message: GeographicTaxonomies or Institution not found, DataType: Problem
      */
+    @Tag(name = "external-v2")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institution}", notes = "${swagger.mscore.institution}")
     @GetMapping(value = "/{id}")
@@ -413,6 +415,7 @@ public class InstitutionController {
      * * Code: 200, Message: successful operation, DataType: List<RelationshipResult>
      * * Code: 404, Message: GeographicTaxonomies or Institution not found, DataType: Problem
      */
+    @Tag(name = "external-v2")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institution.info}", notes = "${swagger.mscore.institution.info}")
     @GetMapping(value = "/{institutionId}/onboardings")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
@@ -72,6 +73,7 @@ public class InstitutionController {
      * * Code: 400, Message: Bad Request, DataType: Problem
      * * Code: 404, Message: Products not found, DataType: Problem
      */
+    @Tag(name = "support")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institutions}", notes = "${swagger.mscore.institutions}")
     @GetMapping(value = "/")
@@ -522,6 +524,7 @@ public class InstitutionController {
         return result;
     }
 
+    @Tag(name = "support")
     @GetMapping(value = "/{institutionId}/users")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.mscore.institutions.api.getInstitutionUsers}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -74,7 +74,7 @@ public class InstitutionController {
      * * Code: 400, Message: Bad Request, DataType: Problem
      * * Code: 404, Message: Products not found, DataType: Problem
      */
-    @Tags({@Tag(name = "support"), @Tag(name = "external-v2")})
+    @Tags({@Tag(name = "support"), @Tag(name = "external-v2"), @Tag(name = "Institution")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institutions}", notes = "${swagger.mscore.institutions}")
     @GetMapping(value = "/")
@@ -363,7 +363,7 @@ public class InstitutionController {
      * * Code: 200, Message: successful operation, DataType: InstitutionResponse
      * * Code: 404, Message: GeographicTaxonomies or Institution not found, DataType: Problem
      */
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "Institution")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institution}", notes = "${swagger.mscore.institution}")
     @GetMapping(value = "/{id}")
@@ -415,7 +415,7 @@ public class InstitutionController {
      * * Code: 200, Message: successful operation, DataType: List<RelationshipResult>
      * * Code: 404, Message: GeographicTaxonomies or Institution not found, DataType: Problem
      */
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "Institution")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institution.info}", notes = "${swagger.mscore.institution.info}")
     @GetMapping(value = "/{institutionId}/onboardings")
@@ -527,7 +527,7 @@ public class InstitutionController {
         return result;
     }
 
-    @Tag(name = "support")
+    @Tags({@Tag(name = "support"), @Tag(name = "Institution")})
     @GetMapping(value = "/{institutionId}/users")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "", notes = "${swagger.mscore.institutions.api.getInstitutionUsers}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
@@ -309,6 +310,7 @@ public class OnboardingController {
      * * Code: 400, Message: Invalid request, DataType: Problem
      */
     @ResponseStatus(HttpStatus.OK)
+    @Tag(name = "support")
     @ApiOperation(value = "${swagger.mscore.onboarding.users}", notes = "${swagger.mscore.onboarding.users}")
     @PostMapping(value = "/users")
     public ResponseEntity<List<RelationshipResult>> onboardingInstitutionUsers(@RequestBody @Valid OnboardingInstitutionUsersRequest request,

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/OnboardingController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
@@ -310,7 +311,7 @@ public class OnboardingController {
      * * Code: 400, Message: Invalid request, DataType: Problem
      */
     @ResponseStatus(HttpStatus.OK)
-    @Tag(name = "support")
+    @Tags({@Tag(name = "support"), @Tag(name = "Onboarding")})
     @ApiOperation(value = "${swagger.mscore.onboarding.users}", notes = "${swagger.mscore.onboarding.users}")
     @PostMapping(value = "/users")
     public ResponseEntity<List<RelationshipResult>> onboardingInstitutionUsers(@RequestBody @Valid OnboardingInstitutionUsersRequest request,

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.core.TokenService;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
@@ -89,6 +90,7 @@ public class TokenController {
      * * Code: 200, Message: successful operation
      * * Code: 404, Message: product not found
      */
+    @Tag(name = "external-v2")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.tokens.findFromProduct}", notes = "${swagger.mscore.tokens.findFromProduct}")
     @GetMapping(value = "/tokens/products/{productId}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.core.TokenService;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
@@ -90,7 +91,7 @@ public class TokenController {
      * * Code: 200, Message: successful operation
      * * Code: 404, Message: product not found
      */
-    @Tag(name = "external-v2")
+    @Tags({@Tag(name = "external-v2"), @Tag(name = "Token")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.tokens.findFromProduct}", notes = "${swagger.mscore.tokens.findFromProduct}")
     @GetMapping(value = "/tokens/products/{productId}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
@@ -241,7 +242,7 @@ public class UserController {
      * * Code: 400, Message: Invalid ID supplied, DataType: Problem
      * * Code: 404, Message: Not found, DataType: Problem
      */
-    @Tag(name = "support")
+    @Tags({@Tag(name = "support"), @Tag(name = "external-v2")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.users}", notes = "${swagger.mscore.users}")
     @GetMapping(value = "/users/{id}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.web.controller;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
@@ -240,6 +241,7 @@ public class UserController {
      * * Code: 400, Message: Invalid ID supplied, DataType: Problem
      * * Code: 404, Message: Not found, DataType: Problem
      */
+    @Tag(name = "support")
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.users}", notes = "${swagger.mscore.users}")
     @GetMapping(value = "/users/{id}")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -242,7 +242,7 @@ public class UserController {
      * * Code: 400, Message: Invalid ID supplied, DataType: Problem
      * * Code: 404, Message: Not found, DataType: Problem
      */
-    @Tags({@Tag(name = "support"), @Tag(name = "external-v2")})
+    @Tags({@Tag(name = "support"), @Tag(name = "external-v2"), @Tag(name = "Persons")})
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.users}", notes = "${swagger.mscore.users}")
     @GetMapping(value = "/users/{id}")


### PR DESCRIPTION
#### List of Changes

Added new tag **external-v2** for operation that will be include into open-api for APIM

#### Motivation and Context

In order to avoid manual construction of open-api for APIM, all operations that will be included into this document are tagged with **external-v2** or **support**. In this way, a step of github action will scan them and automatically include into open-api.