### PR TITLE
[SELC-4470] feat: modified createInstitutionFromIvass API to work using ivassCode instead of taxCode

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
@@ -24,5 +24,5 @@ public interface PartyRegistryProxyConnector {
 
     SaResource getSAFromAnac(String taxId);
 
-    AsResource getASFromIvass(String taxId);
+    AsResource getASFromIvass(String ivassCode);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/CustomError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/CustomError.java
@@ -16,6 +16,7 @@ public enum CustomError {
     INSTITUTION_LEGAL_NOT_FOUND("0037", "Institution with externalInstitutionId %s is not related to user"),
     CREATE_INSTITUTION_CONFLICT("0038", "Institution having externalId %s already exists"),
     CREATE_INSTITUTION_IPA_CONFLICT("0038", "Institution having taxCode %s and subunitCode %s already exists"),
+    CREATE_INSTITUTION_ORIGIN_CONFLICT("0038", "Institution having origin %s and originId %s already exists"),
     CREATE_INSTITUTION_NOT_FOUND("0039", "Institution having externalId %s not exists in registry"),
     INSTITUTION_TAX_CODE_NOT_FOUND("0040", "Cannot find Institution using taxCode %s"),
     ONBOARDING_INVALID_UPDATES("0046", "Cannot perform data overrides on institution having external id %s"),

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/Institution.java
@@ -25,6 +25,7 @@ public class Institution {
     private String address;
     private String zipCode;
     private String taxCode;
+    private String ivassCode;
     private String city;
     private String county;
     private String country;

--- a/connector/rest/docs/openapi/registry_proxy.json
+++ b/connector/rest/docs/openapi/registry_proxy.json
@@ -910,6 +910,79 @@
         } ]
       }
     },
