### PR TITLE
[SELC-3679] fix: institution mail sending on PNPG domain

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/EmailConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/EmailConnector.java
@@ -8,4 +8,6 @@ public interface EmailConnector {
 
     void sendMail(String templateName, List<String> destinationMail, File pdf, String productName, Map<String, String> mailParameters, String nameFile);
 
+    void sendMailPNPG(String templateName, String destinationMail, String businessName);
+
 }

--- a/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
+++ b/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
@@ -21,13 +21,16 @@ import javax.mail.util.ByteArrayDataSource;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_COMPRESS_FILE;
 import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_SEND_MAIL;
+import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_PN;
 
 @Slf4j
 @Service
@@ -79,6 +82,41 @@ public class EmailConnectorImpl implements EmailConnector {
         }
         log.trace("sendMessage end");
     }
+
+    @Override
+    public void sendMailPNPG(String templateName, String destinationMail, String businessName) {
+        log.trace("sendMailPNPG end");
+        log.debug("sendMailPNPG templateName = {}, destinationMail = {}, businessName = {}", templateName, destinationMail, businessName);
+        try {
+            log.info("START - sendMail to {}, for product {}", destinationMail, PROD_PN);
+            String template = fileStorageConnector.getTemplateFile(templateName);
+            MailTemplate mailTemplate = mapper.readValue(template, MailTemplate.class);
+            Map<String, String> mailParameters = new HashMap<>();
+            mailParameters.put("businessName", businessName);
+            String html = StringSubstitutor.replace(mailTemplate.getBody(), mailParameters);
+            log.trace("sendMessage start");
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+            MimeMessageHelper message = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+
+            List<String> destinationMails = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
+                    ? coreConfig.getDestinationMails()
+                    : List.of(destinationMail);
+
+            message.setSubject(mailTemplate.getSubject());
+            message.setFrom(coreConfig.getSenderMail());
+            message.setTo(destinationMails.toArray(new String[0]));
+            message.setText(html, true);
+
+            mailSender.send(mimeMessage);
+            log.info("END - sendMail to {}, for product {}", destinationMail, PROD_PN);
+        } catch (Exception e) {
+            log.error(ERROR_DURING_SEND_MAIL.getMessage() + ":", e.getMessage(), e);
+            throw new MsCoreException(ERROR_DURING_SEND_MAIL.getMessage(), ERROR_DURING_SEND_MAIL.getCode());
+        }
+        log.trace("sendMailPNPG end");
+    }
+
     public byte[] zipBytes(String filename, File pdf)  {
             try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
                  ZipOutputStream zos = new ZipOutputStream(baos)) {

--- a/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
+++ b/connector/email/src/main/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImpl.java
@@ -85,7 +85,7 @@ public class EmailConnectorImpl implements EmailConnector {
 
     @Override
     public void sendMailPNPG(String templateName, String destinationMail, String businessName) {
-        log.trace("sendMailPNPG end");
+        log.trace("sendMailPNPG start");
         log.debug("sendMailPNPG templateName = {}, destinationMail = {}, businessName = {}", templateName, destinationMail, businessName);
         try {
             log.info("START - sendMail to {}, for product {}", destinationMail, PROD_PN);
@@ -102,6 +102,8 @@ public class EmailConnectorImpl implements EmailConnector {
             List<String> destinationMails = Objects.nonNull(coreConfig.getDestinationMails()) && !coreConfig.getDestinationMails().isEmpty()
                     ? coreConfig.getDestinationMails()
                     : List.of(destinationMail);
+
+            log.debug("sendMailPNPG destinationMails = {}", destinationMails);
 
             message.setSubject(mailTemplate.getSubject());
             message.setFrom(coreConfig.getSenderMail());

--- a/connector/email/src/test/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImplTest.java
+++ b/connector/email/src/test/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImplTest.java
@@ -97,5 +97,77 @@ class EmailConnectorImplTest {
         verify(fileStorageConnector).getTemplateFile(any());
     }
 
+    @Test
+    void testSendMailPNPG() throws IOException {
+        final String senderMail = "senderMail";
+        ArrayList<String> destinationMails = new ArrayList<>();
+        final String destinationMail = "destinationMail";
+        final String templateName = "templateName";
+        final String templateFile = "templateFile";
+        final String businessName = "businessName";
+
+        when(fileStorageConnector.getTemplateFile(any())).thenReturn(templateFile);
+        MailTemplate mailTemplate = new MailTemplate();
+        mailTemplate.setBody("body");
+        mailTemplate.setSubject("subject");
+        when(mapper.readValue(anyString(),  eq(MailTemplate.class))).thenReturn(mailTemplate);
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(coreConfig.getSenderMail()).thenReturn(senderMail);
+        when(coreConfig.getDestinationMails()).thenReturn(destinationMails);
+
+        Assertions.assertDoesNotThrow(() -> emailConnector.sendMailPNPG(templateName, destinationMail, businessName));
+    }
+
+    @Test
+    void testSendMailPNPG_changeDestinationMail() throws IOException {
+        final String senderMail = "senderMail";
+        final String destinationMail = "destinationMail";
+        ArrayList<String> destinationMails = new ArrayList<>();
+        destinationMails.add(destinationMail);
+        final String templateName = "templateName";
+        final String templateFile = "templateFile";
+        final String businessName = "businessName";
+
+        when(fileStorageConnector.getTemplateFile(any())).thenReturn(templateFile);
+        MailTemplate mailTemplate = new MailTemplate();
+        mailTemplate.setBody("body");
+        mailTemplate.setSubject("subject");
+        when(mapper.readValue(anyString(),  eq(MailTemplate.class))).thenReturn(mailTemplate);
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(coreConfig.getSenderMail()).thenReturn(senderMail);
+        when(coreConfig.getDestinationMails()).thenReturn(destinationMails);
+
+        Assertions.assertDoesNotThrow(() -> emailConnector.sendMailPNPG(templateName, destinationMail, businessName));
+    }
+
+    @Test
+    void testSendMailPGNG_exception() throws JsonProcessingException {
+        final String senderMail = "senderMail";
+        final String destinationMail = "destinationMail";
+        ArrayList<String> destinationMails = new ArrayList<>();
+        destinationMails.add(destinationMail);        final String templateName = "templateName";
+        final String templateFile = "templateFile";
+        final String businessName = "businessName";
+
+        when(fileStorageConnector.getTemplateFile(any())).thenReturn(templateFile);
+        MailTemplate mailTemplate = new MailTemplate();
+        mailTemplate.setBody("body");
+        mailTemplate.setSubject("subject");
+        when(mapper.readValue(anyString(),  eq(MailTemplate.class))).thenReturn(mailTemplate);
+
+        MimeMessage mimeMessage = mock(MimeMessage.class);
+        when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(coreConfig.getSenderMail()).thenReturn(senderMail);
+        when(coreConfig.getDestinationMails()).thenReturn(destinationMails);
+
+        doThrow(RuntimeException.class).when(javaMailSender).send(any(MimeMessage.class));
+        Assertions.assertThrows(MsCoreException.class, () -> emailConnector.sendMailPNPG(templateName,destinationMail,businessName));
+
+    }
+
 }
 

--- a/connector/email/src/test/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImplTest.java
+++ b/connector/email/src/test/java/it/pagopa/selfcare/mscore/connector/email/EmailConnectorImplTest.java
@@ -148,8 +148,7 @@ class EmailConnectorImplTest {
     void testSendMailPGNG_exception() throws JsonProcessingException {
         final String senderMail = "senderMail";
         final String destinationMail = "destinationMail";
-        ArrayList<String> destinationMails = new ArrayList<>();
-        destinationMails.add(destinationMail);        final String templateName = "templateName";
+        final String templateName = "templateName";
         final String templateFile = "templateFile";
         final String businessName = "businessName";
 
@@ -162,7 +161,7 @@ class EmailConnectorImplTest {
         MimeMessage mimeMessage = mock(MimeMessage.class);
         when(javaMailSender.createMimeMessage()).thenReturn(mimeMessage);
         when(coreConfig.getSenderMail()).thenReturn(senderMail);
-        when(coreConfig.getDestinationMails()).thenReturn(destinationMails);
+        when(coreConfig.getDestinationMails()).thenReturn(null);
 
         doThrow(RuntimeException.class).when(javaMailSender).send(any(MimeMessage.class));
         Assertions.assertThrows(MsCoreException.class, () -> emailConnector.sendMailPNPG(templateName,destinationMail,businessName));

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
@@ -5,7 +5,6 @@ import it.pagopa.selfcare.mscore.api.*;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.config.MailTemplateConfig;
 import it.pagopa.selfcare.mscore.core.util.MailParametersMapper;
-import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.WorkContact;
 import it.pagopa.selfcare.mscore.model.notification.MessageRequest;
@@ -22,8 +21,8 @@ import org.springframework.util.StringUtils;
 import java.io.File;
 import java.util.*;
 
-import static it.pagopa.selfcare.mscore.constant.GenericError.ERROR_DURING_SEND_MAIL;
-import static it.pagopa.selfcare.mscore.constant.ProductId.*;
+import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_FD;
+import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_FD_GARANTITO;
 
 @Slf4j
 @Service
@@ -65,7 +64,9 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public void setCompletedPGOnboardingMail(String destinationMail, String businessName) {
-        try {
+        log.trace("setCompletedPGOnboardingMail start");
+        log.debug("setCompletedPGOnboardingMail destinationMail = {}, businessName = {}", destinationMail, businessName);
+        /*try {
             log.info("START - sendMail to {}, for product {}", destinationMail, PROD_PN);
             String template = fileStorageConnector.getTemplateFile(mailTemplateConfig.getPath());
             MailTemplate mailTemplate = mapper.readValue(template, MailTemplate.class);
@@ -77,6 +78,9 @@ public class NotificationServiceImpl implements NotificationService {
             throw new MsCoreException(ERROR_DURING_SEND_MAIL.getMessage(), ERROR_DURING_SEND_MAIL.getCode());
         }
         log.trace("sendMessage end");
+         */
+        emailConnector.sendMailPNPG(mailTemplateConfig.getPath(), destinationMail, businessName);
+        log.trace("setCompletedPGOnboardingMail end");
     }
 
     public void sendAutocompleteMail(List<String> destinationMail, Map<String, String> templateParameters, File file, String fileName, String productName) {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/NotificationServiceImpl.java
@@ -66,19 +66,6 @@ public class NotificationServiceImpl implements NotificationService {
     public void setCompletedPGOnboardingMail(String destinationMail, String businessName) {
         log.trace("setCompletedPGOnboardingMail start");
         log.debug("setCompletedPGOnboardingMail destinationMail = {}, businessName = {}", destinationMail, businessName);
-        /*try {
-            log.info("START - sendMail to {}, for product {}", destinationMail, PROD_PN);
-            String template = fileStorageConnector.getTemplateFile(mailTemplateConfig.getPath());
-            MailTemplate mailTemplate = mapper.readValue(template, MailTemplate.class);
-            MessageRequest messageRequest = constructMessageRequest(destinationMail, businessName, mailTemplate);
-            log.trace("sendMessage start");
-            notificationConnector.sendNotificationToUser(messageRequest);
-        } catch (Exception e) {
-            log.error(ERROR_DURING_SEND_MAIL.getMessage() + ":", e.getMessage(), e);
-            throw new MsCoreException(ERROR_DURING_SEND_MAIL.getMessage(), ERROR_DURING_SEND_MAIL.getCode());
-        }
-        log.trace("sendMessage end");
-         */
         emailConnector.sendMailPNPG(mailTemplateConfig.getPath(), destinationMail, businessName);
         log.trace("setCompletedPGOnboardingMail end");
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/NotificationServiceImplTest.java
@@ -1,18 +1,15 @@
 package it.pagopa.selfcare.mscore.core;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.*;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.config.MailTemplateConfig;
 import it.pagopa.selfcare.mscore.core.util.MailParametersMapper;
-import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.model.CertifiedField;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionUpdate;
 import it.pagopa.selfcare.mscore.model.institution.WorkContact;
-import it.pagopa.selfcare.mscore.model.onboarding.MailTemplate;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
 import it.pagopa.selfcare.mscore.model.product.Product;
 import it.pagopa.selfcare.mscore.model.user.User;
@@ -23,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.File;
@@ -33,8 +31,6 @@ import java.util.Map;
 
 import static it.pagopa.selfcare.commons.utils.TestUtils.mockInstance;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -91,27 +87,14 @@ class NotificationServiceImplTest {
     }
 
     @Test
-    void setCompletedPGOnboardingMail() throws JsonProcessingException {
-        when(mailTemplateConfig.getPath()).thenReturn("path");
-        when(fileStorageConnector.getTemplateFile(any())).thenReturn("templateFile");
-        MailTemplate mailTemplate = new MailTemplate();
-        mailTemplate.setBody("body");
-        mailTemplate.setSubject("subject");
-        when(mapper.readValue("templateFile", MailTemplate.class)).thenReturn(mailTemplate);
-        assertDoesNotThrow(() ->notificationService.setCompletedPGOnboardingMail("dest","buss"));
-    }
-
-    @Test
-    void setCompletedPGOnboardingMailThrow() throws JsonProcessingException {
-        when(mailTemplateConfig.getPath()).thenReturn("path");
-        when(fileStorageConnector.getTemplateFile(any())).thenReturn("templateFile");
-        MailTemplate mailTemplate = new MailTemplate();
-        mailTemplate.setBody("body");
-        mailTemplate.setSubject("subject");
-        when(mapper.readValue("templateFile", MailTemplate.class)).thenReturn(mailTemplate);
-        doThrow(new MsCoreException("An error occurred", "Code")).when(notificationConnector)
-                .sendNotificationToUser(any());
-        assertThrows(MsCoreException.class, () -> notificationService.setCompletedPGOnboardingMail("42","42"));
+    void setCompletedPGOnboardingMail() {
+        final String path = "path";
+        final String destination = "dest";
+        final String businessName = "buss";
+        when(mailTemplateConfig.getPath()).thenReturn(path);
+        assertDoesNotThrow(() ->notificationService.setCompletedPGOnboardingMail(destination,businessName));
+        Mockito.verify(emailConnector, times(1)).sendMailPNPG(path,destination,businessName);
+        Mockito.verifyNoMoreInteractions(emailConnector);
     }
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
change the implementation on email send to notify the institution of the successful onboarding.

#### Motivation and Context
The previous implementation used a not-certified email to notify the institutions. 
Since the institution's email is a certified email it rejects the email from selfcare. This has increased rebounce rate of the selcare email putting the aws account in review.
The new implementation uses certified aruba email that won't be rebounced by the receiver.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
deployed from branch in development environment and tested by onboarding an institution, verifying that the email was correctly delivered.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.