### PR TITLE
fix: avoid save mail on pdv id empty

### DIFF
--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/UserRegistryConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/UserRegistryConnectorImplTest.java
@@ -96,6 +96,29 @@ class UserRegistryConnectorImplTest {
     }
 
     @Test
+    void testPersistUserUsingPatchWithEmailNull() {
+        UUID id = UUID.randomUUID();
+        UserId userId = new UserId();
+        userId.setId(id);
+        ResponseEntity<UserId> userIdResponseEntity = ResponseEntity.ok(userId);
+        when(userRegistryRestClient._saveUsingPATCH(any())).thenReturn(userIdResponseEntity);
+        User user = userRegistryConnector.persistUserUsingPatch("name", "familyName", "fiscalCode", null,"institutionId");
+        assertEquals(user.getId(), id.toString());
+        SaveUserDto saveUserDto = SaveUserDto.builder()
+                .name(CertifiableFieldResourceOfstring.builder()
+                        .value("name")
+                        .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE)
+                        .build())
+                .familyName(CertifiableFieldResourceOfstring.builder()
+                        .value("familyName")
+                        .certification(CertifiableFieldResourceOfstring.CertificationEnum.NONE)
+                        .build())
+                .fiscalCode("fiscalCode")
+                .build();
+        verify(userRegistryRestClient)._saveUsingPATCH(saveUserDto);
+    }
+
+    @Test
     void persistUserWorksContractUsingPatch() {
         UUID id = UUID.randomUUID();
         UserId userId = new UserId();

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -368,8 +368,10 @@ public class OnboardingServiceImpl implements OnboardingService {
         User userRegistry;
         try {
             userRegistry = userService.retrieveUserFromUserRegistryByFiscalCode(user.getTaxCode());
+
             //We must save mail institution if it is not found on WorkContracts
-            if(Objects.isNull(userRegistry.getWorkContacts()) || !userRegistry.getWorkContacts().containsKey(institutionId)) {
+            if(Objects.nonNull(user.getEmail()) &&
+                    (Objects.isNull(userRegistry.getWorkContacts()) || !userRegistry.getWorkContacts().containsKey(institutionId))) {
                 userRegistry = userService.persistWorksContractToUserRegistry(user.getTaxCode(), user.getEmail(), institutionId);
             }
         } catch (FeignException.NotFound e) {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -1686,12 +1686,60 @@ class OnboardingServiceImplTest {
         when(institutionConnector.findAndUpdate(any(), any(), any(), any())).thenReturn(institution);
 
         when(userService.retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode())).thenReturn(dummyUser());
-        when(userService.persistWorksContractToUserRegistry(any(), any(), any())).thenReturn(user);
+        when(userService.persistWorksContractToUserRegistry(userToOnboard.getTaxCode(), userToOnboard.getEmail(), institution.getId())).thenReturn(user);
 
         onboardingServiceImpl.persistOnboarding(institution.getId(), productId, userToOnboards, onboardingToPersist);
 
         verify(userService, times(1))
                 .retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode());
+
+        verify(userService, times(1))
+                .persistWorksContractToUserRegistry(userToOnboard.getTaxCode(), userToOnboard.getEmail(), institution.getId());
+
+        verify(onboardingDao, times(1))
+                .onboardOperator(any(), any(), any());
+        verifyNoMoreInteractions(userService);
+    }
+
+    /**
+     * Method under test: {@link OnboardingServiceImpl#onboardingUsers(OnboardingUsersRequest, String, String)}
+     */
+    @Test
+    void persistOnboarding_whenUserExistsOnRegistryButMailIsEmpty() {
+
+        String pricingPlan = "pricingPlan";
+        String productId = "productId";
+        Onboarding onboarding = dummyOnboarding();
+        onboarding.setStatus(UtilEnumList.VALID_RELATIONSHIP_STATES.get(0));
+
+        Onboarding onboardingToPersist = new Onboarding();
+        onboardingToPersist.setPricingPlan(pricingPlan);
+        onboardingToPersist.setProductId(productId);
+        onboardingToPersist.setBilling(new Billing());
+
+        Institution institution = new Institution();
+        institution.setId("institutionId");
+        institution.setOnboarding(List.of(onboarding));
+
+        UserToOnboard userToOnboard = createSimpleUserToOnboard();
+        userToOnboard.setEmail(null);
+        User user = new User();
+        user.setFiscalCode("fiscalCode");
+        user.setId("42");
+        final List<UserToOnboard> userToOnboards = List.of(userToOnboard);
+
+        when(institutionConnector.findById(institution.getId())).thenReturn(institution);
+        when(institutionConnector.findAndUpdate(any(), any(), any(), any())).thenReturn(institution);
+
+        when(userService.retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode())).thenReturn(dummyUser());
+
+        onboardingServiceImpl.persistOnboarding(institution.getId(), productId, userToOnboards, onboardingToPersist);
+
+        verify(userService, times(1))
+                .retrieveUserFromUserRegistryByFiscalCode(userToOnboard.getTaxCode());
+
+        verify(userService, times(0))
+                .persistWorksContractToUserRegistry(any(), any(), any());
 
         verify(onboardingDao, times(1))
                 .onboardOperator(any(), any(), any());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Avoid to save user mail on pdv when it is empty

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

In PNPG use case user mail is empty so for persist onboarding or onboarding operator methods it causes errors

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.