### PR TITLE
[SELC-4191] fix: change mail subjects for users activation, sospension, reactivation and removal

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/UserNotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/UserNotificationServiceImpl.java
@@ -25,7 +25,10 @@ import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -33,10 +36,10 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class UserNotificationServiceImpl implements UserNotificationService {
 
-    private static final String ACTIVATE_SUBJECT = "User has been activated";
-    private static final String DELETE_SUBJECT = "User had been deleted";
-    private static final String SUSPEND_SUBJECT = "User has been suspended";
-    private static final String CREATE_SUBJECT = "A new user has been added";
+    private static final String ACTIVATE_SUBJECT = "Il tuo ruolo è stato riabilitato";
+    private static final String DELETE_SUBJECT = "Il tuo ruolo è stato rimosso";
+    private static final String SUSPEND_SUBJECT = "Il tuo ruolo è sospeso";
+    private static final String CREATE_SUBJECT = "Hai un nuovo ruolo per un prodotto PagoPA";
     private static final String ACTIVATE_TEMPLATE = "user_activated.ftlh";
     private static final String DELETE_TEMPLATE = "user_deleted.ftlh";
     private static final String SUSPEND_TEMPLATE = "user_suspended.ftlh";


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- change mail subjects for users activation, sospension, reactivation and removal

<!--- Describe your changes in detail -->

#### Motivation and Context
This change raises to fix a bug related to email subject for users activation, sospension, reactivation and removal.
The email subject was written in english instead of italian.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
This change has been tested by running core ms locally and checking notification manager logs to see the subject field.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.