### PR TITLE
[SELC-4822] feat: add taxCodeSfe to contract queue

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -48,4 +48,4 @@ core:
   user-event-service:
     type: ${CORE_USER_EVENT_SERVICE_TYPE:ignore}
   contract-event-service:
-    type: ${CORE_CONTRACT_EVENT_SERVICE_TYPE:send}
+    type: ${CORE_CONTRACT_EVENT_SERVICE_TYPE:ignore}

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -48,4 +48,4 @@ core:
   user-event-service:
     type: ${CORE_USER_EVENT_SERVICE_TYPE:ignore}
   contract-event-service:
-    type: ${CORE_CONTRACT_EVENT_SERVICE_TYPE:ignore}
+    type: ${CORE_CONTRACT_EVENT_SERVICE_TYPE:send}

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -4435,6 +4435,9 @@
           "taxCode" : {
             "type" : "string"
           },
+          "taxCodeSfe" : {
+            "type" : "string"
+          },
           "updatedAt" : {
             "type" : "string",
             "format" : "date-time"

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/InstitutionToNotify.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.model.institution.PaymentServiceProvider;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class InstitutionToNotify {
 
     private InstitutionType institutionType;
@@ -16,6 +18,7 @@ public class InstitutionToNotify {
     private String digitalAddress;
     private String address;
     private String taxCode;
+    private String taxCodeSfe;
     private String origin;
     private String originId;
     private String zipCode;

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImpl.java
@@ -180,6 +180,7 @@ public class ContractEventNotificationServiceImpl implements ContractEventNotifi
         toNotify.setOriginId(institution.getOriginId());
         toNotify.setZipCode(institution.getZipCode());
         toNotify.setPaymentServiceProvider(institution.getPaymentServiceProvider());
+        toNotify.setTaxCodeSfe(institution.getTaxCodeSfe());
         if (institution.getSubunitType() != null && !institution.getSubunitType().equals("EC")) {
             try {
                 InstitutionPaSubunitType.valueOf(institution.getSubunitType());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImpl.java
@@ -181,13 +181,10 @@ public class ContractEventNotificationServiceImpl implements ContractEventNotifi
         toNotify.setZipCode(institution.getZipCode());
         toNotify.setPaymentServiceProvider(institution.getPaymentServiceProvider());
         toNotify.setTaxCodeSfe(institution.getTaxCodeSfe());
-        if (institution.getSubunitType() != null && !institution.getSubunitType().equals("EC")) {
-            try {
-                InstitutionPaSubunitType.valueOf(institution.getSubunitType());
-                toNotify.setSubUnitType(institution.getSubunitType());
-                toNotify.setSubUnitCode(institution.getSubunitCode());
-            } catch (IllegalArgumentException ignored) {
-            }
+        if (institution.getSubunitType() != null && !"EC".equals(institution.getSubunitType())) {
+            InstitutionPaSubunitType.valueOf(institution.getSubunitType());
+            toNotify.setSubUnitType(institution.getSubunitType());
+            toNotify.setSubUnitCode(institution.getSubunitCode());
         }
         RootParent rootParent = new RootParent();
         rootParent.setDescription(institution.getParentDescription());
@@ -198,7 +195,7 @@ public class ContractEventNotificationServiceImpl implements ContractEventNotifi
             toNotify.setRootParent(rootParent);
         }
 
-        if (institution.getAttributes() != null && institution.getAttributes().size() > 0) {
+        if (institution.getAttributes() != null && !institution.getAttributes().isEmpty()) {
             toNotify.setCategory(institution.getAttributes().get(0).getCode());
         }
         if (institution.getCity() == null) {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImplTest.java
@@ -40,7 +40,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class ContractEventNotificationServiceImplTest {
+class ContractEventNotificationServiceImplTest {
 
 
 
@@ -77,7 +77,7 @@ public class ContractEventNotificationServiceImplTest {
         Onboarding onboarding = mockInstance(new Onboarding());
         onboarding.setProductId("prod");
 
-        Institution institution = mockInstance(new Institution(), "setCity", "setCounty", "setCountry");
+        Institution institution = mockInstance(new Institution(), "setCity", "setCounty", "setCountry", "setSubunitType");
         institution.setOrigin("IPA");
         institution.setOnboarding(List.of(onboarding));
 
@@ -150,7 +150,7 @@ public class ContractEventNotificationServiceImplTest {
         Onboarding onboarding = mockInstance(new Onboarding());
         onboarding.setProductId("prod");
 
-        Institution institution = mockInstance(new Institution());
+        Institution institution = mockInstance(new Institution(), "setSubunitType");
         institution.setOrigin("IPA");
         institution.setOnboarding(List.of(onboarding));
 
@@ -198,7 +198,7 @@ public class ContractEventNotificationServiceImplTest {
         Onboarding onboarding = mockInstance(new Onboarding());
         onboarding.setProductId("prod");
 
-        Institution institution = mockInstance(new Institution(), "setCity");
+        Institution institution = mockInstance(new Institution(), "setCity", "setSubunitType");
         institution.setOrigin("IPA");
         institution.setOnboarding(List.of(onboarding));
 
@@ -263,7 +263,7 @@ public class ContractEventNotificationServiceImplTest {
         Onboarding onboarding = mockInstance(new Onboarding());
         onboarding.setProductId("prod");
 
-        Institution institution = mockInstance(new Institution(), "setCity", "setCounty", "setCountry");
+        Institution institution = mockInstance(new Institution(), "setCity", "setCounty", "setCountry", "setSubunitType");
         institution.setOrigin("IPA");
         institution.setOnboarding(List.of(onboarding));
 
@@ -516,7 +516,7 @@ public class ContractEventNotificationServiceImplTest {
     }
 
     private static Institution createInstitution(String institutionId, Onboarding onboarding) {
-        Institution institution = mockInstance(new Institution());
+        Institution institution = mockInstance(new Institution(), "setSubunitType");
         institution.setId(institutionId);
         institution.setOrigin("IPA");
         institution.setOnboarding(List.of(onboarding));
@@ -524,7 +524,7 @@ public class ContractEventNotificationServiceImplTest {
     }
 
     private static Institution createInstitutionWithoutLocation(String institutionId, Onboarding onboarding) {
-        Institution institution = mockInstance(new Institution(), "setCity", "setCounty", "setCountry");
+        Institution institution = mockInstance(new Institution(), "setCity", "setCounty", "setCountry", "setSubunitType");
         institution.setId(institutionId);
         institution.setOrigin("IPA");
         institution.setOnboarding(List.of(onboarding));

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/ContractEventNotificationServiceImplTest.java
@@ -7,6 +7,7 @@ import it.pagopa.selfcare.mscore.api.UserRegistryConnector;
 import it.pagopa.selfcare.mscore.config.CoreConfig;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.config.KafkaPropertiesConfig;
+import it.pagopa.selfcare.mscore.core.util.InstitutionPaSubunitType;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.Certification;
@@ -468,6 +469,8 @@ public class ContractEventNotificationServiceImplTest {
         Onboarding onboarding = createOnboarding(tokenId, "prod");
         Institution institutionMock = createInstitutionWithoutLocation(institutionId, onboarding);
         institutionMock.setRootParentId(null);
+        institutionMock.setSubunitType(InstitutionPaSubunitType.UO.name());
+        institutionMock.setTaxCodeSfe("taxCodeSfe");
         Token tokenMock = createToken(institutionId, tokenId, null,
                 RelationshipState.DELETED,
                 OffsetDateTime.parse("2020-11-01T10:00:00Z"), // createdAt
@@ -481,6 +484,7 @@ public class ContractEventNotificationServiceImplTest {
         //then
         assertNotNull(notification.getInstitution().getCategory());
         assertNotNull(notification.getInstitution().getCity());
+        assertEquals(institutionMock.getTaxCodeSfe(), notification.getInstitution().getTaxCodeSfe());
         verify(partyRegistryProxyConnectorMock, times(1)).getInstitutionById(institutionMock.getExternalId());
         verify(partyRegistryProxyConnectorMock, times(1)).getExtByCode(any());
     }
@@ -494,7 +498,6 @@ public class ContractEventNotificationServiceImplTest {
         Attributes attribute = new Attributes();
         attribute.setCode("code");
         institutionMock.setAttributes(List.of(attribute));
-        institutionMock.setOrigin("IPA");
         institutionMock.setCity(null);
         institutionMock.setRootParentId(null);
         Token tokenMock = createToken(institutionId, tokenId, null,


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add taxCodeSfe in InstitutionToNotify model
- add taxCodeSfe setting in ToInstitutionToNotify mapper
- add anotation to avoid null fields in queue message
- align open api

<!--- Describe your changes in detail -->

#### Motivation and Context
It's requested to persist codiceFiscaleSfe for UO to queue.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It has been tested by running locally ms-core microservice pointing to dev queue.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.