### PR TITLE
fix: [SELC-4536] fix deleteDelegations query findByToAndStatus

### DIFF
--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.mscore.connector.dao;
 
-import com.mongodb.client.model.Facet;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.connector.dao.model.DelegationEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapper;
@@ -21,10 +20,7 @@ import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Component;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -122,7 +118,7 @@ public class DelegationConnectorImpl implements DelegationConnector {
 
     @Override
     public boolean checkIfDelegationsAreActive(String institutionId) {
-        Optional<DelegationEntity> opt = repository.findByToAndStatus(institutionId, DelegationState.ACTIVE);
-        return opt.isPresent();
+        List<DelegationEntity> opt = repository.findByToAndStatus(institutionId, DelegationState.ACTIVE).orElse(Collections.emptyList());
+        return !opt.isEmpty();
     }
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationRepository.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationRepository.java
@@ -6,6 +6,7 @@ import it.pagopa.selfcare.mscore.constant.DelegationType;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -13,5 +14,5 @@ public interface DelegationRepository extends MongoRepository<DelegationEntity, 
 
     Optional<DelegationEntity> findByFromAndToAndProductIdAndType(String from, String to, String productId, DelegationType type);
 
-    Optional<DelegationEntity> findByToAndStatus(String to, DelegationState status);
+    Optional<List<DelegationEntity>> findByToAndStatus(String to, DelegationState status);
 }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
@@ -27,7 +27,6 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.test.context.ContextConfiguration;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -219,7 +218,7 @@ class DelegationConnectorImplTest {
 
     @Test
     void checkIfDelegationsAreActive() {
-        when(delegationRepository.findByToAndStatus(anyString(), any())).thenReturn(Optional.of(new DelegationEntity()));
+        when(delegationRepository.findByToAndStatus(anyString(), any())).thenReturn(Optional.of(List.of(new DelegationEntity())));
         boolean response = delegationConnectorImpl.checkIfDelegationsAreActive("id");
         assertTrue(response);
     }

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
@@ -27,6 +27,7 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.aggregation.AggregationResults;
 import org.springframework.test.context.ContextConfiguration;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -217,10 +218,17 @@ class DelegationConnectorImplTest {
     }
 
     @Test
-    void checkIfDelegationsAreActive() {
+    void checkIfDelegationsAreActive_true() {
         when(delegationRepository.findByToAndStatus(anyString(), any())).thenReturn(Optional.of(List.of(new DelegationEntity())));
         boolean response = delegationConnectorImpl.checkIfDelegationsAreActive("id");
         assertTrue(response);
+    }
+
+    @Test
+    void checkIfDelegationsAreActive_false() {
+        when(delegationRepository.findByToAndStatus(anyString(), any())).thenReturn(Optional.of(Collections.emptyList()));
+        boolean response = delegationConnectorImpl.checkIfDelegationsAreActive("id");
+        assertFalse(response);
     }
 
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- modify delegations' findByToAndStatus to return a List
- align checkIfDelegationsAreActive method
- align unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
This change was necessary to fix un unhandled exception when there are more than one delegation still active for an institution.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by invoking the mentioned API locally and checking the following cases:
- when there are no more delegations in status active
- when there is only one delegation in status active
- when there are more than one delegation in status active

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.