### PR TITLE
[SELC-3503] feat: enhance /institutions/from-ipa with geotaxonomy integration

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -5962,6 +5962,12 @@
         "title" : "InstitutionFromIpaPost",
         "type" : "object",
         "properties" : {
+          "geographicTaxonomies" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/GeoTaxonomies"
+            }
+          },
           "subunitCode" : {
             "type" : "string"
           },

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -27,7 +27,7 @@ public interface InstitutionService {
 
     List<Institution> getInstitutions(String taxCode, String subunitCode);
 
-    Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode);
+    Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies);
 
     Institution createInstitutionFromPda(Institution institution, String injectionInstitutionType);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -127,12 +127,13 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode) {
+    public Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies) {
         CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyIpa();
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(taxCode)
                 .subunitCode(subunitCode)
                 .subunitType(subunitType)
+                .geographicTaxonomies(geographicTaxonomies)
                 .build());
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
@@ -59,6 +59,8 @@ public class CreateInstitutionStrategyIpa extends CreateInstitutionStrategyCommo
             institution = getInstitutionEC(strategyInput.getTaxCode(), institutionProxyInfo, categoryProxyInfo);
         }
 
+        institution.setGeographicTaxonomies(strategyInput.getGeographicTaxonomies());
+
         try {
             return institutionConnector.save(institution);
         } catch (Exception e) {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
@@ -1,8 +1,11 @@
 package it.pagopa.selfcare.mscore.core.strategy.input;
 
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
+import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.List;
 
 @Builder
 @Data
@@ -11,5 +14,6 @@ public class CreateInstitutionStrategyInput {
     private String taxCode;
     private String description;
     private InstitutionPaSubunitType subunitType;
+    private List<InstitutionGeographicTaxonomies> geographicTaxonomies;
     private String subunitCode;
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -313,13 +313,13 @@ class InstitutionServiceImplTest {
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createInstitutionFromIpa(String, InstitutionPaSubunitType, String)}
+     * Method under test: {@link InstitutionServiceImpl#createInstitutionFromIpa(String, InstitutionPaSubunitType, String, List)}
      */
     @Test
     void testCreateInstitutionFromIpa() {
         when(createInstitutionStrategyFactory.createInstitutionStrategyIpa()).thenReturn(createInstitutionStrategy);
         when(createInstitutionStrategy.createInstitution(any())).thenReturn(new Institution());
-        Institution institution = institutionServiceImpl.createInstitutionFromIpa("id", InstitutionPaSubunitType.AOO,"id");
+        Institution institution = institutionServiceImpl.createInstitutionFromIpa("id", InstitutionPaSubunitType.AOO,"id", List.of());
         assertNotNull(institution);
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -51,6 +51,7 @@ class CreateInstitutionStrategyTest {
 
     private static final AreaOrganizzativaOmogenea dummyAreaOrganizzativaOmogenea;
     private static final GeographicTaxonomies dummyGeotaxonomies;
+    private static final InstitutionGeographicTaxonomies dummyInstitutionGeotaxonomies;
 
     static {
         dummyInstitutionProxyInfo = new InstitutionProxyInfo();
@@ -87,6 +88,10 @@ class CreateInstitutionStrategyTest {
         dummyGeotaxonomies.setDescription("nomeCittà - COMUNE");
         dummyGeotaxonomies.setProvinceAbbreviation("proAbbrv");
         dummyGeotaxonomies.setCountryAbbreviation("countryAbbrv");
+
+        dummyInstitutionGeotaxonomies = new InstitutionGeographicTaxonomies();
+        dummyInstitutionGeotaxonomies.setCode("code");
+        dummyInstitutionGeotaxonomies.setDesc("desc");
     }
 
     private UnitaOrganizzativa dummyUnitaOrganizzativa() {
@@ -245,6 +250,7 @@ class CreateInstitutionStrategyTest {
                         .taxCode(dummyAreaOrganizzativaOmogenea.getCodiceFiscaleEnte())
                         .subunitType(InstitutionPaSubunitType.AOO)
                         .subunitCode(dummyAreaOrganizzativaOmogenea.getCodAoo())
+                        .geographicTaxonomies(List.of(dummyInstitutionGeotaxonomies))
                         .build());
 
         //Then
@@ -259,6 +265,9 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getSubunitType()).isEqualTo(InstitutionPaSubunitType.AOO.name());
         assertThat(actual.getParentDescription()).isEqualTo(dummyInstitutionProxyInfo.getDescription());
         assertThat(actual.getCity()).isEqualTo(dummyGeotaxonomies.getDescription().replace(" - COMUNE", ""));
+        assertThat(actual.getGeographicTaxonomies().size()).isEqualTo(1);
+        assertThat(actual.getGeographicTaxonomies().get(0).getCode()).isEqualTo(dummyInstitutionGeotaxonomies.getCode());
+
         verify(institutionConnector, times(2)).save(any());
         verify(institutionConnector).findByTaxCodeAndSubunitCode(anyString(), anyString());
         verify(partyRegistryProxyConnector).getCategory(any(), any());

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -124,8 +124,12 @@ public class InstitutionController {
             throw new ValidationException("subunitCode and subunitType must both be evaluated.");
         }
 
+        List<InstitutionGeographicTaxonomies> geographicTaxonomies = Optional.ofNullable(institutionFromIpaPost.getGeographicTaxonomies())
+                .map(geoTaxonomies -> geoTaxonomies.stream().map(institutionResourceMapper::toInstitutionGeographicTaxonomies).toList())
+                .orElse(List.of());
+
         Institution saved = institutionService.createInstitutionFromIpa(institutionFromIpaPost.getTaxCode(),
-                institutionFromIpaPost.getSubunitType(), institutionFromIpaPost.getSubunitCode());
+                institutionFromIpaPost.getSubunitType(), institutionFromIpaPost.getSubunitCode(), geographicTaxonomies);
         return ResponseEntity.status(HttpStatus.CREATED).body(institutionResourceMapper.toInstitutionResponse(saved));
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionFromIpaPost.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionFromIpaPost.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
 import lombok.Data;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Data
 public class InstitutionFromIpaPost {
@@ -12,4 +13,5 @@ public class InstitutionFromIpaPost {
     private String taxCode;
     private String subunitCode;
     private InstitutionPaSubunitType subunitType;
+    private List<GeoTaxonomies> geographicTaxonomies;
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionResourceMapper.java
@@ -3,7 +3,9 @@ package it.pagopa.selfcare.mscore.web.model.mapper;
 
 import it.pagopa.selfcare.mscore.model.institution.Billing;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
+import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
 import it.pagopa.selfcare.mscore.web.model.institution.BillingRequest;
+import it.pagopa.selfcare.mscore.web.model.institution.GeoTaxonomies;
 import it.pagopa.selfcare.mscore.web.model.institution.InstitutionResponse;
 import it.pagopa.selfcare.mscore.web.model.institution.RootParentResponse;
 import org.mapstruct.Mapper;
@@ -31,6 +33,8 @@ public interface InstitutionResourceMapper {
 
 
     Billing billingRequestToBilling(BillingRequest billingRequest);
+
+    InstitutionGeographicTaxonomies toInstitutionGeographicTaxonomies(GeoTaxonomies geoTaxonomies);
 
 
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

**Added geotaxonomy in the request for the POST /institutions/from-ipa endpoint**. This enhancement allows the association of geotaxonomy during the creation of an institution. Previously, the endpoint created an institution by retrieving data from the IPA index based on the fiscal code and subunit code, but it did not save any geotaxonomy reference entered during the onboarding phase. 


#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

This change addresses the lack of geotaxonomy integration in the process of creating an institution through the /institutions/from-ipa endpoint. By incorporating geotaxonomy in the request, the system now aligns better with the onboarding phase requirements and ensures a more comprehensive creation of institutional data.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.