### PR TITLE
[SELC-4711] feat: add v2 of API getDelegations to manage pagination

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -348,6 +348,135 @@
         } ]
       }
     },
+    "/v2/delegations" : {
+      "get" : {
+        "tags" : [ "Delegation", "external-v2", "support" ],
+        "summary" : "Retrieve institution's delegations with pagination",
+        "description" : "Retrieve institution's delegations with pagination",
+        "operationId" : "getDelegationsUsingGET_1",
+        "parameters" : [ {
+          "name" : "institutionId",
+          "in" : "query",
+          "description" : "The internal identifier of the institution",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "brokerId",
+          "in" : "query",
+          "description" : "The internal identifier of the institution",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "productId",
+          "in" : "query",
+          "description" : "Product's unique identifier",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "search",
+          "in" : "query",
+          "description" : "Description ente",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "taxCode",
+          "in" : "query",
+          "description" : "Institution's tax code",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "mode",
+          "in" : "query",
+          "description" : "Mode (full or normal) to retreieve institution's delegations",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "FULL", "NORMAL" ]
+          }
+        }, {
+          "name" : "order",
+          "in" : "query",
+          "description" : "Order to show response NONE, ASC, DESC",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "string",
+            "enum" : [ "ASC", "DESC", "NONE" ]
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "page",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }, {
+          "name" : "size",
+          "in" : "query",
+          "description" : "size",
+          "required" : false,
+          "style" : "form",
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/DelegationWithPaginationResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/external/institutions" : {
       "get" : {
         "tags" : [ "External" ],
@@ -2788,6 +2917,21 @@
           }
         }
       },
+      "DelegationWithPaginationResponse" : {
+        "title" : "DelegationWithPaginationResponse",
+        "type" : "object",
+        "properties" : {
+          "delegations" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/DelegationResponse"
+            }
+          },
+          "pageInfo" : {
+            "$ref" : "#/components/schemas/PageInfo"
+          }
+        }
+      },
       "GeoTaxonomies" : {
         "title" : "GeoTaxonomies",
         "type" : "object",
@@ -3552,6 +3696,28 @@
             "items" : {
               "$ref" : "#/components/schemas/OnboardingResponse"
             }
+          }
+        }
+      },
+      "PageInfo" : {
+        "title" : "PageInfo",
+        "type" : "object",
+        "properties" : {
+          "pageNo" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "pageSize" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "totalElements" : {
+            "type" : "integer",
+            "format" : "int64"
+          },
+          "totalPages" : {
+            "type" : "integer",
+            "format" : "int64"
           }
         }
       },

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
@@ -4,6 +4,8 @@ import it.pagopa.selfcare.mscore.constant.DelegationState;
 import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
+import it.pagopa.selfcare.mscore.model.delegation.GetDelegationParameters;
 
 import java.util.List;
 
