### PR TITLE
[SELC-4228] fix: add institutionType in createInstitution from IPA

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -6388,6 +6388,10 @@
               "$ref" : "#/components/schemas/GeoTaxonomies"
             }
           },
+          "institutionType" : {
+            "type" : "string",
+            "enum" : [ "AS", "CON", "GSP", "PA", "PG", "PSP", "PT", "REC", "SA", "SCP" ]
+          },
           "subunitCode" : {
             "type" : "string"
           },

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -27,7 +27,7 @@ public interface InstitutionService {
 
     List<Institution> getInstitutions(String taxCode, String subunitCode);
 
-    Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies);
+    Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies, InstitutionType institutionType);
 
     Institution createInstitutionFromPda(Institution institution, String injectionInstitutionType);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -127,13 +127,14 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies) {
+    public Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies, InstitutionType institutionType) {
         CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyIpa();
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
                 .taxCode(taxCode)
                 .subunitCode(subunitCode)
                 .subunitType(subunitType)
                 .geographicTaxonomies(geographicTaxonomies)
+                .institutionType(institutionType)
                 .build());
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIpa.java
@@ -75,7 +75,7 @@ public class CreateInstitutionStrategyIpa extends CreateInstitutionStrategyCommo
         try {
             Optional<Institution> opt = institutionConnector.findByExternalId(strategyInput.getTaxCode());
             if (opt.isEmpty()) {
-                Institution institutionEC = getInstitutionEC(strategyInput.getTaxCode(), institutionProxyInfo, categoryProxyInfo, null);
+                Institution institutionEC = getInstitutionEC(strategyInput.getTaxCode(), institutionProxyInfo, categoryProxyInfo, InstitutionType.PA);
                 return institutionConnector.save(institutionEC);
             } else {
                 return opt.get();

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.core.strategy.input;
 
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
 import it.pagopa.selfcare.mscore.model.institution.InstitutionGeographicTaxonomies;
 import lombok.Builder;
@@ -16,4 +17,5 @@ public class CreateInstitutionStrategyInput {
     private InstitutionPaSubunitType subunitType;
     private List<InstitutionGeographicTaxonomies> geographicTaxonomies;
     private String subunitCode;
+    private InstitutionType institutionType;
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -319,7 +319,7 @@ class InstitutionServiceImplTest {
     void testCreateInstitutionFromIpa() {
         when(createInstitutionStrategyFactory.createInstitutionStrategyIpa()).thenReturn(createInstitutionStrategy);
         when(createInstitutionStrategy.createInstitution(any())).thenReturn(new Institution());
-        Institution institution = institutionServiceImpl.createInstitutionFromIpa("id", InstitutionPaSubunitType.AOO,"id", List.of());
+        Institution institution = institutionServiceImpl.createInstitutionFromIpa("id", InstitutionPaSubunitType.AOO,"id", List.of(), InstitutionType.PA);
         assertNotNull(institution);
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -129,7 +129,7 @@ public class InstitutionController {
                 .orElse(List.of());
 
         Institution saved = institutionService.createInstitutionFromIpa(institutionFromIpaPost.getTaxCode(),
-                institutionFromIpaPost.getSubunitType(), institutionFromIpaPost.getSubunitCode(), geographicTaxonomies);
+                institutionFromIpaPost.getSubunitType(), institutionFromIpaPost.getSubunitCode(), geographicTaxonomies, institutionFromIpaPost.getInstitutionType());
         return ResponseEntity.status(HttpStatus.CREATED).body(institutionResourceMapper.toInstitutionResponse(saved));
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionFromIpaPost.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionFromIpaPost.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.web.model.institution;
 
+import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
 import lombok.Data;
 
@@ -14,4 +15,5 @@ public class InstitutionFromIpaPost {
     private String subunitCode;
     private InstitutionPaSubunitType subunitType;
     private List<GeoTaxonomies> geographicTaxonomies;
+    private InstitutionType institutionType;
 }

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -15,7 +15,6 @@ import it.pagopa.selfcare.mscore.model.user.UserInfo;
 import it.pagopa.selfcare.mscore.web.TestUtils;
 import it.pagopa.selfcare.mscore.web.model.institution.*;
 import it.pagopa.selfcare.mscore.web.model.mapper.*;
-import it.pagopa.selfcare.mscore.web.model.onboarding.OnboardingInstitutionUsersRequest;
 import it.pagopa.selfcare.mscore.web.model.user.Person;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -351,7 +350,7 @@ class InstitutionControllerTest {
         institution.setParentDescription("parentDescription");
         institution.setRootParentId("rootParentId");
 
-        when(institutionService.createInstitutionFromIpa(any(), any(), any(), any())).thenReturn(institution);
+        when(institutionService.createInstitutionFromIpa(any(), any(), any(), any(), any())).thenReturn(institution);
 
         //Then
         MockHttpServletRequestBuilder requestBuilder = post("/institutions/from-ipa/")
@@ -366,7 +365,7 @@ class InstitutionControllerTest {
 
         ArgumentCaptor<List<InstitutionGeographicTaxonomies>> captorGeo = ArgumentCaptor.forClass(List.class);
         verify(institutionService, times(1))
-                .createInstitutionFromIpa(any(),any(),any(),captorGeo.capture());
+                .createInstitutionFromIpa(any(),any(),any(),captorGeo.capture(), any());
         assertEquals(institutionFromIpaPost.getGeographicTaxonomies().size(), captorGeo.getValue().size());
         assertEquals(geoTaxonomies.getCode(), captorGeo.getValue().get(0).getCode());
         assertEquals(geoTaxonomies.getDesc(), captorGeo.getValue().get(0).getDesc());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add institutionType in createInstitutionFromIpa method
- align unit tests
- align api-docs

<!--- Describe your changes in detail -->

#### Motivation and Context
This change raises from a bug found onboarding a GPS through IPA research
When submitting a GPS onboarding, if it is present on IPA, the institution was wrongly saved as PA instead of GPS.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
This change has been tested by running ms-core and ms-onboarding locally and calling API by postman.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.