### PR TITLE
[SELC-4520] Adding new taxCode param on search delegation

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -87,6 +87,15 @@
             "type" : "string"
           }
         }, {
+          "name" : "taxCode",
+          "in" : "query",
+          "description" : "Institution's tax code",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
           "name" : "mode",
           "in" : "query",
           "description" : "Mode (full or normal) to retreieve institution's delegations",

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
@@ -10,7 +10,7 @@ public interface DelegationConnector {
 
     Delegation save(Delegation delegation);
     boolean checkIfExists(Delegation delegation);
-    List<Delegation> find(String from, String to, String productId, String search, GetDelegationsMode mode, Integer page, Integer size);
+    List<Delegation> find(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Integer page, Integer size);
     Delegation findByIdAndModifyStatus(String delegationId, DelegationState status);
     boolean checkIfDelegationsAreActive(String institutionId);
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImpl.java
@@ -2,6 +2,7 @@ package it.pagopa.selfcare.mscore.connector.dao;
 
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.connector.dao.model.DelegationEntity;
+import it.pagopa.selfcare.mscore.connector.dao.model.InstitutionEntity;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationEntityMapper;
 import it.pagopa.selfcare.mscore.connector.dao.model.mapper.DelegationInstitutionMapper;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
@@ -62,7 +63,7 @@ public class DelegationConnectorImpl implements DelegationConnector {
     }
 
     @Override
-    public List<Delegation> find(String from, String to, String productId, String search, GetDelegationsMode mode, Integer page, Integer size) {
+    public List<Delegation> find(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Integer page, Integer size) {
         List<Criteria> criterias = new ArrayList<>();
         Criteria criteria = new Criteria();
         Pageable pageable = PageRequest.of(page, size);
@@ -80,6 +81,10 @@ public class DelegationConnectorImpl implements DelegationConnector {
             criterias.add(Criteria.where(DelegationEntity.Fields.institutionFromName.name()).regex("(?i)" + Pattern.quote(search)));
         }
         if (GetDelegationsMode.FULL.equals(mode)) {
+
+            if (Objects.nonNull(taxCode)) {
+                criterias.add(Criteria.where(InstitutionEntity.Fields.taxCode.name()).regex("(?i)" + Pattern.quote(taxCode)));
+            }
 
             GraphLookupOperation.GraphLookupOperationBuilder lookup = Aggregation.graphLookup("Institution")
                     .startWith(Objects.nonNull(from) ? "to" : "from")

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/DelegationConnectorImplTest.java
@@ -130,7 +130,7 @@ class DelegationConnectorImplTest {
                 .find(any(), any(), any());
 
         List<Delegation> response = delegationConnectorImpl.find(delegationEntity.getFrom(),
-                delegationEntity.getTo(), delegationEntity.getProductId(), null, GetDelegationsMode.NORMAL, PAGE_SIZE, MAX_PAGE_SIZE);
+                delegationEntity.getTo(), delegationEntity.getProductId(), null, null, GetDelegationsMode.NORMAL, PAGE_SIZE, MAX_PAGE_SIZE);
 
         //Then
         assertNotNull(response);
@@ -158,7 +158,7 @@ class DelegationConnectorImplTest {
                 thenReturn(results);
 
         List<Delegation> response = delegationConnectorImpl.find(dummyDelegationEntity.getFrom(), null,
-                dummyDelegationEntity.getProductId(), null, GetDelegationsMode.FULL, PAGE_SIZE, MAX_PAGE_SIZE);
+                dummyDelegationEntity.getProductId(), null, null, GetDelegationsMode.FULL, PAGE_SIZE, MAX_PAGE_SIZE);
 
         //Then
         assertNotNull(response);
@@ -188,7 +188,7 @@ class DelegationConnectorImplTest {
                 thenReturn(results);
 
         List<Delegation> response = delegationConnectorImpl.find(null, dummyDelegationEntity.getTo(),
-                dummyDelegationEntity.getProductId(), null, GetDelegationsMode.FULL, PAGE_SIZE, MAX_PAGE_SIZE);
+                dummyDelegationEntity.getProductId(), null, null, GetDelegationsMode.FULL, PAGE_SIZE, MAX_PAGE_SIZE);
 
         //Then
         assertNotNull(response);
@@ -247,7 +247,7 @@ class DelegationConnectorImplTest {
                 thenReturn(results);
 
         List<Delegation> response = delegationConnectorImpl.find(null,
-                TO1, "productId", null, GetDelegationsMode.FULL, 0, 1);
+                TO1, "productId", null, null, GetDelegationsMode.FULL, 0, 1);
 
         //Then
         assertNotNull(response);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
@@ -10,7 +10,7 @@ public interface DelegationService {
 
     Delegation createDelegation(Delegation delegation);
     boolean checkIfExists(Delegation delegation);
-    List<Delegation> getDelegations(String from, String to, String productId, String search, GetDelegationsMode mode, Optional<Integer> page, Optional<Integer> size);
+    List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Optional<Integer> page, Optional<Integer> size);
     Delegation createDelegationFromInstitutionsTaxCode(Delegation delegation);
     void deleteDelegationByDelegationId(String delegationId);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
@@ -162,9 +162,9 @@ public class DelegationServiceImpl implements DelegationService {
     }
 
     @Override
-    public List<Delegation> getDelegations(String from, String to, String productId, String search, GetDelegationsMode mode,
+    public List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode,
                                            Optional<Integer> page, Optional<Integer> size) {
         int pageSize = size.filter(s -> s > 0).filter(s -> s <= DEFAULT_DELEGATIONS_PAGE_SIZE).orElse(DEFAULT_DELEGATIONS_PAGE_SIZE);
-        return delegationConnector.find(from, to, productId, search, mode, page.orElse(0), pageSize);
+        return delegationConnector.find(from, to, productId, search, taxCode, mode, page.orElse(0), pageSize);
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -176,12 +176,12 @@ class DelegationServiceImplTest {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId", null,
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId", null, null,
                 GetDelegationsMode.NORMAL, Optional.of(0), Optional.of(100));
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -196,12 +196,12 @@ class DelegationServiceImplTest {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null,
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null, null,
                 GetDelegationsMode.FULL, Optional.of(0), Optional.of(0));
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(),m any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -216,12 +216,12 @@ class DelegationServiceImplTest {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null,
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null, null,
                 GetDelegationsMode.FULL, Optional.empty(), Optional.empty());
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -201,7 +201,7 @@ class DelegationServiceImplTest {
         List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null, null,
                 GetDelegationsMode.FULL, Optional.of(0), Optional.of(0));
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(),m any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -101,6 +101,8 @@ public class DelegationController {
                                                                    @RequestParam(name = "productId", required = false) String productId,
                                                                    @ApiParam("${swagger.mscore.institutions.model.description}")
                                                                    @RequestParam(name = "search", required = false) String search,
+                                                                   @ApiParam("${swagger.mscore.institutions.model.taxCode}")
+                                                                   @RequestParam(name = "taxCode", required = false) String taxCode,
                                                                    @ApiParam("${swagger.mscore.institutions.delegations.mode}")
                                                                    @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
                                                                    @RequestParam(name = "page", required = false) Optional<Integer> page,
@@ -109,7 +111,7 @@ public class DelegationController {
         if(Objects.isNull(institutionId) && Objects.isNull(brokerId))
             throw new InvalidRequestException("institutionId or brokerId must not be null!!", GenericError.GENERIC_ERROR.getCode());
 
-        return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId, search, mode, page, size).stream()
+        return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId, search, taxCode, mode, page, size).stream()
                 .map(delegationMapper::toDelegationResponse)
                 .collect(Collectors.toList()));
     }

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
@@ -130,7 +130,7 @@ class DelegationControllerTest {
     }
 
     /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, GetDelegationsMode, Optional, Optional)}
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional)}
      */
     @Test
     void getDelegations_shouldGetData() throws Exception {
@@ -138,7 +138,7 @@ class DelegationControllerTest {
         Delegation expectedDelegation = dummyDelegation();
 
         when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, GetDelegationsMode.NORMAL, Optional.empty(), Optional.empty()))
