### PR TITLE
[SELC-4107] fix: fixed validateOnboardingByInstitutionType for prod-interop-coll …

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/factory/OnboardingInstitutionStrategyFactory.java
@@ -169,8 +169,8 @@ public class OnboardingInstitutionStrategyFactory {
         boolean checkRecipientCode = !(institutionType.equals(InstitutionType.SA)
                 || institutionType.equals(InstitutionType.PT)
                 || institutionType.equals(InstitutionType.AS))
-                && (!productId.equalsIgnoreCase(PROD_INTEROP.getValue())
-                || !productId.equalsIgnoreCase(PROD_INTEROP_COLL.getValue()));
+                && !(productId.equalsIgnoreCase(PROD_INTEROP.getValue())
+                || productId.equalsIgnoreCase(PROD_INTEROP_COLL.getValue()));
         OnboardingInstitutionUtils.validateOnboarding(billing, checkRecipientCode);
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_INTEROP;
+import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_INTEROP_COLL;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -606,6 +607,7 @@ class OnboardingInstitutionStrategyTest {
         institution.setTaxCode(institutionUpdate.getTaxCode());
 
         Billing billing1 = TestUtils.createSimpleBilling();
+        billing1.setRecipientCode(null);
         Contract contract = TestUtils.createSimpleContract();
 
         OnboardingRequest onboardingRequest = new OnboardingRequest();
@@ -614,7 +616,7 @@ class OnboardingInstitutionStrategyTest {
         onboardingRequest.setInstitutionExternalId("42");
         onboardingRequest.setInstitutionUpdate(institutionUpdate);
         onboardingRequest.setPricingPlan("Pricing Plan");
-        onboardingRequest.setProductId(PROD_INTEROP.getValue());
+        onboardingRequest.setProductId(PROD_INTEROP_COLL.getValue());
         onboardingRequest.setProductName("Product Name");
         onboardingRequest.setSignContract(true);
         onboardingRequest.setTokenType(TokenType.INSTITUTION);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -616,7 +616,7 @@ class OnboardingInstitutionStrategyTest {
         onboardingRequest.setInstitutionExternalId("42");
         onboardingRequest.setInstitutionUpdate(institutionUpdate);
         onboardingRequest.setPricingPlan("Pricing Plan");
-        onboardingRequest.setProductId(PROD_INTEROP_COLL.getValue());
+        onboardingRequest.setProductId(PROD_INTEROP.getValue());
         onboardingRequest.setProductName("Product Name");
         onboardingRequest.setSignContract(true);
         onboardingRequest.setTokenType(TokenType.INSTITUTION);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/OnboardingInstitutionStrategyTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_INTEROP;
-import static it.pagopa.selfcare.mscore.constant.ProductId.PROD_INTEROP_COLL;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;


### PR DESCRIPTION
…for recipientCode Check

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

-  added check in the method, to verify that the recipientCode can also be null for the prod-interop-coll product

#### Motivation and Context

This change was necessary because, even if the onboarding interceptor microservice worked correctly, the automatic onboarding to the interop-coll product was not finalized as it required the recipientCode which we no longer pass on the FE side during interop onboarding

#### How Has This Been Tested?

the microservice was started locally and onboarding was carried out for interop without recipient code and it was verified that the interop-coll product was also onboarded

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.