@@ -12,6 +14,7 @@ public interface DelegationConnector {
     Delegation save(Delegation delegation);
     boolean checkIfExistsWithStatus(Delegation delegation, DelegationState status);
     List<Delegation> find(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Order order, Integer page, Integer size);
+    DelegationWithPagination findAndCount(GetDelegationParameters delegationParameters);
     Delegation findByIdAndModifyStatus(String delegationId, DelegationState status);
     boolean checkIfDelegationsAreActive(String institutionId);
     Delegation findAndActivate(String from, String to, String productId);

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/DelegationWithPagination.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/DelegationWithPagination.java
@@ -1,0 +1,19 @@
+package it.pagopa.selfcare.mscore.model.delegation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DelegationWithPagination {
+
+    private List<Delegation> delegations;
+    private PageInfo pageInfo;
+
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/GetDelegationParameters.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/GetDelegationParameters.java
@@ -1,0 +1,20 @@
+package it.pagopa.selfcare.mscore.model.delegation;
+
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
+import it.pagopa.selfcare.mscore.constant.Order;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetDelegationParameters {
+    private String from;
+    private String to;
+    private String productId;
+    private String search;
+    private String taxCode;
+    private GetDelegationsMode mode;
+    private Order order;
+    private Integer page;
+    private Integer size;
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/PageInfo.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/PageInfo.java
@@ -1,0 +1,17 @@
+package it.pagopa.selfcare.mscore.model.delegation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PageInfo {
+    private long pageSize;
+    private long pageNo;
+    private long totalElements;
+    private long totalPages;
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
@@ -4,6 +4,8 @@ import it.pagopa.selfcare.mscore.constant.DelegationState;
 import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
+import it.pagopa.selfcare.mscore.model.delegation.GetDelegationParameters;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +17,6 @@ public interface DelegationService {
     List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Optional<Order> order, Optional<Integer> page, Optional<Integer> size);
     Delegation createDelegationFromInstitutionsTaxCode(Delegation delegation);
     void deleteDelegationByDelegationId(String delegationId);
+    DelegationWithPagination getDelegationsV2(GetDelegationParameters delegationParameters);
+
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
@@ -10,6 +10,8 @@ import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
 import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
+import it.pagopa.selfcare.mscore.model.delegation.GetDelegationParameters;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -151,7 +153,6 @@ public class DelegationServiceImpl implements DelegationService {
         }
     }
 
-
     @Override
     public boolean checkIfExistsWithStatus(Delegation delegation, DelegationState status) {
         return delegationConnector.checkIfExistsWithStatus(delegation, status);
@@ -162,5 +163,10 @@ public class DelegationServiceImpl implements DelegationService {
                                            Optional<Order> order, Optional<Integer> page, Optional<Integer> size) {
         int pageSize = size.filter(s -> s > 0).filter(s -> s <= DEFAULT_DELEGATIONS_PAGE_SIZE).orElse(DEFAULT_DELEGATIONS_PAGE_SIZE);
         return delegationConnector.find(from, to, productId, search, taxCode, mode, order.orElse(Order.NONE), page.orElse(0), pageSize);
+    }
+
+    @Override
+    public DelegationWithPagination getDelegationsV2(GetDelegationParameters delegationParameters) {
+        return delegationConnector.findAndCount(delegationParameters);
     }
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -245,7 +245,7 @@ class DelegationServiceImplTest {
         when(delegationConnector.findAndCount(any())).thenReturn(delegationWithPagination);
         //When
         DelegationWithPagination response = delegationServiceImpl.getDelegationsV2(createDelegationParameters("from", "to", "productId", null, null,
-                GetDelegationsMode.NORMAL, Optional.empty(), Optional.of(0), Optional.of(100)));
+                GetDelegationsMode.NORMAL, null, 0, 100));
         //Then
         verify(delegationConnector).findAndCount(any());
 
@@ -375,7 +375,7 @@ class DelegationServiceImplTest {
 
     private GetDelegationParameters createDelegationParameters(String from, String to, String productId,
                                                                String search, String taxCode, GetDelegationsMode mode,
-                                                               Optional<Order> order, Optional<Integer> page, Optional<Integer> size) {
+                                                               Order order, Integer page, Integer size) {
         return GetDelegationParameters.builder()
                 .from(from)
                 .to(to)

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -16,6 +16,7 @@ import it.pagopa.selfcare.mscore.model.institution.Institution;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -247,7 +248,8 @@ class DelegationServiceImplTest {
         DelegationWithPagination response = delegationServiceImpl.getDelegationsV2(createDelegationParameters("from", "to", "productId", null, null,
                 GetDelegationsMode.NORMAL, null, 0, 100));
         //Then
-        verify(delegationConnector).findAndCount(any());
+        ArgumentCaptor<GetDelegationParameters> argumentCaptor = ArgumentCaptor.forClass(GetDelegationParameters.class);
+        verify(delegationConnector).findAndCount(argumentCaptor.capture());
 
         assertNotNull(response);
         assertNotNull(response.getDelegations());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -244,12 +244,16 @@ class DelegationServiceImplTest {
         delegation.setId("id");
         DelegationWithPagination delegationWithPagination = new DelegationWithPagination(List.of(delegation), new PageInfo(10, 0, 10, 1));
         when(delegationConnector.findAndCount(any())).thenReturn(delegationWithPagination);
+        GetDelegationParameters delegationParameters = createDelegationParameters("from", "to", "productId", null, null,
+                GetDelegationsMode.NORMAL, null, 0, 100);
+
         //When
-        DelegationWithPagination response = delegationServiceImpl.getDelegationsV2(createDelegationParameters("from", "to", "productId", null, null,
-                GetDelegationsMode.NORMAL, null, 0, 100));
+        DelegationWithPagination response = delegationServiceImpl.getDelegationsV2(delegationParameters);
         //Then
         ArgumentCaptor<GetDelegationParameters> argumentCaptor = ArgumentCaptor.forClass(GetDelegationParameters.class);
         verify(delegationConnector).findAndCount(argumentCaptor.capture());
+        assertNotNull(argumentCaptor);
+        assertEquals(argumentCaptor.getValue(), delegationParameters);
 
         assertNotNull(response);
         assertNotNull(response.getDelegations());

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
@@ -22,6 +22,7 @@
     import org.springframework.web.bind.annotation.RequestParam;
     import org.springframework.web.bind.annotation.RestController;
 
+    import javax.validation.constraints.Min;
     import java.util.Objects;
 
     @RestController
@@ -67,8 +68,8 @@
                                                                        @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
                                                                        @ApiParam("${swagger.mscore.institutions.delegations.order}")
                                                                        @RequestParam(name = "order", required = false, defaultValue = "NONE") Order order,
-                                                                       @RequestParam(name = "page", required = false, defaultValue = "0") Integer page,
-                                                                       @RequestParam(name = "size", required = false, defaultValue = "10000") Integer size) {
+                                                                       @RequestParam (name = "page", required = false, defaultValue = "0") @Min(0) Integer page,
+                                                                       @RequestParam(name = "size", required = false, defaultValue = "10000") @Min(1) Integer size) {
 
             if(Objects.isNull(institutionId) && Objects.isNull(brokerId))
                 throw new InvalidRequestException("institutionId or brokerId must not be null!!", GenericError.GENERIC_ERROR.getCode());

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
@@ -1,0 +1,94 @@
+    package it.pagopa.selfcare.mscore.web.controller;
+
+    import io.swagger.annotations.Api;
+    import io.swagger.annotations.ApiOperation;
+    import io.swagger.annotations.ApiParam;
+    import io.swagger.v3.oas.annotations.tags.Tag;
+    import it.pagopa.selfcare.mscore.constant.GenericError;
+    import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
+    import it.pagopa.selfcare.mscore.constant.Order;
+    import it.pagopa.selfcare.mscore.core.DelegationService;
+    import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
+    import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
+    import it.pagopa.selfcare.mscore.model.delegation.GetDelegationParameters;
+    import it.pagopa.selfcare.mscore.web.model.delegation.DelegationWithPaginationResponse;
+    import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapper;
+    import lombok.extern.slf4j.Slf4j;
+    import org.springframework.http.HttpStatus;
+    import org.springframework.http.MediaType;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.GetMapping;
+    import org.springframework.web.bind.annotation.RequestMapping;
+    import org.springframework.web.bind.annotation.RequestParam;
+    import org.springframework.web.bind.annotation.RestController;
+
+    import java.util.Objects;
+
+    @RestController
+    @RequestMapping(value = "/v2/delegations", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Api(tags = "Delegation")
+    @Slf4j
+    public class DelegationV2Controller {
+
+        private final DelegationService delegationService;
+        private final DelegationMapper delegationMapper;
+
+        public DelegationV2Controller(DelegationService delegationService,
+                                      DelegationMapper delegationMapper) {
+            this.delegationService = delegationService;
+            this.delegationMapper = delegationMapper;
+        }
+
+        /**
+         * The function get delegations
+         *
+         * @param institutionId String
+         * @return InstitutionResponse
+         * * Code: 200, Message: successful operation, DataType: List<DelegationResponse>
+         * * Code: 404, Message: Institution data not found, DataType: Problem
+         * * Code: 400, Message: Bad Request, DataType: Problem
+         */
+        @Tag(name = "external-v2")
+        @Tag(name = "support")
+        @Tag(name = "Delegation")
+        @ApiOperation(value = "${swagger.mscore.institutions.delegationsV2}", notes = "${swagger.mscore.institutions.delegationsv2}")
+        @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+        public ResponseEntity<DelegationWithPaginationResponse> getDelegations(@ApiParam("${swagger.mscore.institutions.model.institutionId}")
+                                                                       @RequestParam(name = "institutionId", required = false) String institutionId,
+                                                                       @ApiParam("${swagger.mscore.institutions.model.institutionId}")
+                                                                       @RequestParam(name = "brokerId", required = false) String brokerId,
+                                                                       @ApiParam("${swagger.mscore.product.model.id}")
+                                                                       @RequestParam(name = "productId", required = false) String productId,
+                                                                       @ApiParam("${swagger.mscore.institutions.model.description}")
+                                                                       @RequestParam(name = "search", required = false) String search,
+                                                                       @ApiParam("${swagger.mscore.institutions.model.taxCode}")
+                                                                       @RequestParam(name = "taxCode", required = false) String taxCode,
+                                                                       @ApiParam("${swagger.mscore.institutions.delegations.mode}")
+                                                                       @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
+                                                                       @ApiParam("${swagger.mscore.institutions.delegations.order}")
+                                                                       @RequestParam(name = "order", required = false, defaultValue = "NONE") Order order,
+                                                                       @RequestParam(name = "page", required = false, defaultValue = "0") Integer page,
+                                                                       @RequestParam(name = "size", required = false, defaultValue = "10000") Integer size) {
+
+            if(Objects.isNull(institutionId) && Objects.isNull(brokerId))
+                throw new InvalidRequestException("institutionId or brokerId must not be null!!", GenericError.GENERIC_ERROR.getCode());
+
+            GetDelegationParameters delegationParameters = GetDelegationParameters.builder()
+                    .from(institutionId)
+                    .to(brokerId)
+                    .productId(productId)
+                    .search(search)
+                    .taxCode(taxCode)
+                    .mode(mode)
+                    .order(order)
+                    .page(page)
+                    .size(size)
+                    .build();
+
+            DelegationWithPagination delegationWithPagination = delegationService.getDelegationsV2(delegationParameters);
+
+            DelegationWithPaginationResponse response = new DelegationWithPaginationResponse(delegationWithPagination.getDelegations().stream().map(delegationMapper::toDelegationResponse).toList(), delegationWithPagination.getPageInfo());
+
+            return ResponseEntity.status(HttpStatus.OK).body(response);
+        }
+    }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationWithPaginationResponse.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/delegation/DelegationWithPaginationResponse.java
@@ -1,0 +1,20 @@
+package it.pagopa.selfcare.mscore.web.model.delegation;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import it.pagopa.selfcare.mscore.model.delegation.PageInfo;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class DelegationWithPaginationResponse {
+
+    private List<DelegationResponse> delegations;
+    private PageInfo pageInfo;
+
+}

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -93,6 +93,7 @@ swagger.mscore.users.delete.products=Delete logically the association institutio
 swagger.mscore.api.users.updateUserStatus=Update user status with optional filter for institution, product, role and productRole
 swagger.mscore.api.users.getOnboardedUsers=Retrieve onboarded users according to identifiers in input
 swagger.mscore.institutions.delegations=Retrieve institution's delegations
+swagger.mscore.institutions.delegationsV2=Retrieve institution's delegations with pagination
 swagger.mscore.institutions.delegations.mode=Mode (full or normal) to retreieve institution's delegations
 swagger.mscore.institutions.delegations.order=Order to show response NONE, ASC, DESC
 swagger.mscore.institutions.brokers=Retrieve institution brokers

--- a/web/src/main/resources/swagger/swagger_it.properties
+++ b/web/src/main/resources/swagger/swagger_it.properties
@@ -71,6 +71,7 @@ swagger.mscore.delegation.delete=Il servizio elimina un'associazione tra l'ente 
 swagger.mscore.delegation.model.delegationId=Identificativo interno della delega
 swagger.mscore.users.products=Il servizio restituisce la lista dei prodotti con rispettivo ruolo di cui l'utente è abilitato
 swagger.mscore.institutions.delegations=Il servizio recupera la lista delle deleghe di una institution
+swagger.mscore.institutions.delegationsV2=Il servizio recupera la lista delle deleghe di una institution con paginazione
 swagger.mscore.users=Il servizio restituisce i dati dell'utente dato lo userId e il productId (opzionale)
 swagger.mscore.users.delete.products=Eliminazione logica dell'associazione product e institution con l'user
 swagger.mscore.users.userId=Identificativo univoco dell'utente

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2ControllerTest.java
@@ -1,0 +1,262 @@
+package it.pagopa.selfcare.mscore.web.controller;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.pagopa.selfcare.mscore.constant.DelegationType;
+import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
+import it.pagopa.selfcare.mscore.constant.Order;
+import it.pagopa.selfcare.mscore.core.DelegationService;
+import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
+import it.pagopa.selfcare.mscore.model.delegation.GetDelegationParameters;
+import it.pagopa.selfcare.mscore.model.delegation.PageInfo;
+import it.pagopa.selfcare.mscore.web.model.delegation.DelegationResponse;
+import it.pagopa.selfcare.mscore.web.model.delegation.DelegationWithPaginationResponse;
+import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapper;
+import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapperImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.util.NestedServletException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ContextConfiguration(classes = {DelegationV2Controller.class})
+@ExtendWith(MockitoExtension.class)
+class DelegationV2ControllerTest {
+
+    @InjectMocks
+    private DelegationV2Controller delegationController;
+
+    @Mock
+    private DelegationService delegationService;
+
+    @Spy
+    private DelegationMapper delegationResourceMapper = new DelegationMapperImpl();
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    final String FROM1 = "from1";
+    final String FROM2 = "from2";
+    final String TO1 = "to1";
+
+    /**
+     * Method under test: {@link InstitutionController#findFromProduct(String, Integer, Integer)}
+     */
+    @Test
+    void getDelegations_shouldInvalidRequest() {
+
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/v2/delegations?&productId={productId}", "productId");
+
+        assertThrows(NestedServletException.class, () ->
+            MockMvcBuilders.standaloneSetup(delegationController)
+                    .build()
+                    .perform(requestBuilder));
+        
+    }
+
+    /**
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     */
+    @Test
+    void getDelegations_shouldGetData() throws Exception {
+        // Given
+        Delegation expectedDelegation = dummyDelegation();
+        PageInfo exptectedPageInfo = new PageInfo(10000, 0, 1, 1);
+
+        DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(List.of(expectedDelegation), exptectedPageInfo);
+
+        when(delegationService.getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
+                expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Optional.empty(), Optional.empty(), Optional.empty())))
+                .thenReturn(expectedDelegationWithPagination);
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/v2/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}&mode={mode}", expectedDelegation.getFrom(),
+                        expectedDelegation.getTo(), expectedDelegation.getProductId(), GetDelegationsMode.NORMAL);
+        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andReturn();
+
+        DelegationWithPaginationResponse response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getDelegations()).isNotNull();
+        assertThat(response.getPageInfo()).isNotNull();
+        assertThat(response.getDelegations().size()).isEqualTo(1);
+        DelegationResponse actualDelegation = response.getDelegations().get(0);
+        PageInfo actualPageInfo = response.getPageInfo();
+        assertThat(actualDelegation.getId()).isEqualTo(expectedDelegation.getId());
+        assertThat(actualDelegation.getInstitutionName()).isEqualTo(expectedDelegation.getInstitutionFromName());
+        assertThat(actualDelegation.getBrokerId()).isEqualTo(expectedDelegation.getTo());
+        assertThat(actualDelegation.getProductId()).isEqualTo(expectedDelegation.getProductId());
+        assertThat(actualDelegation.getInstitutionId()).isEqualTo(expectedDelegation.getFrom());
+        assertThat(actualDelegation.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
+        assertThat(actualPageInfo).isEqualTo(exptectedPageInfo);
+
+        verify(delegationService, times(1))
+                .getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
+                        expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Optional.empty(),
+                        Optional.empty(), Optional.empty()));
+
+        verifyNoMoreInteractions(delegationService);
+    }
+
+    @Test
+    void getDelegations_shouldGetDataCustom() throws Exception {
+        // Given
+        List<Delegation> expectedDelegations = new ArrayList<>();
+        Delegation delegation1 = createDelegation("1", FROM1, TO1);
+        Delegation delegation2 = createDelegation("2", FROM2, TO1);
+        expectedDelegations.add(delegation1);
+        expectedDelegations.add(delegation2);
+
+        PageInfo exptectedPageInfo = new PageInfo(10000, 0, 2, 1);
+
+        DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(expectedDelegations, exptectedPageInfo);
+
+        when(delegationService.getDelegationsV2(createDelegationParameters(null, TO1,
+                null, null, null, GetDelegationsMode.FULL, Optional.empty(), Optional.empty(), Optional.empty())))
+                .thenReturn(expectedDelegationWithPagination);
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/v2/delegations?brokerId={brokerId}&mode={mode}", TO1, GetDelegationsMode.FULL);
+        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andReturn();
+
+        DelegationWithPaginationResponse response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getDelegations()).isNotNull();
+        assertThat(response.getPageInfo()).isNotNull();
+        assertThat(response.getDelegations().size()).isEqualTo(2);
+        DelegationResponse actualDelegation = response.getDelegations().get(0);
+        PageInfo actualPageInfo = response.getPageInfo();
+        assertThat(actualDelegation.getId()).isEqualTo(delegation1.getId());
+        assertThat(actualDelegation.getInstitutionName()).isEqualTo(delegation1.getInstitutionFromName());
+        assertThat(actualDelegation.getBrokerId()).isEqualTo(delegation1.getTo());
+        assertThat(actualDelegation.getProductId()).isEqualTo(delegation1.getProductId());
+        assertThat(actualDelegation.getInstitutionId()).isEqualTo(delegation1.getFrom());
+        assertThat(actualDelegation.getInstitutionRootName()).isEqualTo(delegation1.getInstitutionFromRootName());
+        assertThat(actualPageInfo).isEqualTo(exptectedPageInfo);
+
+        verify(delegationService, times(1))
+                .getDelegationsV2(createDelegationParameters(null, TO1, null,
+                        null, null, GetDelegationsMode.FULL, Optional.empty(),
+                        Optional.empty(), Optional.empty()));
+        verifyNoMoreInteractions(delegationService);
+    }
+
+    /**
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     */
+    @Test
+    void getDelegations_shouldGetData_nullMode() throws Exception {
+        // Given
+        Delegation expectedDelegation = dummyDelegation();
+        PageInfo exptectedPageInfo = new PageInfo(10000, 0, 1, 1);
+
+        DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(List.of(expectedDelegation), exptectedPageInfo);
+
+        when(delegationService.getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
+                expectedDelegation.getProductId(), null, null, null, Optional.empty(), Optional.empty(), Optional.empty())))
+                .thenReturn(expectedDelegationWithPagination);
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/v2/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}", expectedDelegation.getFrom(),
+                        expectedDelegation.getTo(), expectedDelegation.getProductId());
+        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andReturn();
+
+        DelegationWithPaginationResponse response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getDelegations()).isNotNull();
+        assertThat(response.getPageInfo()).isNotNull();
+        assertThat(response.getDelegations().size()).isEqualTo(1);
+        DelegationResponse actualDelegation = response.getDelegations().get(0);
+        PageInfo actualPageInfo = response.getPageInfo();
+        assertThat(actualDelegation.getId()).isEqualTo(expectedDelegation.getId());
+        assertThat(actualDelegation.getInstitutionName()).isEqualTo(expectedDelegation.getInstitutionFromName());
+        assertThat(actualDelegation.getBrokerId()).isEqualTo(expectedDelegation.getTo());
+        assertThat(actualDelegation.getProductId()).isEqualTo(expectedDelegation.getProductId());
+        assertThat(actualDelegation.getInstitutionId()).isEqualTo(expectedDelegation.getFrom());
+        assertThat(actualDelegation.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
+        assertThat(actualPageInfo).isEqualTo(exptectedPageInfo);
+
+        verify(delegationService, times(1))
+                .getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
+                        expectedDelegation.getProductId(), null, null, null, Optional.empty(), Optional.empty(), Optional.empty()));
+        verifyNoMoreInteractions(delegationService);
+    }
+
+    private Delegation dummyDelegation() {
+        Delegation delegation = new Delegation();
+        delegation.setFrom("from");
+        delegation.setTo("to");
+        delegation.setId("setId");
+        delegation.setProductId("setProductId");
+        delegation.setType(DelegationType.PT);
+        delegation.setInstitutionFromName("setInstitutionFromName");
+        delegation.setInstitutionFromRootName("setInstitutionFromRootName");
+        return delegation;
+    }
+
+    private Delegation createDelegation(String pattern, String from, String to) {
+        Delegation delegation = new Delegation();
+        delegation.setId("id_" + pattern);
+        delegation.setProductId("productId");
+        delegation.setType(DelegationType.PT);
+        delegation.setTo(to);
+        delegation.setFrom(from);
+        delegation.setInstitutionFromName("name_" + from);
+        delegation.setInstitutionFromRootName("name_" + to);
+        return delegation;
+    }
+
+    private GetDelegationParameters createDelegationParameters(String from, String to, String productId,
+                                                               String search, String taxCode, GetDelegationsMode mode,
+                                                               Optional<Order> order, Optional<Integer> page, Optional<Integer> size) {
+        return GetDelegationParameters.builder()
+                .from(from)
+                .to(to)
+                .productId(productId)
+                .search(search)
+                .taxCode(taxCode)
+                .mode(mode)
+                .order(order)
+                .page(page)
+                .size(size)
+                .build();
+    }
+
+}

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2ControllerTest.java
@@ -103,7 +103,7 @@ class DelegationV2ControllerTest {
         assertThat(response).isNotNull();
         assertThat(response.getDelegations()).isNotNull();
         assertThat(response.getPageInfo()).isNotNull();
-        assertThat(response.getDelegations().size()).isEqualTo(1);
+        assertThat((long) response.getDelegations().size()).isEqualTo(1);
         DelegationResponse actualDelegation = response.getDelegations().get(0);
         PageInfo actualPageInfo = response.getPageInfo();
         assertThat(actualDelegation.getId()).isEqualTo(expectedDelegation.getId());
@@ -154,7 +154,7 @@ class DelegationV2ControllerTest {
         assertThat(response).isNotNull();
         assertThat(response.getDelegations()).isNotNull();
         assertThat(response.getPageInfo()).isNotNull();
-        assertThat(response.getDelegations().size()).isEqualTo(2);
+        assertThat((long) response.getDelegations().size()).isEqualTo(2);
         DelegationResponse actualDelegation = response.getDelegations().get(0);
         PageInfo actualPageInfo = response.getPageInfo();
         assertThat(actualDelegation.getId()).isEqualTo(delegation1.getId());
@@ -203,7 +203,7 @@ class DelegationV2ControllerTest {
         assertThat(response).isNotNull();
         assertThat(response.getDelegations()).isNotNull();
         assertThat(response.getPageInfo()).isNotNull();
-        assertThat(response.getDelegations().size()).isEqualTo(1);
+        assertThat((long) response.getDelegations().size()).isEqualTo(1);
         DelegationResponse actualDelegation = response.getDelegations().get(0);
         PageInfo actualPageInfo = response.getPageInfo();
         assertThat(actualDelegation.getId()).isEqualTo(expectedDelegation.getId());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add v2 API of getDelegations with pagination
- add unit tests
- align open api

<!--- Describe your changes in detail -->

#### Motivation and Context
The new version of API getDelegations was required to include pagination in "I tuoi enti" dashboard FE page .

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by running ms-core locally and call API getDelegationsV2.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.