### PR TITLE
[SELC-4890] feat: Ensure Description Update for Pre-existing Institutions in CreateInstitutionFromInfocamere

### DIFF
--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/strategy/CreateInstitutionStrategyTest.java
@@ -556,7 +556,7 @@ class CreateInstitutionStrategyTest {
         nationalRegistriesProfessionalAddress.setZipCode("00000");
         when(partyRegistryProxyConnector.getLegalAddress(any())).thenReturn(nationalRegistriesProfessionalAddress);
 
-        when(institutionConnector.save(any())).thenReturn(institution);
+        when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
         //When
         Institution actual = strategyFactory.createInstitutionStrategyInfocamere(institution)
                 .createInstitution(CreateInstitutionStrategyInput.builder()
@@ -575,6 +575,42 @@ class CreateInstitutionStrategyTest {
         assertThat(actual.getInstitutionType()).isEqualTo(InstitutionType.PG);
         assertThat(actual.getSubunitType()).isNull();
         assertThat(actual.getOrigin()).isEqualTo(Origin.INFOCAMERE.getValue());
+
+        verify(institutionConnector).save(any());
+    }
+
+
+    /**
+     * Method under test: {@link CreateInstitutionStrategy#createInstitution(CreateInstitutionStrategyInput)}
+     */
+    @Test
+    void createInstitutionWithOriginInfocamere_WhenInstitutionExists() {
+
+        Institution institution = TestUtils.dummyInstitutionPg();
+        final String description = "UPDATE DESCRIPTION";
+
+        when(institutionConnector.findByTaxCodeAndSubunitCode(institution.getTaxCode(), null))
+                .thenReturn(List.of(institution));
+
+        when(institutionConnector.save(any())).thenAnswer(args -> args.getArguments()[0]);
+        //When
+        Institution actual = strategyFactory.createInstitutionStrategyInfocamere(institution)
+                .createInstitution(CreateInstitutionStrategyInput.builder()
+                        .taxCode(institution.getTaxCode())
+                        .description(description)
+                        .build());
+
+        //Then
+        assertThat(actual.getDescription()).isEqualTo(description);
+        assertThat(actual.getDigitalAddress()).isEqualTo(institution.getDigitalAddress());
+        assertThat(actual.getAddress()).isEqualTo(institution.getAddress());
+        assertThat(actual.getZipCode()).isEqualTo(institution.getZipCode());
+        assertThat(actual.getTaxCode()).isEqualTo(institution.getTaxCode());
+        assertThat(actual.getSubunitCode()).isNull();
+        assertThat(actual.getSubunitType()).isNull();
+        assertThat(actual.getInstitutionType()).isEqualTo(institution.getInstitutionType());
+        assertThat(actual.getSubunitType()).isNull();
+        assertThat(actual.getOrigin()).isEqualTo(institution.getOrigin());
 
         verify(institutionConnector).save(any());
     }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Updating the **CreateInstitutionFromInfocamere** function in the core module to include the description if the institution already exists. This ensures that institutions will have consistent and complete data even if they were initially created without a description.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This pull request addresses the issue of data inconsistency for institutions created via the external API POST /v1/pn-pg/institutions/add by the PN team without specifying a description. These institutions, intended to have a unique identifier without immediate adherence to PNPG, lack descriptions, which can lead to inconsistencies if they complete the onboarding process later.

Problem
When institutions created through the external API by the PN team do not have descriptions, it causes data inconsistencies in future functionalities if these institutions complete the onboarding process. Specifically, the missing descriptions can result in incomplete or inaccurate data representation.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.