### PR TITLE
hotfix: save activatedAt as createdAt when persist onboarding

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -6711,6 +6711,10 @@
         "title" : "InstitutionOnboardingRequest",
         "type" : "object",
         "properties" : {
+          "activatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
           "billing" : {
             "$ref" : "#/components/schemas/BillingRequest"
           },

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -180,7 +180,10 @@ public class OnboardingServiceImpl implements OnboardingService {
         log.debug("persistForUpdate institutionId = {}, productId = {}, users = {}", institutionId, productId, users);
         onboarding.setStatus(RelationshipState.ACTIVE);
         onboarding.setProductId(productId);
-        onboarding.setCreatedAt(OffsetDateTime.now());
+
+        if(Objects.isNull(onboarding.getCreatedAt())) {
+            onboarding.setCreatedAt(OffsetDateTime.now());
+        }
 
         //Verify if onboarding exists, in case onboarding must fail
         final Institution institution = institutionConnector.findById(institutionId);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,9 +49,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -1709,6 +1708,13 @@ class OnboardingServiceImplTest {
 
         verify(onboardingDao, times(1))
                 .onboardOperator(any(), any(), any());
+
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        verify(institutionConnector, times(1))
+                .findAndUpdate(any(), captor.capture(), any(), any());
+        Onboarding actual = captor.getValue();
+        assertEquals(actual.getCreatedAt().getDayOfYear(), LocalDate.now().getDayOfYear());
+
         verifyNoMoreInteractions(userService);
     }
 
@@ -1727,6 +1733,10 @@ class OnboardingServiceImplTest {
         onboardingToPersist.setPricingPlan(pricingPlan);
         onboardingToPersist.setProductId(productId);
         onboardingToPersist.setBilling(new Billing());
+        onboardingToPersist.setCreatedAt(LocalDateTime
+                .of(2022,1,1,0,0,0)
+                .atZone(ZoneOffset.systemDefault())
+                .toOffsetDateTime());
 
         Institution institution = new Institution();
         institution.setId("institutionId");
@@ -1754,6 +1764,13 @@ class OnboardingServiceImplTest {
 
         verify(onboardingDao, times(1))
                 .onboardOperator(any(), any(), any());
+
+        ArgumentCaptor<Onboarding> captor = ArgumentCaptor.forClass(Onboarding.class);
+        verify(institutionConnector, times(1))
+                .findAndUpdate(any(), captor.capture(), any(), any());
+        Onboarding actual = captor.getValue();
+        assertEquals(actual.getCreatedAt(), onboardingToPersist.getCreatedAt());
+
         verifyNoMoreInteractions(userService);
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardingRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardingRequest.java
@@ -4,6 +4,7 @@ import it.pagopa.selfcare.mscore.web.model.user.Person;
 import lombok.Data;
 
 import javax.validation.constraints.NotEmpty;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -19,5 +20,7 @@ public class InstitutionOnboardingRequest {
     private String contractPath;
     private String pricingPlan;
     private BillingRequest billing;
+
+    private LocalDateTime activatedAt;
 
 }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingResourceMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/OnboardingResourceMapper.java
@@ -14,6 +14,9 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 
 @Mapper(componentModel = "spring", uses = {InstitutionUpdateMapper.class})
@@ -36,5 +39,13 @@ public interface OnboardingResourceMapper {
     }
 
     @Mapping(target = "contract", source = "contractPath")
+    @Mapping(target = "createdAt", source = "activatedAt", qualifiedByName = "toOffsetDateTime")
     Onboarding toOnboarding(InstitutionOnboardingRequest onboardingRequest);
+
+    @Named("toOffsetDateTime")
+    default OffsetDateTime toOffsetDateTime(LocalDateTime date) {
+        return Optional.ofNullable(date)
+                .map(ld -> ld.atZone(ZoneOffset.systemDefault()).toOffsetDateTime())
+                .orElse(null);
+    }
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Added activatedAt to persist onboarding request for saving it as createdAd

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It is needed when persist onboarding from an import 

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.