### PR TITLE
[SELC-4180] fix: filter for ACTIVE onboarding when updating createdAt and activatedAt dates

### DIFF
--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -305,7 +305,8 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
         Update update = new Update();
         update.set(constructQuery(CURRENT_ONBOARDING_REFER, OnboardingEntity.Fields.createdAt.name()), createdAt)
                 .set(constructQuery(CURRENT_ONBOARDING_REFER, OnboardingEntity.Fields.updatedAt.name()), OffsetDateTime.now())
-                .filterArray(Criteria.where(CURRENT_ONBOARDING + OnboardingEntity.Fields.productId.name()).is(productId));
+                .filterArray(Criteria.where(CURRENT_ONBOARDING + OnboardingEntity.Fields.productId.name()).is(productId)
+                        .and(CURRENT_ONBOARDING + OnboardingEntity.Fields.status.name()).is(RelationshipState.ACTIVE.name()));
 
         Update updateInstitutionEntityUpdatedAt = new Update();
         updateInstitutionEntityUpdatedAt.set(InstitutionEntity.Fields.updatedAt.name(), OffsetDateTime.now());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -414,8 +414,10 @@ public class InstitutionServiceImpl implements InstitutionService {
 
         Institution updatedInstitution = institutionConnector.updateOnboardedProductCreatedAt(institutionId, productId, createdAt);
         String tokenId = updatedInstitution.getOnboarding().stream()
-                .filter(onboarding -> onboarding.getProductId().equals(productId))
-                .findFirst().get().getTokenId();
+                .filter(onboarding -> onboarding.getProductId().equals(productId) && onboarding.getStatus() == RelationshipState.ACTIVE)
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(CustomError.CONTRACT_NOT_FOUND.getMessage(), institutionId, productId), CustomError.CONTRACT_NOT_FOUND.getCode()))
+                .getTokenId();
         Token updatedToken = tokenConnector.updateTokenCreatedAt(tokenId, createdAt, activatedAt);
         List<String> usersId = updatedToken.getUsers().stream().map(TokenUser::getUserId).collect(Collectors.toList());
         userConnector.updateUserBindingCreatedAt(institutionId, productId, usersId, createdAt);

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -1420,6 +1420,26 @@ class InstitutionServiceImplTest {
 
     }
 
+    @Test
+    void updateCreatedAt_onboardingNotFound() {
+        // Given
+        String institutionIdMock = "institutionId";
+        String productIdMock = "producttId";
+        OffsetDateTime createdAtMock = OffsetDateTime.parse("2020-11-01T02:15:30+01:00");
+        OffsetDateTime activatedAtMock = OffsetDateTime.parse("2020-11-02T02:15:30+01:00");
+
+        Institution institutionMock = mockInstance(new Institution());
+        institutionMock.setOnboarding(Collections.emptyList());
+        when(institutionConnector.updateOnboardedProductCreatedAt(institutionIdMock, productIdMock, createdAtMock))
+                .thenReturn(institutionMock);
+        // When
+        Executable executable = () -> institutionServiceImpl.updateCreatedAt(institutionIdMock, productIdMock, createdAtMock, activatedAtMock);
+        // Then
+        assertThrows(ResourceNotFoundException.class, executable);
+        verifyNoInteractions(tokenConnector, userConnector);
+
+    }
+
     /**
      * Method under test: {@link InstitutionServiceImpl#getInstitutionBrokers(String, InstitutionType)}
      */


### PR DESCRIPTION
#### List of Changes

Added filter on status to get only active onboardings.

#### Motivation and Context

The API must recognize the only token in the Active state for the institution and product pair before attempting to update the dates

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.