### PR TITLE
[SELC-3693] Feat: Added API for retrieve ScContract for DL

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -4641,6 +4641,81 @@
         } ]
       }
     },
+    "/tokens" : {
+      "get" : {
+        "tags" : [ "Token", "external-v2" ],
+        "summary" : "${swagger.mscore.tokens.getAll}",
+        "description" : "${swagger.mscore.tokens.getAll}",
+        "operationId" : "getAllTokensUsingGET",
+        "parameters" : [ {
+          "name" : "states",
+          "in" : "query",
+          "description" : "${swagger.mscore.token.model.states}",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ACTIVE", "DELETED", "PENDING", "REJECTED", "SUSPENDED", "TOBEVALIDATED" ]
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "${swagger.mscore.page.number}",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "${swagger.mscore.page.size}",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/PaginatedTokenResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/tokens/products/{productId}" : {
       "get" : {
         "tags" : [ "Token", "external-v2" ],
@@ -6631,6 +6706,64 @@
           }
         }
       },
+      "InstitutionToNotifyResponse" : {
+        "title" : "InstitutionToNotifyResponse",
+        "type" : "object",
+        "properties" : {
+          "address" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "city" : {
+            "type" : "string"
+          },
+          "country" : {
+            "type" : "string"
+          },
+          "county" : {
+            "type" : "string"
+          },
+          "description" : {
+            "type" : "string"
+          },
+          "digitalAddress" : {
+            "type" : "string"
+          },
+          "institutionType" : {
+            "type" : "string",
+            "enum" : [ "AS", "GSP", "PA", "PG", "PSP", "PT", "SA", "SCP" ]
+          },
+          "istatCode" : {
+            "type" : "string"
+          },
+          "origin" : {
+            "type" : "string"
+          },
+          "originId" : {
+            "type" : "string"
+          },
+          "paymentServiceProvider" : {
+            "$ref" : "#/components/schemas/PaymentServiceProvider"
+          },
+          "rootParent" : {
+            "$ref" : "#/components/schemas/RootParent"
+          },
+          "subUnitCode" : {
+            "type" : "string"
+          },
+          "subUnitType" : {
+            "type" : "string"
+          },
+          "taxCode" : {
+            "type" : "string"
+          },
+          "zipCode" : {
+            "type" : "string"
+          }
+        }
+      },
       "InstitutionToOnboard" : {
         "title" : "InstitutionToOnboard",
         "type" : "object",
@@ -7537,6 +7670,22 @@
           }
         }
       },
+      "PaginatedTokenResponse" : {
+        "title" : "PaginatedTokenResponse",
+        "type" : "object",
+        "properties" : {
+          "items" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ScContractResponse"
+            }
+          },
+          "totalNumber" : {
+            "type" : "integer",
+            "format" : "int64"
+          }
+        }
+      },
       "PaymentServiceProvider" : {
         "title" : "PaymentServiceProvider",
         "type" : "object",
@@ -7812,6 +7961,21 @@
           }
         }
       },
