### PR TITLE
[SELC-4598] fix: fix on optional parameter institutionId for getUserInfo

### DIFF
--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/UserConnectorImpl.java
@@ -356,7 +356,12 @@ public class UserConnectorImpl implements UserConnector {
         }
 
         MatchOperation matchInstitutionExist = Aggregation.match(Criteria.where("institutions").size(1));
-        MatchOperation matchOperation = new MatchOperation(new Criteria().andOperator(criterias.toArray(new Criteria[criterias.size()])));
+        MatchOperation matchOperation;
+        if(!criterias.isEmpty()) {
+            matchOperation = new MatchOperation(new Criteria().andOperator(criterias.toArray(new Criteria[criterias.size()])));
+        } else {
+            matchOperation = new MatchOperation(new Criteria());
+        }
         Aggregation aggregation = Aggregation.newAggregation(matchUserId, unwindBindings, lookup, matchInstitutionExist, unwindProducts, matchOperation);
 
         return mongoOperations.aggregate(aggregation, "User", UserInstitutionAggregation.class).getMappedResults();


### PR DESCRIPTION
#### List of Changes

Added condition to check if criterias are empty or not

#### Motivation and Context

This fix is necessary to invoke the getUserInfo API with a null institutionId

#### How Has This Been Tested?

I have run the microservice locally and tested the API with path **/users/{userId}/institution-products**