+                expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Optional.empty(), Optional.empty()))
                 .thenReturn(List.of(expectedDelegation));
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
@@ -166,7 +166,7 @@ class DelegationControllerTest {
 
         verify(delegationService, times(1))
                 .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, GetDelegationsMode.NORMAL,
+                        expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL,
                         Optional.empty(), Optional.empty());
 
         verifyNoMoreInteractions(delegationService);
@@ -182,7 +182,7 @@ class DelegationControllerTest {
         expectedDelegations.add(delegation2);
 
         when(delegationService.getDelegations(null, TO1,
-                null, null, GetDelegationsMode.FULL, Optional.empty(), Optional.empty()))
+                null, null, null, GetDelegationsMode.FULL, Optional.empty(), Optional.empty()))
                 .thenReturn(expectedDelegations);
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
@@ -208,14 +208,14 @@ class DelegationControllerTest {
         assertThat(actual.getInstitutionRootName()).isEqualTo(delegation1.getInstitutionFromRootName());
 
         verify(delegationService, times(1))
-                .getDelegations(null, TO1,
+                .getDelegations(null, TO1, null,
                         null, null, GetDelegationsMode.FULL,
                         Optional.empty(), Optional.empty());
         verifyNoMoreInteractions(delegationService);
     }
 
     /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, GetDelegationsMode, Optional, Optional)}
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional)}
      */
     @Test
     void getDelegations_shouldGetData_nullMode() throws Exception {
@@ -223,7 +223,7 @@ class DelegationControllerTest {
         Delegation expectedDelegation = dummyDelegation();
 
         when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty()))
+                expectedDelegation.getProductId(), null, null, null, Optional.empty(), Optional.empty()))
                 .thenReturn(List.of(expectedDelegation));
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
@@ -251,7 +251,7 @@ class DelegationControllerTest {
 
         verify(delegationService, times(1))
                 .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty());
+                        expectedDelegation.getProductId(), null, null, null, Optional.empty(), Optional.empty());
         verifyNoMoreInteractions(delegationService);
     }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

When an institution needs to retrieve the delegations received, it can filter the response using some parameters such as the sender's tax code or the sender's name.

#### List of Changes
Adding taxCode param on getDelegation API.
 
<!--- Describe your changes in detail -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.