### PR TITLE
[SELC - 3708] feat: added activatedAd for complete onboarding

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -7661,6 +7661,10 @@
         "title" : "OnboardingImportContract",
         "type" : "object",
         "properties" : {
+          "activatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
           "contractType" : {
             "type" : "string"
           },
@@ -7819,6 +7823,10 @@
           },
           "contract" : {
             "$ref" : "#/components/schemas/Contract"
+          },
+          "contractActivatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
           },
           "contractCreatedAt" : {
             "type" : "string",

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/OnboardingRequest.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/onboarding/OnboardingRequest.java
@@ -30,6 +30,7 @@ public class OnboardingRequest {
     private TokenType tokenType;
     private String contractFilePath;
     private OffsetDateTime contractCreatedAt;
+    private OffsetDateTime contractActivatedAt;
     private Boolean sendCompleteOnboardingEmail;
 
     public Contract getContract() {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingDao.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingDao.java
@@ -80,12 +80,14 @@ public class OnboardingDao {
         log.info("createToken for institution {} and product {}", institution.getExternalId(), request.getProductId());
 
         OffsetDateTime createdAt = Objects.nonNull(request.getContractCreatedAt()) ? request.getContractCreatedAt() : OffsetDateTime.now();
+        OffsetDateTime activatedAt = Objects.nonNull(request.getContractActivatedAt()) ? request.getContractActivatedAt() : OffsetDateTime.now();
 
         Token token = TokenUtils.toToken(request, institution, digest, null);
         token.setStatus(RelationshipState.ACTIVE);
         token.setContractSigned(request.getContractFilePath());
         token.setContentType(MediaType.APPLICATION_JSON_VALUE);
         token.setCreatedAt(createdAt);
+        token.setActivatedAt(activatedAt);
         token = tokenConnector.save(token, geographicTaxonomies);
 
         log.info("created token {} for institution {} and product {}", token.getId(), institution.getId(), request.getProductId());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/util/TokenUtils.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/util/TokenUtils.java
@@ -27,6 +27,7 @@ public class TokenUtils {
         }
         token.setCreatedAt(OffsetDateTime.now());
         token.setUpdatedAt(OffsetDateTime.now());
+        token.setActivatedAt(OffsetDateTime.now());
         token.setInstitutionId(institution.getId());
         token.setProductId(request.getProductId());
         token.setChecksum(digest);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingResourceMapper.java
@@ -25,6 +25,7 @@ public interface OnboardingResourceMapper {
     @Mapping(target = "contractCreatedAt", source = "contractImported.createdAt")
     @Mapping(target = "billingRequest", source = "billing")
     @Mapping(target = "signContract", source = "signContract", qualifiedByName = "mapSignContract")
+    @Mapping(target = "contractActivatedAt", source = "contractImported.activatedAt")
     OnboardingRequest toOnboardingRequest(OnboardingInstitutionRequest onboardingInstitutionRequest);
 
     OnboardingUsersRequest toOnboardingUsersRequest(OnboardingInstitutionUsersRequest request);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/OnboardingImportContract.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/onboarding/OnboardingImportContract.java
@@ -12,4 +12,5 @@ public class OnboardingImportContract {
     private String filePath;
     private String contractType;
     private OffsetDateTime createdAt;
+    private OffsetDateTime activatedAt;
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- added activatedAt for complete onboarding 

#### Motivation and Context

This addition was necessary because we now have information about the date onboarding was completed

#### How Has This Been Tested?

the microservice was started locally and subsequently two API calls were made from the external microservice that invoked the onboarding/complete API

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.