### PR TITLE
[SELC-3700] Feat: Added api to update user binding status

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -5276,6 +5276,109 @@
         } ]
       }
     },
+    "/users/{id}/status" : {
+      "put" : {
+        "tags" : [ "support" ],
+        "summary" : "Update user status with optional filter for institution, product, role and productRole",
+        "description" : "Update user status with optional filter for institution, product, role and productRole",
+        "operationId" : "updateUserStatusUsingPUT",
+        "parameters" : [ {
+          "name" : "id",
+          "in" : "path",
+          "description" : "User's unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "institutionId",
+          "in" : "query",
+          "description" : "The internal identifier of the institution",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "description" : "Product's unique identifier",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "role",
+          "in" : "query",
+          "description" : "role",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "DELEGATE", "MANAGER", "OPERATOR", "SUB_DELEGATE" ]
+          }
+        }, {
+          "name" : "productRole",
+          "in" : "query",
+          "description" : "productRole",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "status",
+          "in" : "query",
+          "description" : "status",
+          "required" : true,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ACTIVE", "DELETED", "PENDING", "REJECTED", "SUSPENDED", "TOBEVALIDATED" ]
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/users/{id}/update" : {
       "post" : {
         "tags" : [ "Persons" ],

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/UserConnector.java
@@ -35,7 +35,7 @@ public interface UserConnector {
      */
     void findAndUpdateState(String userId, @Nullable String relationshipId, @Nullable Token token, RelationshipState state);
 
-    void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state);
+    void findAndUpdateStateWithOptionalFilter(String userId, String institutionId, String productId, PartyRole role, String productRole, RelationshipState state);
 
     void findAndUpdate(OnboardedUser onboardedUser, String id, String institutionId, OnboardedProduct product, UserBinding bindings);
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/CustomError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/CustomError.java
@@ -38,7 +38,13 @@ public enum CustomError {
     MISSING_QUERY_PARAMETER("0045", "At least one query parameter between [userId, institutionId] must be passed"),
     RELATIONSHIP_NOT_FOUND("0008", "Relationship not found for Institution %s, User %s and Role %s"),
     CREATE_DELEGATION_CONFLICT("0041", "Delegation with parameters [from, to, productId, type] already exists"),
-    INSTITUTION_NOT_FOUND_IN_REGISTRY("0042", "NOT_FOUND_IN_REGISTRY");
+    INSTITUTION_NOT_FOUND_IN_REGISTRY("0042", "NOT_FOUND_IN_REGISTRY"),
+    ROLE_NOT_FOUND("0000", "ROLE_NOT_FOUND"),
+    ROLE_IS_NULL("0000", "ROLE_IS_NULL - Role is required if productRole is present"),
+
+    PRODUCT_ROLE_NOT_FOUND("0000", "PRODUCT_ROLE_NOT_FOUND");
+
+
 
     private final String code;
     private final String detail;

--- a/connector/dao/pom.xml
+++ b/connector/dao/pom.xml
@@ -20,6 +20,10 @@
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>it.pagopa.selfcare</groupId>
+            <artifactId>selc-ms-core-connector-rest</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImplTest.java
@@ -10,6 +10,7 @@ import it.pagopa.selfcare.mscore.connector.dao.model.inner.OnboardedProductEntit
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.OnboardingEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.inner.UserBindingEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.*;
+import it.pagopa.selfcare.mscore.connector.rest.client.ProductsRestClient;
 import it.pagopa.selfcare.mscore.constant.Env;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
@@ -20,6 +21,8 @@ import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedProduct;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardedUser;
 import it.pagopa.selfcare.mscore.model.onboarding.Token;
+import it.pagopa.selfcare.mscore.model.product.Product;
+import it.pagopa.selfcare.mscore.model.product.ProductRoleInfo;
 import it.pagopa.selfcare.mscore.model.user.UserBinding;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,7 @@ import org.springframework.data.mongodb.core.query.Update;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,6 +59,9 @@ class UserConnectorImplTest {
 
     @Spy
     private UserEntityMapper userMapper = new UserEntityMapperImpl();
+
+    @Mock
+    private ProductsRestClient productsRestClient;
 
     @Spy
     private OnboardedProductMapper productMapper = new OnboardedProductMapperImpl();
@@ -690,8 +697,51 @@ class UserConnectorImplTest {
     void findAndUpdateStateByInstitutionAndProduct() {
         when(userRepository.findAndModify(any(), any(), any(), any()))
                 .thenReturn(new UserEntity());
-        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateByInstitutionAndProduct("42", "42", "productId", RelationshipState.PENDING));
+        Product product = mock(Product.class);
+        EnumMap<PartyRole, ProductRoleInfo> map = mock(EnumMap.class);
+        ProductRoleInfo productRoleInfo = mock(ProductRoleInfo.class);
+        ProductRoleInfo.ProductRole productRole = mock(ProductRoleInfo.ProductRole.class);
+        when(productRole.getCode()).thenReturn("productRole");
+        when(productRoleInfo.getRoles()).thenReturn(List.of(productRole));
+        when(map.get(PartyRole.DELEGATE)).thenReturn(productRoleInfo);
+        when(product.getRoleMappings()).thenReturn(map);
+
+        when(productsRestClient.getProductById(anyString(), any())).thenReturn(product);
+        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateWithOptionalFilter("42", "42", "productId", PartyRole.DELEGATE, "productRole", RelationshipState.PENDING));
     }
+
+    @Test
+    void findAndUpdateStateByInstitutionId() {
+        when(userRepository.findAndModify(any(), any(), any(), any()))
+                .thenReturn(new UserEntity());
+        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateWithOptionalFilter("42", "42", null, null, null, RelationshipState.PENDING));
+    }
+
+    @Test
+    void findAndUpdateStateByProductId() {
+        when(userRepository.findAndModify(any(), any(), any(), any()))
+                .thenReturn(new UserEntity());
+        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateWithOptionalFilter("42", null, "productId", null, null, RelationshipState.PENDING));
+    }
+
+    @Test
+    void findAndUpdateStateWithoutFilter() {
+        when(userRepository.findAndModify(any(), any(), any(), any()))
+                .thenReturn(new UserEntity());
+        Product product = mock(Product.class);
+        EnumMap<PartyRole, ProductRoleInfo> map = mock(EnumMap.class);
+        ProductRoleInfo productRoleInfo = mock(ProductRoleInfo.class);
+        ProductRoleInfo.ProductRole productRole = mock(ProductRoleInfo.ProductRole.class);
+        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateWithOptionalFilter("42", null, null, null, null, RelationshipState.PENDING));
+    }
+
+    @Test
+    void findAndUpdateStateByInstitutionAndProductWithoutProductRole() {
+        when(userRepository.findAndModify(any(), any(), any(), any()))
+                .thenReturn(new UserEntity());
+        Assertions.assertDoesNotThrow(() -> userConnectorImpl.findAndUpdateStateWithOptionalFilter("42", "42", "productId", PartyRole.DELEGATE, null, RelationshipState.PENDING));
+    }
+
 
     @Test
     void testFindAndUpdate() {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserService.java
@@ -43,9 +43,9 @@ public interface UserService {
 
     List<UserInstitutionAggregation> findUserInstitutionAggregation(UserInstitutionFilter filter);
 
-    void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state);
-
     User retrievePerson(String userId, String productId, String institutionId);
 
     List<OnboardingInfo> getUserInfo(String userId, String institutionId, String[] states);
+
+    void updateUserStatus(String userId, String institutionId, String productId, PartyRole role, String productRole, RelationshipState status);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserServiceImpl.java
@@ -155,8 +155,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void findAndUpdateStateByInstitutionAndProduct(String userId, String institutionId, String productId, RelationshipState state) {
-        userConnector.findAndUpdateStateByInstitutionAndProduct(userId, institutionId, productId, state);
+    public void updateUserStatus(String userId, String institutionId, String productId, PartyRole role, String productRole, RelationshipState status) {
+        userConnector.findAndUpdateStateWithOptionalFilter(userId, institutionId, productId, role, productRole, status);
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/UserServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/UserServiceImplTest.java
@@ -400,11 +400,11 @@ class UserServiceImplTest {
     }
 
     @Test
-    void findAndUpdateStateByInstitutionAndProduct() {
+    void updateUserStatus() {
 
-        doNothing().when(userConnector).findAndUpdateStateByInstitutionAndProduct(anyString(),anyString(),anyString(),any());
+        doNothing().when(userConnector).findAndUpdateStateWithOptionalFilter(anyString(),anyString(),anyString(), eq(null), anyString(), any());
         Assertions.assertDoesNotThrow(() -> userServiceImpl
-                .findAndUpdateStateByInstitutionAndProduct("userId","institutionId","productId",RelationshipState.DELETED));
+                .updateUserStatus("userId","institutionId","productId",null, "", RelationshipState.DELETED));
     }
 
     @Test

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -322,15 +322,16 @@ public class UserController {
      * * Code: 400, Message: Bad Request, DataType: Problem
      * * Code: 404, Message: Not Found, DataType: Problem
      */
+    @Tag(name = "support")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiOperation(value = "${swagger.mscore.api.users.updateUserStatus}", notes = "${swagger.mscore.api.users.updateUserStatus}")
     @PutMapping(value = "/users/{id}/status")
     public ResponseEntity<Void> updateUserStatus(@ApiParam(value = "${swagger.mscore.users.userId}", required = true) @PathVariable(value = "id") String userId,
                                                  @ApiParam(value = "${swagger.mscore.institutions.model.institutionId}") @RequestParam(value = "institutionId", required = false) String institutionId,
                                                  @ApiParam(value = "${swagger.mscore.institutions.model.productId}") @RequestParam(value = "productId", required = false) String productId,
-                                                 @ApiParam(value = "${swagger.mscore.institutions.model.role}") @RequestParam(value = "role", required = false) PartyRole role,
-                                                 @ApiParam(value = "${swagger.mscore.institutions.model.productRole}") @RequestParam(value = "productRole", required = false) String productRole,
-                                                 @ApiParam(value = "${swagger.mscore..model.relationshipState}", required = true) @RequestParam(value = "status") RelationshipState status) {
+                                                 @RequestParam(value = "role", required = false) PartyRole role,
+                                                 @RequestParam(value = "productRole", required = false) String productRole,
+                                                 @ApiParam(required = true) @RequestParam(value = "status") RelationshipState status) {
         log.debug("updateProductStatus - userId: {}", userId);
         userService.updateUserStatus(userId, institutionId, productId, role, productRole, status);
         return ResponseEntity.noContent().build();

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/UserController.java
@@ -5,6 +5,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.tags.Tags;
+import it.pagopa.selfcare.commons.base.security.PartyRole;
 import it.pagopa.selfcare.commons.base.security.SelfCareUser;
 import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
@@ -227,7 +228,7 @@ public class UserController {
                                                @ApiParam("${swagger.mscore.institutions.model.productId}")
                                                @PathVariable(value = "productId") String productId) {
 
-        userService.findAndUpdateStateByInstitutionAndProduct(userId, institutionId, productId, RelationshipState.DELETED);
+        userService.updateUserStatus(userId, institutionId, productId, null, null, RelationshipState.DELETED);
         return ResponseEntity.ok().build();
     }
 
@@ -304,5 +305,34 @@ public class UserController {
                 .map(userMapper::toUserNotification)
                 .collect(Collectors.toList()));
         return ResponseEntity.ok(userNotificationResponse);
+    }
+
+    /**
+     * Update user status and send notification to DL.
+     *
+     * @param userId        User's unique identifier.
+     * @param institutionId User's institution identifier.
+     * @param productId     User's product identifier.
+     * @param role          User's role.
+     * @param productRole   Product's role.
+     * @param status        User's status.
+     * @return ResponseEntity<Void>
+     * <p>
+     * * Code: 204, Message: Update successful, DataType: No Content
+     * * Code: 400, Message: Bad Request, DataType: Problem
+     * * Code: 404, Message: Not Found, DataType: Problem
+     */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "${swagger.mscore.api.users.updateUserStatus}", notes = "${swagger.mscore.api.users.updateUserStatus}")
+    @PutMapping(value = "/users/{id}/status")
+    public ResponseEntity<Void> updateUserStatus(@ApiParam(value = "${swagger.mscore.users.userId}", required = true) @PathVariable(value = "id") String userId,
+                                                 @ApiParam(value = "${swagger.mscore.institutions.model.institutionId}") @RequestParam(value = "institutionId", required = false) String institutionId,
+                                                 @ApiParam(value = "${swagger.mscore.institutions.model.productId}") @RequestParam(value = "productId", required = false) String productId,
+                                                 @ApiParam(value = "${swagger.mscore.institutions.model.role}") @RequestParam(value = "role", required = false) PartyRole role,
+                                                 @ApiParam(value = "${swagger.mscore.institutions.model.productRole}") @RequestParam(value = "productRole", required = false) String productRole,
+                                                 @ApiParam(value = "${swagger.mscore..model.relationshipState}", required = true) @RequestParam(value = "status") RelationshipState status) {
+        log.debug("updateProductStatus - userId: {}", userId);
+        userService.updateUserStatus(userId, institutionId, productId, role, productRole, status);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -78,6 +78,7 @@ swagger.mscore.delegation.createFromTaxCode=Create an association between instit
 swagger.mscore.users.products=Retrieves products info and role which the user is enabled
 swagger.mscore.users=Retrieves user given userId and optional ProductId
 swagger.mscore.users.delete.products=Delete logically the association institution and product
+swagger.mscore.api.users.updateUserStatus=Update user status with optional filter for institution, product, role and productRole
 swagger.mscore.institutions.delegations=Retrieve institution's delegations
 swagger.mscore.institutions.delegations.mode=Mode (full or normal) to retreieve institution's delegations
 swagger.mscore.institutions.brokers=Retrieve institution brokers

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/UserControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/UserControllerTest.java
@@ -469,7 +469,7 @@ class UserControllerTest {
         final String institutionId = "institutionId";
         final String productId = "productId";
 
-        doNothing().when(userService).findAndUpdateStateByInstitutionAndProduct(userId, institutionId, productId, RelationshipState.DELETED);
+        doNothing().when(userService).updateUserStatus(userId, institutionId, productId, null, null, RelationshipState.DELETED);
 
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                 .delete("/users/{userId}/institutions/{institutionId}/products/{productId}", userId, institutionId, productId)
@@ -630,6 +630,23 @@ class UserControllerTest {
         Assertions.assertEquals("prod-io", response.getUsers().get(0).getProductId());
         Assertions.assertEquals("institutionId", response.getUsers().get(0).getInstitutionId());
 
+    }
+
+    @Test
+    void updateUserStatus() throws Exception {
+        final String userId = "userId";
+
+        doNothing().when(userService).updateUserStatus(userId, null, null, null, null, RelationshipState.DELETED);
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .put("/users/{id}/status", userId)
+                .queryParam("status","DELETED")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        MockMvcBuilders.standaloneSetup(userController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isNoContent());
     }
 
 }


### PR DESCRIPTION
#### List of Changes

Added api to update user binding status

#### Motivation and Context

an API is needed to update the status of a specific binding to satisfy the need, for example, to change the manager of an institution

#### How Has This Been Tested?

Started ms locally and called new API /users/{id}/status. 