+    "/insurance-companies/origin/{originId}" : {
+      "get" : {
+        "tags" : [ "insurance-companies" ],
+        "summary" : "Search insurance company by its taxCode",
+        "description" : "Returns only one insurance company.",
+        "operationId" : "searchByOriginIdUsingGET",
+        "parameters" : [ {
+          "name" : "originId",
+          "in" : "path",
+          "description" : "insurance company's IVASS unique identifier",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/InsuranceCompanyResource"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Internal Server Error",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/insurance-companies/{taxId}" : {
       "get" : {
         "tags" : [ "insurance-companies" ],

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
@@ -182,7 +182,6 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     @Override
     public AsResource getASFromIvass(String ivassCode) {
         try {
-            log.debug("getASFromIvass = {}", ivassCode);
             Assert.hasText(ivassCode, "IvassCode is required");
             ResponseEntity<InsuranceCompanyResource> result = restClient._searchByOriginIdUsingGET(ivassCode);
             log.debug("getASFromIvass = {}", ivassCode);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
@@ -182,6 +182,7 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     @Override
     public AsResource getASFromIvass(String ivassCode) {
         try {
+            if (ivassCode.matches("\\w*")) { log.debug("getASFromIvass = {}", ivassCode); }
             Assert.hasText(ivassCode, "IvassCode is required");
             ResponseEntity<InsuranceCompanyResource> result = restClient._searchByOriginIdUsingGET(ivassCode);
             log.debug("getASFromIvass = {}", ivassCode);

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
@@ -185,7 +185,6 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
             if (ivassCode.matches("\\w*")) { log.debug("getASFromIvass = {}", ivassCode); }
             Assert.hasText(ivassCode, "IvassCode is required");
             ResponseEntity<InsuranceCompanyResource> result = restClient._searchByOriginIdUsingGET(ivassCode);
-            log.debug("getASFromIvass = {}", ivassCode);
             if (result != null) {
                 return asMapper.toResource(result.getBody());
             }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
@@ -180,16 +180,16 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     }
 
     @Override
-    public AsResource getASFromIvass(String taxId) {
+    public AsResource getASFromIvass(String ivassCode) {
         try {
-            log.debug("getASFromIvass = {}", taxId);
-            Assert.hasText(taxId, "TaxId is required");
-            ResponseEntity<InsuranceCompanyResource> result = restClient._searchByTaxCodeUsingGET(taxId);
-            log.debug("getASFromIvass = {}", taxId);
+            log.debug("getASFromIvass = {}", ivassCode);
+            Assert.hasText(ivassCode, "IvassCode is required");
+            ResponseEntity<InsuranceCompanyResource> result = restClient._searchByOriginIdUsingGET(ivassCode);
+            log.debug("getASFromIvass = {}", ivassCode);
             if (result != null) {
                 return asMapper.toResource(result.getBody());
             }
-            throw new ResourceNotFoundException(String.format(CREATE_INSTITUTION_NOT_FOUND.getMessage(), taxId), CREATE_INSTITUTION_NOT_FOUND.getCode());
+            throw new ResourceNotFoundException(String.format(CREATE_INSTITUTION_NOT_FOUND.getMessage(), ivassCode), CREATE_INSTITUTION_NOT_FOUND.getCode());
         } catch (FeignException e) {
             throw new MsCoreException(e.getMessage(), String.valueOf(e.status()));
         }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
@@ -570,7 +570,6 @@ class PartyRegistryProxyConnectorImplTest {
     void getASFromIvassNotFound() {
         //given
         String ivassCode = "ivassCode";
-        when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(anyString())).thenThrow(ResourceNotFoundException.class);
         when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(anyString())).thenReturn(null);
 
         //when

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
@@ -236,7 +236,7 @@ class PartyRegistryProxyConnectorImplTest {
         FeignException feignException = mock(FeignException.class);
         when(partyRegistryProxyRestClient.getCategory(any(), any()))
                 .thenThrow(feignException);
-        assertThrows(MsCoreException.class, () -> partyRegistryProxyConnectorImpl.getCategory("origin","code"));
+        assertThrows(MsCoreException.class, () -> partyRegistryProxyConnectorImpl.getCategory("origin", "code"));
         verify(partyRegistryProxyRestClient).getCategory(any(), any());
     }
 
@@ -530,7 +530,7 @@ class PartyRegistryProxyConnectorImplTest {
     }
 
     @Test
-    void getSAFromAnac(){
+    void getSAFromAnac() {
         //given
         String taxId = "taxId";
         when(partyRegistryProxyRestClient.getSaByTaxId(anyString())).thenReturn(pdndResponse);
@@ -542,7 +542,7 @@ class PartyRegistryProxyConnectorImplTest {
     }
 
     @Test
-    void getSAFromAnacNotFound(){
+    void getSAFromAnacNotFound() {
         //given
         String taxId = "taxId";
         when(partyRegistryProxyRestClient.getSaByTaxId(anyString())).thenThrow(ResourceNotFoundException.class);
@@ -554,29 +554,39 @@ class PartyRegistryProxyConnectorImplTest {
     }
 
     @Test
-    void getASFromIvass(){
+    void getASFromIvass() {
         //given
-        ResponseEntity<InsuranceCompanyResource> response =  new ResponseEntity<>(asResponse, HttpStatus.FOUND);
-        String taxId = "taxId";
-        when(partyRegistryProxyRestClient._searchByTaxCodeUsingGET(anyString())).thenReturn(response);
+        ResponseEntity<InsuranceCompanyResource> response = new ResponseEntity<>(asResponse, HttpStatus.FOUND);
+        String ivassCode = "ivassCode";
+        when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(anyString())).thenReturn(response);
         //when
-        AsResource result = partyRegistryProxyConnectorImpl.getASFromIvass(taxId);
+        AsResource result = partyRegistryProxyConnectorImpl.getASFromIvass(ivassCode);
         //then
         checkNotNullFields(result);
-        verify(partyRegistryProxyRestClient, times(1))._searchByTaxCodeUsingGET(taxId);
+        verify(partyRegistryProxyRestClient, times(1))._searchByOriginIdUsingGET(ivassCode);
     }
 
     @Test
-    void getASFromIvassNotFound(){
+    void getASFromIvassNotFound() {
         //given
-        String taxId = "taxId";
-        when(partyRegistryProxyRestClient._searchByTaxCodeUsingGET(anyString())).thenThrow(ResourceNotFoundException.class);
+        String ivassCode = "ivassCode";
+        when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(anyString())).thenThrow(ResourceNotFoundException.class);
+        when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(anyString())).thenReturn(null);
+
         //when
-        Executable executable = () -> partyRegistryProxyConnectorImpl.getASFromIvass(taxId);
+        Executable executable = () -> partyRegistryProxyConnectorImpl.getASFromIvass(ivassCode);
         //then
         assertThrows(ResourceNotFoundException.class, executable);
-        verify(partyRegistryProxyRestClient, times(1))._searchByTaxCodeUsingGET(taxId);
+        verify(partyRegistryProxyRestClient, times(1))._searchByOriginIdUsingGET(ivassCode);
     }
 
+    @Test
+    void shouldThrowResourceNotFoundExceptionWhenIvassCodeNotFound() {
+        String ivassCode = "12345";
+
+        when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(ivassCode)).thenReturn(null);
+
+        assertThrows(ResourceNotFoundException.class, () -> partyRegistryProxyConnectorImpl.getASFromIvass(ivassCode));
+    }
 }
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -109,11 +109,11 @@ public class InstitutionServiceImpl implements InstitutionService {
 
     @Override
     public List<Institution> getInstitutions(String taxCode, String subunitCode, String origin, String originId) {
-        if(StringUtils.hasText(taxCode) && (StringUtils.hasText(origin) || StringUtils.hasText(originId))) {
+        if (StringUtils.hasText(taxCode) && (StringUtils.hasText(origin) || StringUtils.hasText(originId))) {
             throw new InvalidRequestException(GenericError.GET_INSTITUTIONS_REQUEST_ERROR.getMessage(), GenericError.GET_INSTITUTIONS_REQUEST_ERROR.getCode());
         }
 
-        if(StringUtils.hasText(taxCode)) {
+        if (StringUtils.hasText(taxCode)) {
             return institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
         } else {
             return institutionConnector.findByOriginAndOriginId(origin, originId);
@@ -175,11 +175,7 @@ public class InstitutionServiceImpl implements InstitutionService {
     public Institution createInstitutionFromIvass(Institution institution) {
         return createInstitutionStrategyFactory.createInstitutionStrategyIvass(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
-                        .taxCode(institution.getTaxCode())
-                        .subunitCode(institution.getSubunitCode())
-                        .subunitType(Optional.ofNullable(institution.getSubunitType())
-                                .map(InstitutionPaSubunitType::valueOf)
-                                .orElse(null))
+                        .ivassCode(institution.getIvassCode())
                         .build());
     }
 
@@ -191,6 +187,7 @@ public class InstitutionServiceImpl implements InstitutionService {
                 .description(institution.getDescription())
                 .build());
     }
+
     @Override
     public Institution createInstitutionByExternalId(String externalId) {
         checkIfAlreadyExists(externalId);
@@ -311,7 +308,7 @@ public class InstitutionServiceImpl implements InstitutionService {
     public Optional<GeographicTaxonomies> retrieveGeoTaxonomies(String code) {
         try {
             return Optional.of(partyRegistryProxyConnector.getExtByCode(code));
-        } catch (ResourceNotFoundException e){
+        } catch (ResourceNotFoundException e) {
             return Optional.empty();
         }
     }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyCommon.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyCommon.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import static it.pagopa.selfcare.mscore.constant.CustomError.CREATE_INSTITUTION_ORIGIN_CONFLICT;
+
 @Slf4j
 @Component
 public class CreateInstitutionStrategyCommon {
@@ -19,11 +21,18 @@ public class CreateInstitutionStrategyCommon {
     }
 
     protected void checkIfAlreadyExistsByTaxCodeAndSubunitCode(String taxCode, String subunitCode) {
-
         List<Institution> institutions = institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
         if (!institutions.isEmpty())
             throw new ResourceConflictException(String
                     .format(CustomError.CREATE_INSTITUTION_IPA_CONFLICT.getMessage(), taxCode, subunitCode),
                     CustomError.CREATE_INSTITUTION_CONFLICT.getCode());
+    }
+
+    protected void checkIfAlreadyExistByOriginAndOriginId(String origin, String originId) {
+        List<Institution> institutions = institutionConnector.findByOriginAndOriginId(origin, originId);
+        if (!institutions.isEmpty())
+            throw new ResourceConflictException(String.format(
+                    CREATE_INSTITUTION_ORIGIN_CONFLICT.getMessage(), origin, originId),
+                    CREATE_INSTITUTION_ORIGIN_CONFLICT.getCode());
     }
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIvass.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIvass.java
@@ -31,10 +31,9 @@ public class CreateInstitutionStrategyIvass extends CreateInstitutionStrategyCom
 
     @Override
     public Institution createInstitution(CreateInstitutionStrategyInput strategyInput) {
+        checkIfAlreadyExistByOriginAndOriginId(Origin.IVASS.name(), strategyInput.getIvassCode());
 
-        checkIfAlreadyExistsByTaxCodeAndSubunitCode(strategyInput.getTaxCode(), strategyInput.getSubunitCode());
-
-        AsResource asResource = partyRegistryProxyConnector.getASFromIvass(strategyInput.getTaxCode());
+        AsResource asResource = partyRegistryProxyConnector.getASFromIvass(strategyInput.getIvassCode());
 
         institution = addFieldsToInstitution(asResource);
         try {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/input/CreateInstitutionStrategyInput.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class CreateInstitutionStrategyInput {
 
     private String taxCode;
+    private String ivassCode;
     private String description;
     private InstitutionPaSubunitType subunitType;
     private List<InstitutionGeographicTaxonomies> geographicTaxonomies;

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -45,6 +45,9 @@ class CreateInstitutionStrategyTest {
     @Spy
     InstitutionMapper institutionMapper = new InstitutionMapperImpl();
 
+    @InjectMocks
+    CreateInstitutionStrategyIvass createInstitutionStrategyIvass;
+
 
     private static final InstitutionProxyInfo dummyInstitutionProxyInfo;
     private static final CategoryProxyInfo dummyCategoryProxyInfo;
@@ -117,6 +120,19 @@ class CreateInstitutionStrategyTest {
                 .createInstitution(CreateInstitutionStrategyInput.builder().subunitType(InstitutionPaSubunitType.AOO)
                         .build()));
 
+    }
+
+    @Test
+    void shouldThrowMsCoreExceptionWhenInstitutionAlreadyExists() {
+        String origin = "IVASS";
+        String originId = "12345";
+
+        when(institutionConnector.findByOriginAndOriginId(origin, originId)).thenReturn(List.of(new Institution()));
+
+        assertThrows(ResourceConflictException.class, () -> strategyFactory.createInstitutionStrategyIvass(new Institution())
+                .createInstitution(CreateInstitutionStrategyInput.builder()
+                        .ivassCode(originId)
+                        .build()));
     }
 
     @Test

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/util/TestUtils.java
@@ -44,7 +44,7 @@ public class TestUtils {
 
         return new Institution("42", "42", Origin.SELC.name(), "START - setupCommonData",
                 "The characteristics of someone or something", institutionType, "42 Main St", "42 Main St", "21654",
-                "TaxCode", "city", "county", "country", "istatCode", billing, onboarding, geographicTaxonomies, attributes, paymentServiceProvider,
+                "TaxCode","ivass", "city", "county", "country", "istatCode", billing, onboarding, geographicTaxonomies, attributes, paymentServiceProvider,
                 new DataProtectionOfficer(), null, null, "START - setupCommonData", "START - setupCommonData",
                 "START - setupCommonData", true, OffsetDateTime.now(), OffsetDateTime.now(), null, null, null, null, new PaAttributes(),false);
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
@@ -4,7 +4,6 @@ import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.model.onboarding.OnboardingRequest;
 import lombok.Data;
 
-import javax.validation.constraints.NotEmpty;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -23,8 +22,8 @@ public class InstitutionRequest {
     private String city;
     private String county;
     private String country;
-    @NotEmpty(message = "TaxCode is required")
     private String taxCode;
+    private String ivassCode;
 
     private BillingRequest billing;
     private List<OnboardingRequest> onboarding;

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
@@ -171,6 +171,7 @@ public class InstitutionMapperCustom {
         institution.setBusinessRegisterPlace(request.getBusinessRegisterPlace());
         institution.setSupportEmail(request.getSupportEmail());
         institution.setSupportPhone(request.getSupportPhone());
+        institution.setIvassCode(request.getIvassCode());
         if (request.getPaymentServiceProvider() != null)
             institution.setPaymentServiceProvider(toPaymentServiceProvider(request.getPaymentServiceProvider()));
         if (request.getDataProtectionOfficer() != null)


### PR DESCRIPTION
#### List of Changes

Modified createInstitutionFromIvass API to work using ivassCode instead of taxCode. In CreateInstitutionStrategyIvass now we don't check for previous persisted institution using taxCode, but we try to query using origin and originId.

#### Motivation and Context

In the context of foreign insurance companies onboarding, it is necessary to make it possible to create institutions using the Ivass code since the tax code is not always present.

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.