### PR TITLE
[SELC-3791] fix: change field name ipa and agentOfPublicService

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/AdditionalInformations.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/AdditionalInformations.java
@@ -6,11 +6,11 @@ import lombok.Data;
 public class AdditionalInformations {
     private boolean belongRegulatedMarket;
     private String regulatedMarketNote;
-    private boolean isIpa;
+    private boolean ipa;
     private String ipaCode;
     private boolean establishedByRegulatoryProvision;
     private String establishedByRegulatoryProvisionNote;
-    private boolean isAgentOfPublicService;
+    private boolean agentOfPublicService;
     private String agentOfPublicServiceNote;
     private String otherNote;
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/inner/AdditionalInformationsEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/inner/AdditionalInformationsEntity.java
@@ -8,11 +8,11 @@ import lombok.experimental.FieldNameConstants;
 public class AdditionalInformationsEntity {
     private boolean belongRegulatedMarket;
     private String regulatedMarketNote;
-    private boolean isIpa;
+    private boolean ipa;
     private String ipaCode;
     private boolean establishedByRegulatoryProvision;
     private String establishedByRegulatoryProvisionNote;
-    private boolean isAgentOfPublicService;
+    private boolean agentOfPublicService;
     private String agentOfPublicServiceNote;
     private String otherNote;
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/AdditionalInformationsRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/AdditionalInformationsRequest.java
@@ -6,11 +6,11 @@ import lombok.Data;
 public class AdditionalInformationsRequest {
     private boolean belongRegulatedMarket;
     private String regulatedMarketNote;
-    private boolean isIpa;
+    private boolean ipa;
     private String ipaCode;
     private boolean establishedByRegulatoryProvision;
     private String establishedByRegulatoryProvisionNote;
-    private boolean isAgentOfPublicService;
+    private boolean agentOfPublicService;
     private String agentOfPublicServiceNote;
     private String otherNote;
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- change isAgentOfPublicService and isIpa to agentOfPublicService and ipa 

<!--- Describe your changes in detail -->

#### Motivation and Context
The mentioned fields names ("isIpa" and "isAgentOfPublicService") were not reconized.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.