### PR TITLE
SELC-4470 fix: renamed AsResource class in ASResource and set ExternalId as originId

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
@@ -24,5 +24,5 @@ public interface PartyRegistryProxyConnector {
 
     SaResource getSAFromAnac(String taxId);
 
-    AsResource getASFromIvass(String ivassCode);
+    ASResource getASFromIvass(String ivassCode);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/ASResource.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/ASResource.java
@@ -4,7 +4,7 @@ import it.pagopa.selfcare.mscore.constant.Origin;
 import lombok.Data;
 
 @Data
-public class AsResource {
+public class ASResource {
     private String id;
     private String originId;
     private String taxCode;

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
@@ -180,7 +180,7 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     }
 
     @Override
-    public AsResource getASFromIvass(String ivassCode) {
+    public ASResource getASFromIvass(String ivassCode) {
         try {
             if (ivassCode.matches("\\w*")) { log.debug("getASFromIvass = {}", ivassCode); }
             Assert.hasText(ivassCode, "IvassCode is required");

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/mapper/AsMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/mapper/AsMapper.java
@@ -1,6 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.rest.mapper;
 
-import it.pagopa.selfcare.mscore.model.institution.AsResource;
+import it.pagopa.selfcare.mscore.model.institution.ASResource;
 import it.pagopa.selfcare.registry_proxy.generated.openapi.v1.dto.InsuranceCompanyResource;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -8,5 +8,5 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface AsMapper {
     @Mapping(target = "origin", source="origin.value")
-    AsResource toResource(InsuranceCompanyResource response);
+    ASResource toResource(InsuranceCompanyResource response);
 }

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
@@ -560,7 +560,7 @@ class PartyRegistryProxyConnectorImplTest {
         String ivassCode = "ivassCode";
         when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(anyString())).thenReturn(response);
         //when
-        AsResource result = partyRegistryProxyConnectorImpl.getASFromIvass(ivassCode);
+        ASResource result = partyRegistryProxyConnectorImpl.getASFromIvass(ivassCode);
         //then
         checkNotNullFields(result);
         verify(partyRegistryProxyRestClient, times(1))._searchByOriginIdUsingGET(ivassCode);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIvass.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyIvass.java
@@ -5,7 +5,7 @@ import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;
 import it.pagopa.selfcare.mscore.constant.Origin;
 import it.pagopa.selfcare.mscore.core.strategy.input.CreateInstitutionStrategyInput;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
-import it.pagopa.selfcare.mscore.model.institution.AsResource;
+import it.pagopa.selfcare.mscore.model.institution.ASResource;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import lombok.extern.slf4j.Slf4j;
 
@@ -33,7 +33,7 @@ public class CreateInstitutionStrategyIvass extends CreateInstitutionStrategyCom
     public Institution createInstitution(CreateInstitutionStrategyInput strategyInput) {
         checkIfAlreadyExistByOriginAndOriginId(Origin.IVASS.name(), strategyInput.getIvassCode());
 
-        AsResource asResource = partyRegistryProxyConnector.getASFromIvass(strategyInput.getIvassCode());
+        ASResource asResource = partyRegistryProxyConnector.getASFromIvass(strategyInput.getIvassCode());
 
         institution = addFieldsToInstitution(asResource);
         try {
@@ -43,9 +43,9 @@ public class CreateInstitutionStrategyIvass extends CreateInstitutionStrategyCom
         }
     }
 
-    private Institution addFieldsToInstitution(AsResource asResource) {
-
-        institution.setExternalId(institution.getTaxCode());
+    private Institution addFieldsToInstitution(ASResource asResource) {
+        institution.setTaxCode(asResource.getTaxCode());
+        institution.setExternalId(asResource.getOriginId());
         institution.setOrigin(Origin.IVASS.getValue());
         institution.setOriginId(asResource.getOriginId());
         institution.setCreatedAt(OffsetDateTime.now());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -186,7 +186,7 @@ class CreateInstitutionStrategyTest {
     void shouldCreateInstitutionFromIvass() {
 
         Institution institution = TestUtils.dummyInstitutionAs();
-        AsResource asResource = new AsResource();
+        ASResource asResource = new ASResource();
         asResource.setOriginId("originId");
         asResource.setTaxCode("taxCode");
         asResource.setDescription("desc");


### PR DESCRIPTION
#### List of Changes

renamed AsResource class in ASResource and set originId as externalId when persisting new Institution from IVASS  

#### Motivation and Context


#### How Has This Been Tested?

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.