### PR TITLE
[SELC-4466] fix: removed ivassCode parameter, instead will use originId

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -175,7 +175,7 @@ public class InstitutionServiceImpl implements InstitutionService {
     public Institution createInstitutionFromIvass(Institution institution) {
         return createInstitutionStrategyFactory.createInstitutionStrategyIvass(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
-                        .ivassCode(institution.getIvassCode())
+                        .ivassCode(institution.getOriginId())
                         .build());
     }
 

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionRequest.java
@@ -23,7 +23,6 @@ public class InstitutionRequest {
     private String county;
     private String country;
     private String taxCode;
-    private String ivassCode;
     private BillingRequest billing;
     private List<OnboardingRequest> onboarding;
     private List<GeoTaxonomies> geographicTaxonomies;

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/InstitutionMapperCustom.java
@@ -171,7 +171,6 @@ public class InstitutionMapperCustom {
         institution.setBusinessRegisterPlace(request.getBusinessRegisterPlace());
         institution.setSupportEmail(request.getSupportEmail());
         institution.setSupportPhone(request.getSupportPhone());
-        institution.setIvassCode(request.getIvassCode());
         if (request.getPaymentServiceProvider() != null)
             institution.setPaymentServiceProvider(toPaymentServiceProvider(request.getPaymentServiceProvider()));
         if (request.getDataProtectionOfficer() != null)


### PR DESCRIPTION
#### List of Changes

removed ivassCode parameter, instead will use originId

#### Motivation and Context

it's better not to use a parameter called ivassCode, because selfcare-onboarding will not be able to provide it

#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.