### PR TITLE
[SELC-1891] - feature: Changed data overwriting verification logic in onboarding api

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtils.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtils.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.core.util;
 
 import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
+import it.pagopa.selfcare.commons.base.utils.Origin;
 import it.pagopa.selfcare.mscore.constant.CustomError;
 import it.pagopa.selfcare.mscore.constant.Env;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
@@ -55,12 +56,14 @@ public class OnboardingInstitutionUtils {
 
     public static void validateOverridingData(InstitutionUpdate institutionUpdate, Institution institution) {
         log.info("START - validateOverridingData for institution having externalId: {}", institution.getExternalId());
-        if (InstitutionType.PA == institutionUpdate.getInstitutionType()
+        if (Origin.IPA.getValue().equals(institution.getOrigin())
                 && (!validateParameter(institution.getDescription(), institutionUpdate.getDescription())
                 || !validateParameter(institution.getTaxCode(), institutionUpdate.getTaxCode())
                 || !validateParameter(institution.getDigitalAddress(), institutionUpdate.getDigitalAddress())
                 || !validateParameter(institution.getZipCode(), institutionUpdate.getZipCode())
                 || !validateParameter(institution.getAddress(), institutionUpdate.getAddress()))) {
+            throw new InvalidRequestException(String.format(ONBOARDING_INVALID_UPDATES.getMessage(), institution.getExternalId()), ONBOARDING_INVALID_UPDATES.getCode());
+        } else if (!validateParameter(institution.getDigitalAddress(), institutionUpdate.getDigitalAddress())) {
             throw new InvalidRequestException(String.format(ONBOARDING_INVALID_UPDATES.getMessage(), institution.getExternalId()), ONBOARDING_INVALID_UPDATES.getCode());
         }
         log.info("END - validateOverridingData without error");

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -268,6 +268,7 @@ class OnboardingInstitutionStrategyTest {
 
         Institution institution = new Institution();
         institution.setInstitutionType(InstitutionType.SA);
+        institution.setDigitalAddress(institutionUpdate.getDigitalAddress());
 
         Billing billing = TestUtils.createSimpleBilling();
         Contract contract = TestUtils.createSimpleContract();
@@ -298,8 +299,9 @@ class OnboardingInstitutionStrategyTest {
      * Method under test: {@link OnboardingServiceImpl#onboardingInstitution(OnboardingRequest, SelfCareUser)}
      */
     @Test
-    void testOnboardingInstitutionGSP() throws IOException {
+    void testOnboardingInstitutionGSP() {
 
+        InstitutionUpdate institutionUpdate1 = TestUtils.createDummyInstitutionUpdateGSP();
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -308,14 +310,15 @@ class OnboardingInstitutionStrategyTest {
         billing.setVatNumber("42");
 
         Institution institution = new Institution();
-        institution.setOrigin("IPA");
+        institution.setOrigin("SELC");
         institution.setBilling(billing);
         institution.setInstitutionType(InstitutionType.GSP);
+        institution.setDigitalAddress(institutionUpdate1.getDigitalAddress());
 
         Billing billing1 = TestUtils.createSimpleBilling();
         Contract contract = TestUtils.createSimpleContract();
 
-        InstitutionUpdate institutionUpdate1 = TestUtils.createDummyInstitutionUpdateGSP();
+
 
         OnboardingRequest onboardingRequest = TestUtils.dummyOnboardingRequest();
         onboardingRequest.setBillingRequest(billing1);
@@ -341,25 +344,9 @@ class OnboardingInstitutionStrategyTest {
      *Method under test: {@link OnboardingServiceImpl#onboardingInstitution(OnboardingRequest, SelfCareUser)}
      */
     @Test
-    void testOnboardingInstitutionGSP2() throws IOException {
+    void testOnboardingInstitutionGSP2() {
+        InstitutionUpdate institutionUpdate1 = TestUtils.createDummyInstitutionUpdateGSP();
 
-        InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
-
-        Token token = new Token();
-        token.setChecksum("Checksum");
-        token.setDeletedAt(null);
-        token.setContractSigned("Contract Signed");
-        token.setContractTemplate("Contract Template");
-        token.setCreatedAt(null);
-        token.setExpiringDate(null);
-        token.setId("42");
-        token.setInstitutionId("42");
-        token.setInstitutionUpdate(institutionUpdate);
-        token.setProductId(PROD_INTEROP.getValue());
-        token.setStatus(RelationshipState.PENDING);
-        token.setType(TokenType.INSTITUTION);
-        token.setUpdatedAt(null);
-        token.setUsers(new ArrayList<>());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -368,14 +355,14 @@ class OnboardingInstitutionStrategyTest {
         billing.setVatNumber("42");
 
         Institution institution = new Institution();
-        institution.setOrigin("IPA");
+        institution.setOrigin("SELC");
         institution.setBilling(billing);
         institution.setInstitutionType(InstitutionType.GSP);
+        institution.setDigitalAddress(institutionUpdate1.getDigitalAddress());
 
         Billing billing1 = TestUtils.createSimpleBilling();
         Contract contract = TestUtils.createSimpleContract();
 
-        InstitutionUpdate institutionUpdate1 = TestUtils.createDummyInstitutionUpdateGSP();
 
         OnboardingRequest onboardingRequest = new OnboardingRequest();
         onboardingRequest.setBillingRequest(billing1);
@@ -397,8 +384,6 @@ class OnboardingInstitutionStrategyTest {
         onboardingRollback.setToken(token1);
         when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
         when(onboardingDao.persist(any(), any(), any(), any(), any(), any())).thenReturn(onboardingRollback);
-        when(contractService.extractTemplate(any())).thenReturn("template");
-        when(contractService.createContractPDF(any(), any(), any(), any(), any(), any(), any())).thenReturn(File.createTempFile("file",".txt"));
 
         assertDoesNotThrow(() -> strategyFactory.retrieveOnboardingInstitutionStrategy(InstitutionType.GSP, onboardingRequest.getProductId(), institution)
                 .onboardingInstitution(onboardingRequest, mock(SelfCareUser.class)));
@@ -492,7 +477,7 @@ class OnboardingInstitutionStrategyTest {
      */
     @Test
     void testOnboardingInstitutionPT() {
-
+        InstitutionUpdate institutionUpdate1 = TestUtils.createSimpleInstitutionUpdate();
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -501,14 +486,14 @@ class OnboardingInstitutionStrategyTest {
         billing.setVatNumber("42");
 
         Institution institution = new Institution();
-        institution.setOrigin("IPA");
+        institution.setOrigin("SELC");
         institution.setBilling(billing);
         institution.setInstitutionType(InstitutionType.PT);
+        institution.setDigitalAddress(institutionUpdate1.getDigitalAddress());
 
         Billing billing1 = TestUtils.createSimpleBilling();
         Contract contract = TestUtils.createSimpleContract();
 
-        InstitutionUpdate institutionUpdate1 = TestUtils.createSimpleInstitutionUpdate();
         institutionUpdate1.setInstitutionType(InstitutionType.PT);
 
         OnboardingRequest onboardingRequest = TestUtils.dummyOnboardingRequest();

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -464,7 +464,11 @@ class OnboardingInstitutionStrategyTest {
 
         Institution institution = new Institution();
         institution.setExternalId("externalId");
+        institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.GSP);
+        institution.setDescription(institutionUpdate.getDescription());
+        institution.setDigitalAddress(institutionUpdate.getDigitalAddress());
+        institution.setTaxCode(institutionUpdate.getTaxCode());
 
         assertThrows(InvalidRequestException.class,
                 () -> strategyFactory.retrieveOnboardingInstitutionStrategy(institutionUpdate.getInstitutionType(), onboardingRequest.getProductId(), institution)
@@ -585,21 +589,6 @@ class OnboardingInstitutionStrategyTest {
 
         InstitutionUpdate institutionUpdate = TestUtils.createSimpleInstitutionUpdate();
 
-        Token token = new Token();
-        token.setChecksum("Checksum");
-        token.setDeletedAt(null);
-        token.setContractSigned("Contract Signed");
-        token.setContractTemplate("Contract Template");
-        token.setCreatedAt(null);
-        token.setExpiringDate(null);
-        token.setId("42");
-        token.setInstitutionId("42");
-        token.setInstitutionUpdate(institutionUpdate);
-        token.setProductId(PROD_INTEROP.getValue());
-        token.setStatus(RelationshipState.PENDING);
-        token.setType(TokenType.INSTITUTION);
-        token.setUpdatedAt(null);
-        token.setUsers(new ArrayList<>());
 
         Billing billing = new Billing();
         billing.setPublicServices(true);
@@ -608,20 +597,22 @@ class OnboardingInstitutionStrategyTest {
         billing.setVatNumber("42");
 
         Institution institution = new Institution();
-        institution.setOrigin("selc");
+        institution.setOrigin("IPA");
         institution.setInstitutionType(InstitutionType.PA);
+        institution.setDescription(institutionUpdate.getDescription());
+        institution.setAddress(institutionUpdate.getAddress());
+        institution.setDigitalAddress(institutionUpdate.getDigitalAddress());
+        institution.setZipCode(institutionUpdate.getZipCode());
+        institution.setTaxCode(institutionUpdate.getTaxCode());
 
         Billing billing1 = TestUtils.createSimpleBilling();
         Contract contract = TestUtils.createSimpleContract();
-
-        InstitutionUpdate institutionUpdate1 = new InstitutionUpdate();
-        institutionUpdate1.setInstitutionType(InstitutionType.PA);
 
         OnboardingRequest onboardingRequest = new OnboardingRequest();
         onboardingRequest.setBillingRequest(billing1);
         onboardingRequest.setContract(contract);
         onboardingRequest.setInstitutionExternalId("42");
-        onboardingRequest.setInstitutionUpdate(institutionUpdate1);
+        onboardingRequest.setInstitutionUpdate(institutionUpdate);
         onboardingRequest.setPricingPlan("Pricing Plan");
         onboardingRequest.setProductId(PROD_INTEROP.getValue());
         onboardingRequest.setProductName("Product Name");

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtilsTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/OnboardingInstitutionUtilsTest.java
@@ -980,98 +980,78 @@ class OnboardingInstitutionUtilsTest {
     }
 
     /**
-     * Method under test: {@link OnboardingInstitutionUtils#validateOverridingData(InstitutionUpdate, Institution)}
+     * Method under test:
+     * {@link OnboardingInstitutionUtils#validateOverridingData(InstitutionUpdate, Institution)}
      */
     @Test
-    void testValidateOverridingData2() {
-        DataProtectionOfficer dataProtectionOfficer = new DataProtectionOfficer();
-        dataProtectionOfficer.setAddress("42 Main St");
-        dataProtectionOfficer.setEmail("jane.doe@example.org");
-        dataProtectionOfficer.setPec("Pec");
-
-        PaymentServiceProvider paymentServiceProvider = new PaymentServiceProvider();
-        paymentServiceProvider.setAbiCode("Abi Code");
-        paymentServiceProvider.setBusinessRegisterNumber("42");
-        paymentServiceProvider.setLegalRegisterName("Legal Register Name");
-        paymentServiceProvider.setLegalRegisterNumber("42");
-        paymentServiceProvider.setVatNumberGroup(true);
-
+    void testValidateOverridingData() {
         InstitutionUpdate institutionUpdate = new InstitutionUpdate();
         institutionUpdate.setAddress("42 Main St");
         institutionUpdate.setBusinessRegisterPlace("Business Register Place");
-        institutionUpdate.setDataProtectionOfficer(dataProtectionOfficer);
+        institutionUpdate.setCity("Oxford");
+        institutionUpdate.setCountry("GB");
+        institutionUpdate.setCounty("3");
+        institutionUpdate.setDataProtectionOfficer(new DataProtectionOfficer("42 Main St", "jane.doe@example.org", "Pec"));
         institutionUpdate.setDescription("The characteristics of someone or something");
         institutionUpdate.setDigitalAddress("42 Main St");
         institutionUpdate.setGeographicTaxonomies(new ArrayList<>());
+        institutionUpdate.setImported(true);
         institutionUpdate.setInstitutionType(InstitutionType.PA);
-        institutionUpdate.setPaymentServiceProvider(paymentServiceProvider);
+        institutionUpdate.setIvassCode("Ivass Code");
+        institutionUpdate
+                .setPaymentServiceProvider(new PaymentServiceProvider("Abi Code", "42", "Legal Register Name", "42", true));
         institutionUpdate.setRea("Rea");
         institutionUpdate.setShareCapital("Share Capital");
         institutionUpdate.setSupportEmail("jane.doe@example.org");
-        institutionUpdate.setSupportPhone("4105551212");
+        institutionUpdate.setSupportPhone("6625550144");
         institutionUpdate.setTaxCode("Tax Code");
         institutionUpdate.setZipCode("21654");
 
-        Institution institution = dummyInstitutionPa();
-
         assertThrows(InvalidRequestException.class,
-                () -> OnboardingInstitutionUtils.validateOverridingData(institutionUpdate, institution));
+                () -> OnboardingInstitutionUtils.validateOverridingData(institutionUpdate, new Institution()));
     }
 
     /**
-     * Method under test: {@link OnboardingInstitutionUtils#validateOverridingData(InstitutionUpdate, Institution)}
+     * Method under test:
+     * {@link OnboardingInstitutionUtils#validateOverridingData(InstitutionUpdate, Institution)}
      */
     @Test
-    void testValidateOverridingData5() {
-        DataProtectionOfficer dataProtectionOfficer = new DataProtectionOfficer();
-        dataProtectionOfficer.setAddress("42 Main St");
-        dataProtectionOfficer.setEmail("jane.doe@example.org");
-        dataProtectionOfficer.setPec("Pec");
-
-        PaymentServiceProvider paymentServiceProvider = new PaymentServiceProvider();
-        paymentServiceProvider.setAbiCode("Abi Code");
-        paymentServiceProvider.setBusinessRegisterNumber("42");
-        paymentServiceProvider.setLegalRegisterName("Legal Register Name");
-        paymentServiceProvider.setLegalRegisterNumber("42");
-        paymentServiceProvider.setVatNumberGroup(true);
-
+    void testValidateOverridingData2() {
         InstitutionUpdate institutionUpdate = new InstitutionUpdate();
-        institutionUpdate.setAddress("42 Main St");
         institutionUpdate.setBusinessRegisterPlace("Business Register Place");
+        institutionUpdate.setCity("Oxford");
+        institutionUpdate.setCountry("GB");
+        institutionUpdate.setCounty("3");
+        DataProtectionOfficer dataProtectionOfficer = new DataProtectionOfficer("42 Main St", "jane.doe@example.org",
+                "Pec");
+
         institutionUpdate.setDataProtectionOfficer(dataProtectionOfficer);
-        institutionUpdate.setDescription("START - validateOverridingData for institution having externalId: {}");
-        institutionUpdate.setDigitalAddress("42 Main St");
         institutionUpdate.setGeographicTaxonomies(new ArrayList<>());
+        institutionUpdate.setImported(true);
         institutionUpdate.setInstitutionType(InstitutionType.PA);
+        institutionUpdate.setIvassCode("Ivass Code");
+        PaymentServiceProvider paymentServiceProvider = new PaymentServiceProvider("Abi Code", "42", "Legal Register Name",
+                "42", true);
+
         institutionUpdate.setPaymentServiceProvider(paymentServiceProvider);
         institutionUpdate.setRea("Rea");
         institutionUpdate.setShareCapital("Share Capital");
         institutionUpdate.setSupportEmail("jane.doe@example.org");
-        institutionUpdate.setSupportPhone("4105551212");
-        institutionUpdate.setTaxCode("Tax Code");
-        institutionUpdate.setZipCode("21654");
+        institutionUpdate.setSupportPhone("6625550144");
+        institutionUpdate.setZipCode(null);
+        institutionUpdate.setAddress("via del corso");
 
-        Institution institution = dummyInstitutionPa();
+        Institution institution = new Institution();
+        institution.setOrigin("IPA");
+        institution.setZipCode(null);
+        institution.setExternalId("42");
+        institution.setAddress("via roma");
+        institution.setDigitalAddress(null);
+        institution.setDescription(null);
+        institution.setTaxCode(null);
 
         assertThrows(InvalidRequestException.class,
                 () -> OnboardingInstitutionUtils.validateOverridingData(institutionUpdate, institution));
-    }
-
-    /**
-     * Method under test: {@link OnboardingInstitutionUtils#validateOverridingData(InstitutionUpdate, Institution)}
-     */
-    @Test
-    void testValidateOverridingData6() {
-        Institution institution = dummyInstitutionPa();
-
-        InstitutionUpdate institutionUpdate = new InstitutionUpdate();
-        institutionUpdate.setDescription(institution.getDescription());
-        institutionUpdate.setDigitalAddress(institution.getDigitalAddress());
-        institutionUpdate.setGeographicTaxonomies(new ArrayList<>());
-        institutionUpdate.setInstitutionType(institution.getInstitutionType());
-
-
-        OnboardingInstitutionUtils.validateOverridingData(institutionUpdate, institution);
     }
 
 


### PR DESCRIPTION
#### List of Changes

The control logic that prevents overwriting of master data that was previously performed only for PA institutions is now performed for all institutions with IPA origin. While for institutions with other origins, it is checked that the digitalAddress field has not been overwritten

#### Motivation and Context

It was decided to extend the check for PA institutions to all Institutions present on IPA, to prevent overwriting of certified data

#### How Has This Been Tested?

Local environment