+      "RootParent" : {
+        "title" : "RootParent",
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "originId" : {
+            "type" : "string"
+          }
+        }
+      },
       "RootParentResponse" : {
         "title" : "RootParentResponse",
         "type" : "object",
@@ -7821,6 +7985,61 @@
           },
           "id" : {
             "type" : "string"
+          }
+        }
+      },
+      "ScContractResponse" : {
+        "title" : "ScContractResponse",
+        "type" : "object",
+        "properties" : {
+          "billing" : {
+            "$ref" : "#/components/schemas/BillingResponse"
+          },
+          "closedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "contentType" : {
+            "type" : "string"
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "fileName" : {
+            "type" : "string"
+          },
+          "filePath" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "institution" : {
+            "$ref" : "#/components/schemas/InstitutionToNotifyResponse"
+          },
+          "internalIstitutionID" : {
+            "type" : "string"
+          },
+          "notificationType" : {
+            "type" : "string",
+            "enum" : [ "ADD", "UPDATE" ]
+          },
+          "onboardingTokenId" : {
+            "type" : "string"
+          },
+          "pricingPlan" : {
+            "type" : "string"
+          },
+          "product" : {
+            "type" : "string"
+          },
+          "state" : {
+            "type" : "string"
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           }
         }
       },

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -4643,7 +4643,7 @@
     },
     "/tokens" : {
       "get" : {
-        "tags" : [ "Token", "external-v2" ],
+        "tags" : [ "Token" ],
         "summary" : "${swagger.mscore.tokens.getAll}",
         "description" : "${swagger.mscore.tokens.getAll}",
         "operationId" : "getAllTokensUsingGET",

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/TokenConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/TokenConnector.java
@@ -28,4 +28,6 @@ public interface TokenConnector {
     Token updateTokenCreatedAt(String tokenId, OffsetDateTime createdAt);
 
     List<Token> findByStatusAndProductId(EnumSet<RelationshipState> statuses, String productId, Integer nextPage, Integer size);
+
+    Long countAllTokenFilterByStates(List<RelationshipState> states);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/PaginatedToken.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/PaginatedToken.java
@@ -1,0 +1,16 @@
+package it.pagopa.selfcare.mscore.model.onboarding;
+
+import it.pagopa.selfcare.mscore.model.NotificationToSend;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaginatedToken {
+    private List<NotificationToSend> items;
+    private Long totalNumber;
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/MongoCustomConnector.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/MongoCustomConnector.java
@@ -13,6 +13,8 @@ public interface MongoCustomConnector {
 
     <O> boolean exists(Query query, Class<O> outputType);
 
+    <O> Long count(Query query, Class<O> outputType);
+
     <O> List<O> find(Query query, Class<O> outputType);
 
     <O> Page<O> find(Query query, Pageable pageable, Class<O> outputType);

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/MongoCustomConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/MongoCustomConnectorImpl.java
@@ -33,6 +33,11 @@ public class MongoCustomConnectorImpl implements MongoCustomConnector {
     }
 
     @Override
+    public <O> Long count(Query query, Class<O> outputType) {
+        return mongoOperations.count(query, outputType);
+    }
+
+    @Override
     public <O> List<O> find(Query query, Class<O> outputType) {
         return mongoOperations.find(query, outputType);
     }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
@@ -153,7 +153,14 @@ public class TokenConnectorImpl implements TokenConnector {
         return tokenRepository.find(query, pageable, TokenEntity.class)
                 .stream()
                 .map(TokenMapper::convertToToken)
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    @Override
+    public Long countAllTokenFilterByStates(List<RelationshipState> states) {
+        Query query = Query.query(Criteria.where(TokenEntity.Fields.status.name()).in(states))
+                .with(Sort.by(Sort.Direction.ASC, TokenEntity.Fields.id.name()));
+        return tokenRepository.count(query, TokenEntity.class);
     }
 
 }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/MongoCustomConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/MongoCustomConnectorImplTest.java
@@ -20,8 +20,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -41,6 +40,14 @@ class MongoCustomConnectorImplTest {
         Query query = new Query();
         assertTrue(mongoCustomConnector.exists(query, Object.class));
     }
+
+    @Test
+    void testCount() {
+        when(mongoOperations.count(any(), (Class<?>) any())).thenReturn(10L);
+        Query query = new Query();
+        assertEquals(10L, mongoCustomConnector.count(query, Object.class));
+    }
+
 
     @Test
     void testFind() {

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
@@ -1262,4 +1262,10 @@ class TokenConnectorImplTest {
         assertEquals(pageNumber, capturedPage.getPageNumber());
         verifyNoMoreInteractions(tokenRepository);
     }
+
+    @Test
+    void countAllTokenFilterByStates(){
+        when(tokenRepository.count(any(), any())).thenReturn(1L);
+        Assertions.assertEquals(1L, tokenConnectorImpl.countAllTokenFilterByStates(List.of(RelationshipState.ACTIVE)));
+    }
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -268,6 +268,12 @@ public class ContractService {
                 notification.setUpdatedAt(Optional.ofNullable(token.getUpdatedAt()).orElse(token.getCreatedAt()));
             }
         }
+        // ADD or UPDATE msg event
+        notification.setNotificationType(queueEvent);
+        return toNotificationToSend(notification, institution, token);
+    }
+
+    public NotificationToSend toNotificationToSend(NotificationToSend notification, Institution institution, Token token) {
         notification.setInternalIstitutionID(institution.getId());
         notification.setProduct(token.getProductId());
         notification.setFilePath(token.getContractSigned());
@@ -276,7 +282,6 @@ public class ContractService {
         notification.setCreatedAt(Optional.ofNullable(token.getActivatedAt()).orElse(token.getCreatedAt()));
 
         // ADD or UPDATE msg event
-        notification.setNotificationType(queueEvent);
         notification.setFileName(token.getContractSigned() == null ? "" : Paths.get(token.getContractSigned()).getFileName().toString());
         notification.setContentType(token.getContentType() == null ? "" : token.getContentType());
 
@@ -292,7 +297,7 @@ public class ContractService {
         return notification;
     }
 
-    protected InstitutionToNotify toInstitutionToNotify(Institution institution) {
+    private InstitutionToNotify toInstitutionToNotify(Institution institution) {
         InstitutionToNotify toNotify = new InstitutionToNotify();
         toNotify.setInstitutionType(institution.getInstitutionType());
         toNotify.setDescription(institution.getDescription());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractService.java
@@ -292,7 +292,7 @@ public class ContractService {
         return notification;
     }
 
-    private InstitutionToNotify toInstitutionToNotify(Institution institution) {
+    protected InstitutionToNotify toInstitutionToNotify(Institution institution) {
         InstitutionToNotify toNotify = new InstitutionToNotify();
         toNotify.setInstitutionType(institution.getInstitutionType());
         toNotify.setDescription(institution.getDescription());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/TokenService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/TokenService.java
@@ -1,5 +1,7 @@
 package it.pagopa.selfcare.mscore.core;
 
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
+import it.pagopa.selfcare.mscore.model.onboarding.PaginatedToken;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
 import it.pagopa.selfcare.mscore.model.onboarding.TokenRelationships;
 
@@ -17,4 +19,5 @@ public interface TokenService {
 
     List<TokenRelationships> getTokensByProductId(String productId, Integer page, Integer size);
 
+    PaginatedToken retrieveContractsFilterByStatus(List<RelationshipState> states, Integer page, Integer size);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/TokenServiceImpl.java
@@ -4,22 +4,22 @@ import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.TokenConnector;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.util.TokenUtils;
+import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
-import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
-import it.pagopa.selfcare.mscore.model.onboarding.Token;
-import it.pagopa.selfcare.mscore.model.onboarding.TokenRelationships;
-import it.pagopa.selfcare.mscore.model.onboarding.TokenUser;
+import it.pagopa.selfcare.mscore.model.NotificationToSend;
+import it.pagopa.selfcare.mscore.model.institution.Institution;
+import it.pagopa.selfcare.mscore.model.institution.Onboarding;
+import it.pagopa.selfcare.mscore.model.onboarding.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.nio.file.Paths;
 import java.time.OffsetDateTime;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.mscore.constant.CustomError.TOKEN_ALREADY_CONSUMED;
+import static it.pagopa.selfcare.mscore.constant.RelationshipState.ACTIVE;
 import static it.pagopa.selfcare.mscore.core.util.UtilEnumList.VERIFY_TOKEN_RELATIONSHIP_STATES;
 
 @Slf4j
@@ -30,15 +30,18 @@ public class TokenServiceImpl implements TokenService {
     private final UserService userService;
     private final OnboardingDao onboardingDao;
     private final InstitutionConnector institutionConnector;
+    private final ContractService contractService;
 
     public TokenServiceImpl(TokenConnector tokenConnector,
                             UserService userService,
                             OnboardingDao onboardingDao,
-                            InstitutionConnector institutionConnector) {
+                            InstitutionConnector institutionConnector,
+                            ContractService contractService) {
         this.tokenConnector = tokenConnector;
         this.userService = userService;
         this.onboardingDao = onboardingDao;
         this.institutionConnector = institutionConnector;
+        this.contractService = contractService;
     }
 
     @Override
@@ -110,5 +113,62 @@ public class TokenServiceImpl implements TokenService {
         log.debug("getTokensByProductId result = {}", tokens);
         log.trace("getTokensByProductId end");
         return tokens;
+    }
+
+    @Override
+    public PaginatedToken retrieveContractsFilterByStatus(List<RelationshipState> states, Integer page, Integer size) {
+        log.trace("getTokens start");
+        log.debug("getTokens states = {}, page = {}, size = {}", states, page, size);
+        Long totalNumber = tokenConnector.countAllTokenFilterByStates(states);
+        List<Token> tokensByStatusAndProduct = tokenConnector.findByStatusAndProductId(EnumSet.copyOf(states), null, page, size);
+        List<NotificationToSend> notificationToSends = tokensByStatusAndProduct.stream()
+                .map(token -> {
+                    Institution institution = retrieveRelatedInstitution(token.getInstitutionId());
+                    return toNotificationToSend(institution, token);
+                })
+                .toList();
+
+        log.debug("getTokens result = {}", notificationToSends);
+        log.trace("getTokens end");
+        return new PaginatedToken(notificationToSends, totalNumber);
+    }
+
+    private Institution retrieveRelatedInstitution(String institutionId) {
+        return institutionConnector.findById(institutionId);
+    }
+
+    public NotificationToSend toNotificationToSend(Institution institution, Token token) {
+        NotificationToSend notification = new NotificationToSend();
+        notification.setId(token.getId());
+        notification.setState(token.getStatus() == RelationshipState.DELETED ? "CLOSED" : token.getStatus().toString());
+        if (ACTIVE.equals(token.getStatus())) {
+            notification.setUpdatedAt(Optional.ofNullable(token.getActivatedAt()).orElse(token.getCreatedAt()));
+        } else {
+            notification.setUpdatedAt(Optional.ofNullable(token.getUpdatedAt()).orElse(token.getCreatedAt()));
+            if (token.getStatus().equals(RelationshipState.DELETED)) {
+                notification.setClosedAt(Optional.ofNullable(token.getDeletedAt()).orElse(token.getUpdatedAt()));
+                notification.setUpdatedAt(Optional.ofNullable(token.getDeletedAt()).orElse(token.getUpdatedAt()));
+            } else {
+                notification.setUpdatedAt(Optional.ofNullable(token.getUpdatedAt()).orElse(token.getCreatedAt()));
+            }
+        }
+        notification.setInternalIstitutionID(institution.getId());
+        notification.setProduct(token.getProductId());
+        notification.setFilePath(token.getContractSigned());
+        notification.setOnboardingTokenId(token.getId());
+        notification.setCreatedAt(Optional.ofNullable(token.getActivatedAt()).orElse(token.getCreatedAt()));
+        notification.setFileName(token.getContractSigned() == null ? "" : Paths.get(token.getContractSigned()).getFileName().toString());
+        notification.setContentType(token.getContentType() == null ? "" : token.getContentType());
+
+        if (token.getProductId() != null && institution.getOnboarding() != null) {
+            Onboarding onboarding = institution.getOnboarding().stream()
+                    .filter(o -> token.getProductId().equalsIgnoreCase(o.getProductId()))
+                    .findFirst().orElseThrow(() -> new InvalidRequestException(String.format("Product %s not found", token.getProductId()), "0000"));
+            notification.setPricingPlan(onboarding.getPricingPlan());
+            notification.setBilling(onboarding.getBilling() != null ? onboarding.getBilling() : institution.getBilling());
+            notification.setInstitution(contractService.toInstitutionToNotify(institution));
+        }
+
+        return notification;
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/TokenServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/TokenServiceImpl.java
@@ -152,23 +152,6 @@ public class TokenServiceImpl implements TokenService {
                 notification.setUpdatedAt(Optional.ofNullable(token.getUpdatedAt()).orElse(token.getCreatedAt()));
             }
         }
-        notification.setInternalIstitutionID(institution.getId());
-        notification.setProduct(token.getProductId());
-        notification.setFilePath(token.getContractSigned());
-        notification.setOnboardingTokenId(token.getId());
-        notification.setCreatedAt(Optional.ofNullable(token.getActivatedAt()).orElse(token.getCreatedAt()));
-        notification.setFileName(token.getContractSigned() == null ? "" : Paths.get(token.getContractSigned()).getFileName().toString());
-        notification.setContentType(token.getContentType() == null ? "" : token.getContentType());
-
-        if (token.getProductId() != null && institution.getOnboarding() != null) {
-            Onboarding onboarding = institution.getOnboarding().stream()
-                    .filter(o -> token.getProductId().equalsIgnoreCase(o.getProductId()))
-                    .findFirst().orElseThrow(() -> new InvalidRequestException(String.format("Product %s not found", token.getProductId()), "0000"));
-            notification.setPricingPlan(onboarding.getPricingPlan());
-            notification.setBilling(onboarding.getBilling() != null ? onboarding.getBilling() : institution.getBilling());
-            notification.setInstitution(contractService.toInstitutionToNotify(institution));
-        }
-
-        return notification;
+        return contractService.toNotificationToSend(notification, institution, token);
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/TokenServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/TokenServiceImplTest.java
@@ -5,6 +5,7 @@ import it.pagopa.selfcare.mscore.api.TokenConnector;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
 import it.pagopa.selfcare.mscore.model.InstitutionToNotify;
+import it.pagopa.selfcare.mscore.model.NotificationToSend;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.Onboarding;
 import it.pagopa.selfcare.mscore.model.onboarding.*;
@@ -273,7 +274,7 @@ class TokenServiceImplTest {
                 Mockito.<Integer>any(), Mockito.<Integer>any())).thenReturn(tokenList);
         when(tokenConnector.countAllTokenFilterByStates(List.of(RelationshipState.ACTIVE))).thenReturn(10L);
         when(institutionConnector.findById(Mockito.<String>any())).thenReturn(institution);
-        when(contractService.toInstitutionToNotify(institution)).thenReturn(institutionToNotify);
+        when(contractService.toNotificationToSend((NotificationToSend) any(),any(), any())).thenReturn(new NotificationToSend());
 
         // Assert
         PaginatedToken paginatedToken = tokenServiceImpl.retrieveContractsFilterByStatus(List.of(RelationshipState.ACTIVE), 0, 1);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
@@ -6,11 +6,14 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
 import it.pagopa.selfcare.mscore.constant.GenericError;
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.TokenService;
+import it.pagopa.selfcare.mscore.model.onboarding.PaginatedToken;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
 import it.pagopa.selfcare.mscore.model.onboarding.TokenRelationships;
-import it.pagopa.selfcare.mscore.web.model.mapper.TokenMapper;
 import it.pagopa.selfcare.mscore.web.model.onboarding.TokenListResponse;
+import it.pagopa.selfcare.mscore.web.model.token.PaginatedTokenResponse;
+import it.pagopa.selfcare.mscore.web.model.mapper.TokenMapper;
 import it.pagopa.selfcare.mscore.web.model.onboarding.TokenResponse;
 import it.pagopa.selfcare.mscore.web.model.token.TokenResource;
 import it.pagopa.selfcare.mscore.web.util.CustomExceptionMessage;
@@ -111,6 +114,39 @@ public class TokenController {
                         .collect(Collectors.toList()));
 
         log.trace("findFromProduct end");
+        return ResponseEntity.ok().body(tokenListResponse);
+    }
+
+    /**
+     * Retrieve Contract filter by Status
+     *
+     * @param states List<RelationshipState>
+     * @param page   Integer
+     * @param size   Integer
+     * @return List
+     * * Code: 200, Message: successful operation
+     * * Code: 404, Message: product not found
+     */
+    @Tag(name = "Token")
+    @ResponseStatus(HttpStatus.OK)
+    @ApiOperation(value = "${swagger.mscore.tokens.getAll}", notes = "${swagger.mscore.tokens.getAll}")
+    @GetMapping(value = "/tokens")
+    public ResponseEntity<PaginatedTokenResponse> getAllTokens(@ApiParam("${swagger.mscore.token.model.states}")
+                                                               @RequestParam(value = "states", defaultValue = "ACTIVE,DELETED") List<RelationshipState> states,
+                                                               @ApiParam("${swagger.mscore.page.number}")
+                                                               @RequestParam(name = "page", defaultValue = "0") Integer page,
+                                                               @ApiParam("${swagger.mscore.page.size}")
+                                                               @RequestParam(name = "size", defaultValue = "10") Integer size) {
+        log.trace("getAllToken start");
+        log.debug("getAllToken page = {}", page);
+        PaginatedToken tokens = tokenService.retrieveContractsFilterByStatus(states, page, size);
+
+        PaginatedTokenResponse tokenListResponse = new PaginatedTokenResponse(
+                tokens.getItems().stream()
+                        .map(tokenMapper::toScContractResponse)
+                        .toList(), tokens.getTotalNumber());
+
+        log.trace("getAllToken end");
         return ResponseEntity.ok().body(tokenListResponse);
     }
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/TokenController.java
@@ -136,7 +136,7 @@ public class TokenController {
                                                                @ApiParam("${swagger.mscore.page.number}")
                                                                @RequestParam(name = "page", defaultValue = "0") Integer page,
                                                                @ApiParam("${swagger.mscore.page.size}")
-                                                               @RequestParam(name = "size", defaultValue = "10") Integer size) {
+                                                               @RequestParam(name = "size", defaultValue = "100") Integer size) {
         log.trace("getAllToken start");
         log.debug("getAllToken page = {}", page);
         PaginatedToken tokens = tokenService.retrieveContractsFilterByStatus(states, page, size);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/TokenMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/TokenMapper.java
@@ -1,10 +1,12 @@
 package it.pagopa.selfcare.mscore.web.model.mapper;
 
+import it.pagopa.selfcare.mscore.model.NotificationToSend;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
 import it.pagopa.selfcare.mscore.model.onboarding.TokenRelationships;
 import it.pagopa.selfcare.mscore.web.model.onboarding.LegalsResponse;
 import it.pagopa.selfcare.mscore.web.model.onboarding.TokenResponse;
+import it.pagopa.selfcare.mscore.web.model.token.ScContractResponse;
 import it.pagopa.selfcare.mscore.web.model.token.TokenResource;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -22,6 +24,9 @@ public interface TokenMapper {
     TokenResponse toTokenResponse(TokenRelationships tokenRelationships);
 
     TokenResource toTokenResponse(Token token);
+
+    ScContractResponse toScContractResponse(NotificationToSend notification);
+
     @Named("toLegalsResponse")
     default List<LegalsResponse> toLegalsResponse( TokenRelationships tokenRelationships){
         List<LegalsResponse> legalsResponses = new ArrayList<>();

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/InstitutionToNotifyResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/InstitutionToNotifyResponse.java
@@ -1,0 +1,33 @@
+package it.pagopa.selfcare.mscore.web.model.token;
+
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.mscore.model.RootParent;
+import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InstitutionToNotifyResponse {
+
+    private InstitutionType institutionType;
+    private String description;
+    private String digitalAddress;
+    private String address;
+    private String taxCode;
+    private String origin;
+    private String originId;
+    private String zipCode;
+    private PaymentServiceProvider paymentServiceProvider;
+    private String istatCode;
+    private String city;
+    private String country;
+    private String county;
+    private String subUnitCode;
+    private String category;
+    private String subUnitType;
+    private RootParent rootParent;
+
+}

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/PaginatedTokenResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/PaginatedTokenResponse.java
@@ -1,0 +1,15 @@
+package it.pagopa.selfcare.mscore.web.model.token;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PaginatedTokenResponse {
+    private List<ScContractResponse> items;
+    private Long totalNumber;
+}

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/ScContractResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/token/ScContractResponse.java
@@ -1,0 +1,30 @@
+package it.pagopa.selfcare.mscore.web.model.token;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import it.pagopa.selfcare.mscore.model.QueueEvent;
+import it.pagopa.selfcare.mscore.web.model.institution.BillingResponse;
+import lombok.Data;
+
+import java.time.OffsetDateTime;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ScContractResponse {
+
+    private String id;
+    private String internalIstitutionID;
+    private String product;
+    private String state;
+    private String filePath;
+    private String fileName;
+    private String contentType;
+    private String onboardingTokenId;
+    private String pricingPlan;
+    private InstitutionToNotifyResponse institution;
+    private BillingResponse billing;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime closedAt;
+    private OffsetDateTime updatedAt;
+    private QueueEvent notificationType;
+
+}


### PR DESCRIPTION
**List of Changes**

- Added API to retrieve all contract to send to DataLake

**Motivation and Context**

This API has been developed in order to retrieve all contract sent on sc-contract topic

**How Has This Been Tested?**

Called api GET /tokens in TokenController in local env

