### PR TITLE
[SELC-4180] feature: Added activatedAt parameter to update createdAt API.

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/TokenConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/TokenConnector.java
@@ -21,7 +21,7 @@ public interface TokenConnector {
 
     Token findWithFilter(String institutionId, String productId);
 
-    Token updateTokenCreatedAt(String tokenId, OffsetDateTime createdAt);
+    Token updateTokenCreatedAt(String tokenId, OffsetDateTime createdAt, OffsetDateTime activatedAt);
 
     List<Token> findByStatusAndProductId(EnumSet<RelationshipState> statuses, String productId, Integer nextPage, Integer size);
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImpl.java
@@ -25,7 +25,6 @@ import java.time.OffsetDateTime;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.mscore.connector.dao.model.mapper.TokenMapper.convertToToken;
 import static it.pagopa.selfcare.mscore.connector.dao.model.mapper.TokenMapper.convertToTokenEntity;
@@ -105,12 +104,16 @@ public class TokenConnectorImpl implements TokenConnector {
     }
 
     @Override
-    public Token updateTokenCreatedAt(String tokenId, OffsetDateTime createdAt) {
+    public Token updateTokenCreatedAt(String tokenId, OffsetDateTime createdAt, OffsetDateTime activatedAt) {
         Query query = Query.query(Criteria.where(TokenEntity.Fields.id.name()).is(tokenId));
 
         Update update = new Update();
         update.set(TokenEntity.Fields.updatedAt.name(), OffsetDateTime.now())
                 .set(TokenEntity.Fields.createdAt.name(), createdAt);
+
+        if(activatedAt != null) {
+            update.set(TokenEntity.Fields.activatedAt.name(), activatedAt);
+        }
 
         FindAndModifyOptions findAndModifyOptions = FindAndModifyOptions.options().upsert(false).returnNew(true);
         return TokenMapper.convertToToken(tokenRepository.findAndModify(query, update, findAndModifyOptions, TokenEntity.class));

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/TokenConnectorImplTest.java
@@ -697,12 +697,13 @@ class TokenConnectorImplTest {
         // Given
         String tokenIdMock = "tokenIdMock";
         OffsetDateTime createdAt = OffsetDateTime.parse("2020-11-01T02:15:30+01:00");
+        OffsetDateTime activatedAt = OffsetDateTime.parse("2020-11-02T02:15:30+01:00");
         TokenEntity updatedTokenMock = mockInstance(new TokenEntity());
         updatedTokenMock.setId(tokenIdMock);
         when(tokenRepository.findAndModify(any(), any(), any(), any()))
                 .thenReturn(updatedTokenMock);
         // When
-        Token result = tokenConnectorImpl.updateTokenCreatedAt(tokenIdMock, createdAt);
+        Token result = tokenConnectorImpl.updateTokenCreatedAt(tokenIdMock, createdAt, activatedAt);
         // Then
         assertNotNull(result);
         assertEquals(result.getId(), tokenIdMock);
@@ -714,7 +715,8 @@ class TokenConnectorImplTest {
         Update capturedUpdate = updateArgumentCaptor.getValue();
         assertTrue(capturedUpdate.getUpdateObject().get("$set").toString().contains("updatedAt") &&
                 capturedUpdate.getUpdateObject().get("$set").toString().contains("updatedAt") &&
-                capturedUpdate.getUpdateObject().get("$set").toString().contains(createdAt.toString()));
+                capturedUpdate.getUpdateObject().get("$set").toString().contains(createdAt.toString()) &&
+                capturedUpdate.getUpdateObject().get("$set").toString().contains(activatedAt.toString()));
         verifyNoMoreInteractions(tokenRepository);
     }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionService.java
@@ -77,7 +77,7 @@ public interface InstitutionService {
 
     List<ValidInstitution> retrieveInstitutionByExternalIds(List<ValidInstitution> validInstitutionList, String productId);
 
-    void updateCreatedAt(String institutionId, String productId, OffsetDateTime createdAt);
+    void updateCreatedAt(String institutionId, String productId, OffsetDateTime createdAt, OffsetDateTime activatedAt);
 
     List<RelationshipInfo> retrieveAllProduct(String userId, UserBinding binding, Institution institution, List<PartyRole> roles, List<RelationshipState> states, List<String> products, List<String> productRoles);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -412,9 +412,9 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public void updateCreatedAt(String institutionId, String productId, OffsetDateTime createdAt) {
+    public void updateCreatedAt(String institutionId, String productId, OffsetDateTime createdAt, OffsetDateTime activatedAt) {
         log.trace("updateCreatedAt start");
-        log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}", institutionId, productId, createdAt);
+        log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}, activatedAt = {}", institutionId, productId, createdAt, activatedAt);
         Assert.hasText(institutionId, "An institution ID is required.");
         Assert.hasText(productId, "A product ID is required.");
         Assert.notNull(createdAt, "A createdAt date is required.");
@@ -423,7 +423,7 @@ public class InstitutionServiceImpl implements InstitutionService {
         String tokenId = updatedInstitution.getOnboarding().stream()
                 .filter(onboarding -> onboarding.getProductId().equals(productId))
                 .findFirst().get().getTokenId();
-        Token updatedToken = tokenConnector.updateTokenCreatedAt(tokenId, createdAt);
+        Token updatedToken = tokenConnector.updateTokenCreatedAt(tokenId, createdAt, activatedAt);
         List<String> usersId = updatedToken.getUsers().stream().map(TokenUser::getUserId).collect(Collectors.toList());
         userConnector.updateUserBindingCreatedAt(institutionId, productId, usersId, createdAt);
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -313,7 +313,7 @@ class InstitutionServiceImplTest {
     }
 
     /**
-     * Method under test: {@link InstitutionServiceImpl#createInstitutionFromIpa(String, InstitutionPaSubunitType, String, List)}
+     * Method under test: {@link InstitutionServiceImpl#createInstitutionFromIpa(String, InstitutionPaSubunitType, String, List, InstitutionType)}
      */
     @Test
     void testCreateInstitutionFromIpa() {
@@ -1402,6 +1402,8 @@ class InstitutionServiceImplTest {
         String institutionIdMock = "institutionIdMock";
         String productIdMock = "productId";
         OffsetDateTime createdAtMock = OffsetDateTime.parse("2020-11-01T02:15:30+01:00");
+        OffsetDateTime activatedAtMock = OffsetDateTime.parse("2020-11-02T02:15:30+01:00");
+
 
         Onboarding onboardingMock1 = mockInstance(new Onboarding());
         onboardingMock1.setStatus(RelationshipState.ACTIVE);
@@ -1444,16 +1446,16 @@ class InstitutionServiceImplTest {
 
         when(institutionConnector.updateOnboardedProductCreatedAt(institutionIdMock, productIdMock, createdAtMock))
                 .thenReturn(updatedInstitutionMock);
-        when(tokenConnector.updateTokenCreatedAt(updatedTokenMock.getId(), createdAtMock))
+        when(tokenConnector.updateTokenCreatedAt(updatedTokenMock.getId(), createdAtMock, activatedAtMock))
                 .thenReturn(updatedTokenMock);
 
         // When
-        institutionServiceImpl.updateCreatedAt(institutionIdMock, productIdMock, createdAtMock);
+        institutionServiceImpl.updateCreatedAt(institutionIdMock, productIdMock, createdAtMock, activatedAtMock);
         // Then
         verify(institutionConnector, times(1))
                 .updateOnboardedProductCreatedAt(institutionIdMock, productIdMock, createdAtMock);
         verify(tokenConnector, times(1))
-                .updateTokenCreatedAt(updatedTokenMock.getId(), createdAtMock);
+                .updateTokenCreatedAt(updatedTokenMock.getId(), createdAtMock, activatedAtMock);
         verify(userConnector, times(1))
                 .updateUserBindingCreatedAt(institutionIdMock, productIdMock, List.of(tokenUserMock1.getUserId(), tokenUserMock2.getUserId()), createdAtMock);
         verify(contractService, times(1))
@@ -1467,7 +1469,7 @@ class InstitutionServiceImplTest {
         String productIdMock = "productId";
         OffsetDateTime createdAtMock = OffsetDateTime.parse("2020-11-01T02:15:30+01:00");
         // When
-        Executable executable = () -> institutionServiceImpl.updateCreatedAt(null, productIdMock, createdAtMock);
+        Executable executable = () -> institutionServiceImpl.updateCreatedAt(null, productIdMock, createdAtMock, null);
         // Then
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, executable);
         assertEquals("An institution ID is required.", illegalArgumentException.getMessage());
@@ -1480,7 +1482,7 @@ class InstitutionServiceImplTest {
         String institutionIdMock = "institutionId";
         OffsetDateTime createdAtMock = OffsetDateTime.parse("2020-11-01T02:15:30+01:00");
         // When
-        Executable executable = () -> institutionServiceImpl.updateCreatedAt(institutionIdMock, null, createdAtMock);
+        Executable executable = () -> institutionServiceImpl.updateCreatedAt(institutionIdMock, null, createdAtMock, null);
         // Then
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, executable);
         assertEquals("A product ID is required.", illegalArgumentException.getMessage());
@@ -1493,7 +1495,7 @@ class InstitutionServiceImplTest {
         String institutionIdMock = "institutionId";
         String productIdMock = "producttId";
         // When
-        Executable executable = () -> institutionServiceImpl.updateCreatedAt(institutionIdMock, productIdMock, null);
+        Executable executable = () -> institutionServiceImpl.updateCreatedAt(institutionIdMock, productIdMock, null, null);
         // Then
         IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, executable);
         assertEquals("A createdAt date is required.", illegalArgumentException.getMessage());

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -496,13 +496,14 @@ public class InstitutionController {
                                                 @ApiParam("${swagger.mscore.product.model.id}")
                                                 @PathVariable("productId") String productId,
                                                 @ApiParam("${swagger.mscore.institutions.model.createdAt}")
-                                                @RequestParam(value = "createdAt") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime createdAt) {
+                                                @RequestParam(value = "createdAt") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime createdAt,
+                                                @RequestParam(value = "activatedAt", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime activatedAt) {
         log.trace("updateCreatedAt start");
         log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}", institutionId, productId, createdAt);
-        if (createdAt.compareTo(OffsetDateTime.now()) > 0) {
+        if (createdAt.isAfter(OffsetDateTime.now())) {
             throw new ValidationException("Invalid createdAt date: the createdAt date must be prior to the current date.");
         }
-        institutionService.updateCreatedAt(institutionId, productId, createdAt);
+        institutionService.updateCreatedAt(institutionId, productId, createdAt, activatedAt);
         log.trace("updateCreatedAt end");
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -487,14 +487,15 @@ public class InstitutionController {
      */
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institutions.updateCreatedAt}", notes = "${swagger.mscore.institutions.updateCreatedAt}")
-    @PutMapping(value = "/createdAt")
-    public ResponseEntity<Void> updateCreatedAt(@Valid @RequestBody CreatedAtRequest createdAtRequest) {
+    @PutMapping(value = "/{institutionId}/createdAt")
+    public ResponseEntity<Void> updateCreatedAt( @PathVariable(value = "institutionId") String institutionId,
+                                                 @Valid @RequestBody CreatedAtRequest createdAtRequest) {
         log.trace("updateCreatedAt start");
-        log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}", createdAtRequest.getInstitutionId(), createdAtRequest.getProductId(), createdAtRequest.getCreatedAt());
+        log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}", institutionId, createdAtRequest.getProductId(), createdAtRequest.getCreatedAt());
         if (createdAtRequest.getCreatedAt().isAfter(OffsetDateTime.now())) {
             throw new ValidationException("Invalid createdAt date: the createdAt date must be prior to the current date.");
         }
-        institutionService.updateCreatedAt(createdAtRequest.getInstitutionId(), createdAtRequest.getProductId(), createdAtRequest.getCreatedAt(), createdAtRequest.getActivatedAt());
+        institutionService.updateCreatedAt(institutionId, createdAtRequest.getProductId(), createdAtRequest.getCreatedAt(), createdAtRequest.getActivatedAt());
         log.trace("updateCreatedAt end");
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -21,7 +21,6 @@ import it.pagopa.selfcare.mscore.web.model.mapper.*;
 import it.pagopa.selfcare.mscore.web.model.onboarding.OnboardedProducts;
 import it.pagopa.selfcare.mscore.web.util.CustomExceptionMessage;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -481,29 +480,21 @@ public class InstitutionController {
     /**
      * The function updates the field createdAt of the OnboardedProduct, the related Token and UserBindings for the given institution-product pair
      *
-     * @param institutionId String
-     * @param productId     String
-     * @param createdAt     OffsetDateTime
+     * @param createdAtRequest     CreatedAtRequest
      * @return no content
      * * Code: 200, Message: successful operation
      * * Code: 404, Message: Institution or Token or UserBinding not found, DataType: Problem
      */
     @ResponseStatus(HttpStatus.OK)
     @ApiOperation(value = "${swagger.mscore.institutions.updateCreatedAt}", notes = "${swagger.mscore.institutions.updateCreatedAt}")
-    @PutMapping(value = "/{institutionId}/products/{productId}/createdAt")
-    public ResponseEntity<Void> updateCreatedAt(@ApiParam("${swagger.mscore.institutions.model.institutionId}")
-                                                @PathVariable("institutionId") String institutionId,
-                                                @ApiParam("${swagger.mscore.product.model.id}")
-                                                @PathVariable("productId") String productId,
-                                                @ApiParam("${swagger.mscore.institutions.model.createdAt}")
-                                                @RequestParam(value = "createdAt") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime createdAt,
-                                                @RequestParam(value = "activatedAt", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime activatedAt) {
+    @PutMapping(value = "/createdAt")
+    public ResponseEntity<Void> updateCreatedAt(@Valid @RequestBody CreatedAtRequest createdAtRequest) {
         log.trace("updateCreatedAt start");
-        log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}", institutionId, productId, createdAt);
-        if (createdAt.isAfter(OffsetDateTime.now())) {
+        log.debug("updateCreatedAt institutionId = {}, productId = {}, createdAt = {}", createdAtRequest.getInstitutionId(), createdAtRequest.getProductId(), createdAtRequest.getCreatedAt());
+        if (createdAtRequest.getCreatedAt().isAfter(OffsetDateTime.now())) {
             throw new ValidationException("Invalid createdAt date: the createdAt date must be prior to the current date.");
         }
-        institutionService.updateCreatedAt(institutionId, productId, createdAt, activatedAt);
+        institutionService.updateCreatedAt(createdAtRequest.getInstitutionId(), createdAtRequest.getProductId(), createdAtRequest.getCreatedAt(), createdAtRequest.getActivatedAt());
         log.trace("updateCreatedAt end");
         return ResponseEntity.status(HttpStatus.OK).build();
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/CreatedAtRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/CreatedAtRequest.java
@@ -1,0 +1,21 @@
+package it.pagopa.selfcare.mscore.web.model.institution;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+
+@Data
+public class CreatedAtRequest {
+    @NotBlank(message = "institutionId is mandatory")
+    private String institutionId;
+    @NotBlank(message = "productId is mandatory")
+    private String productId;
+    @NotNull(message = "createdAt is mandatory")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private OffsetDateTime createdAt;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private OffsetDateTime activatedAt;
+}

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/CreatedAtRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/CreatedAtRequest.java
@@ -9,8 +9,6 @@ import java.time.OffsetDateTime;
 
 @Data
 public class CreatedAtRequest {
-    @NotBlank(message = "institutionId is mandatory")
-    private String institutionId;
     @NotBlank(message = "productId is mandatory")
     private String productId;
     @NotNull(message = "createdAt is mandatory")

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -1221,7 +1221,7 @@ class InstitutionControllerTest {
     }
 
     /**
-     * Method under test: {@link InstitutionController#updateCreatedAt(String, String, java.time.OffsetDateTime)}
+     * Method under test: {@link InstitutionController#updateCreatedAt(String, String, java.time.OffsetDateTime, java.time.OffsetDateTime)}
      */
     @Test
     void updateCreatedAt() throws Exception {
@@ -1239,7 +1239,7 @@ class InstitutionControllerTest {
                 .andExpect(MockMvcResultMatchers.status().isOk());
         // Then
         verify(institutionService, times(1))
-                .updateCreatedAt(institutionIdMock, productIdMock, createdAtMock);
+                .updateCreatedAt(institutionIdMock, productIdMock, createdAtMock, null);
         verifyNoMoreInteractions(institutionService);
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -1221,7 +1221,7 @@ class InstitutionControllerTest {
     }
 
     /**
-     * Method under test: {@link InstitutionController#updateCreatedAt(CreatedAtRequest)}
+     * Method under test: {@link InstitutionController#updateCreatedAt(String, CreatedAtRequest)}
      */
     @Test
     void updateCreatedAt() throws Exception {
@@ -1232,10 +1232,9 @@ class InstitutionControllerTest {
 
         CreatedAtRequest createdAtRequest = new CreatedAtRequest();
         createdAtRequest.setCreatedAt(createdAtMock);
-        createdAtRequest.setInstitutionId(institutionIdMock);
         createdAtRequest.setProductId(productIdMock);
         // When
-        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.put(BASE_URL + "/createdAt")
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.put(BASE_URL + "/{institutionId}/createdAt", institutionIdMock)
                 .content(new ObjectMapper().findAndRegisterModules().writeValueAsString(createdAtRequest))
                 .contentType(APPLICATION_JSON_VALUE)
                 .accept(APPLICATION_JSON_VALUE);
@@ -1387,12 +1386,11 @@ class InstitutionControllerTest {
         String productIdMock = "productId";
         OffsetDateTime createdAtMock = OffsetDateTime.now().minusHours(10);
         CreatedAtRequest createdAtRequest = new CreatedAtRequest();
-        createdAtRequest.setInstitutionId(institutionIdMock);
         createdAtRequest.setProductId(productIdMock);
         createdAtRequest.setCreatedAt(createdAtMock);
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                        .put(BASE_URL + "/createdAt")
+                        .put(BASE_URL + "/{institutionId}/createdAt", institutionIdMock)
                         .content(objectMapper.writeValueAsString(createdAtRequest))
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE);

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -79,7 +79,8 @@ class InstitutionControllerTest {
     @Spy
     private UserMapper userMapper = new UserMapperImpl();
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+        //.registerModule(new JavaTimeModule());
 
 
     private final static Onboarding onboarding;
@@ -110,7 +111,6 @@ class InstitutionControllerTest {
         institution.setDescription("description");
         institution.setOnboarding(List.of(onboarding));
         institution.setAttributes(List.of(attribute));
-
 
     }
 
@@ -1221,25 +1221,31 @@ class InstitutionControllerTest {
     }
 
     /**
-     * Method under test: {@link InstitutionController#updateCreatedAt(String, String, java.time.OffsetDateTime, java.time.OffsetDateTime)}
+     * Method under test: {@link InstitutionController#updateCreatedAt(CreatedAtRequest)}
      */
     @Test
     void updateCreatedAt() throws Exception {
         // Given
         String institutionIdMock = "institutionId";
         String productIdMock = "productId";
-        String createdAtString = "2020-11-01T02:15:30+01:00";
         OffsetDateTime createdAtMock = OffsetDateTime.parse("2020-11-01T02:15:30+01:00");
+
+        CreatedAtRequest createdAtRequest = new CreatedAtRequest();
+        createdAtRequest.setCreatedAt(createdAtMock);
+        createdAtRequest.setInstitutionId(institutionIdMock);
+        createdAtRequest.setProductId(productIdMock);
         // When
-        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.put(BASE_URL + "/{institutionId}/products/{productId}/createdAt", institutionIdMock, productIdMock)
-                .param("createdAt", createdAtString);
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.put(BASE_URL + "/createdAt")
+                .content(new ObjectMapper().findAndRegisterModules().writeValueAsString(createdAtRequest))
+                .contentType(APPLICATION_JSON_VALUE)
+                .accept(APPLICATION_JSON_VALUE);
         MockMvcBuilders.standaloneSetup(institutionController)
                 .build()
                 .perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isOk());
         // Then
         verify(institutionService, times(1))
-                .updateCreatedAt(institutionIdMock, productIdMock, createdAtMock, null);
+                .updateCreatedAt(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
         verifyNoMoreInteractions(institutionService);
     }
 
@@ -1375,14 +1381,19 @@ class InstitutionControllerTest {
     @Test
     void updateCreatedAt_invalidDate() throws Exception {
         // Given
+
+
         String institutionIdMock = "institutionId";
         String productIdMock = "productId";
         OffsetDateTime createdAtMock = OffsetDateTime.now().minusHours(10);
-        String createdAtString = createdAtMock.toString();
+        CreatedAtRequest createdAtRequest = new CreatedAtRequest();
+        createdAtRequest.setInstitutionId(institutionIdMock);
+        createdAtRequest.setProductId(productIdMock);
+        createdAtRequest.setCreatedAt(createdAtMock);
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                        .put(BASE_URL + "/{institutionId}/products/{productId}/createdAt", institutionIdMock, productIdMock)
-                        .param("createdAt", createdAtString)
+                        .put(BASE_URL + "/createdAt")
+                        .content(objectMapper.writeValueAsString(createdAtRequest))
                         .contentType(APPLICATION_JSON_VALUE)
                         .accept(APPLICATION_JSON_VALUE);
 


### PR DESCRIPTION
#### List of Changes

Added activatedAt parameter to update activatedAt field in Token collection.

#### Motivation and Context

This API will be used to update the joining dates of Institutions imported from the pda. In fact, the activatedAt field has been added since it is considered as the joining date when the event is sent on the datalake.

#### How Has This Been Tested?

local environment

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.