### PR TITLE
hotfix: Environment Variable Names and Add Email Sending Block in Dev and UAT

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/MailNotificationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/MailNotificationServiceImpl.java
@@ -68,6 +68,9 @@ public class MailNotificationServiceImpl implements MailNotificationService {
 
 
     private List<String> getUsersEmailByInstitutionAndProductV2(String institutionId, String productId){
-     return userApiConnector.getUserEmails(institutionId, productId);
+        if (coreConfig.isSendEmailToInstitution()) {
+            return userApiConnector.getUserEmails(institutionId, productId);
+        }
+        return List.of(coreConfig.getInstitutionAlternativeEmail());
     }
 }

--- a/infra/container_apps/env/dev-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/dev-pnpg/terraform.tfvars
@@ -144,6 +144,6 @@ secrets_names = {
   "USER_REGISTRY_API_KEY"                    = "user-registry-api-key"
   "JWT_TOKEN_PUBLIC_KEY"                     = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
-  "AWS-SES-ACCESS-KEY-ID"                    = "aws-ses-access-key-id"
-  "AWS-SES-SECRET-ACCESS-KEY"                = "aws-ses-secret-access-key"
+  "AWS_SES_ACCESS_KEY_ID"                    = "aws-ses-access-key-id"
+  "AWS_SES_SECRET_ACCESS_KEY"                = "aws-ses-secret-access-key"
 }

--- a/infra/container_apps/env/dev/terraform.tfvars
+++ b/infra/container_apps/env/dev/terraform.tfvars
@@ -162,6 +162,6 @@ secrets_names = {
   "JWT_TOKEN_PUBLIC_KEY"                         = "jwt-public-key"
   "KAFKA_USERS_SELFCARE_WO_SASL_JAAS_CONFIG"     = "eventhub-sc-users-selfcare-wo-connection-string-lc"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"       = "blob-storage-product-connection-string"
-  "AWS-SES-ACCESS-KEY-ID"                        = "aws-ses-access-key-id"
-  "AWS-SES-SECRET-ACCESS-KEY"                    = "aws-ses-secret-access-key"
+  "AWS_SES_ACCESS_KEY_ID"                        = "aws-ses-access-key-id"
+  "AWS_SES_SECRET_ACCESS_KEY"                    = "aws-ses-secret-access-key"
 }

--- a/infra/container_apps/env/prod-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/prod-pnpg/terraform.tfvars
@@ -144,6 +144,6 @@ secrets_names = {
   "USER_REGISTRY_API_KEY"                    = "user-registry-api-key"
   "JWT_TOKEN_PUBLIC_KEY"                     = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
-  "AWS-SES-ACCESS-KEY-ID"                    = "aws-ses-access-key-id"
-  "AWS-SES-SECRET-ACCESS-KEY"                = "aws-ses-secret-access-key"
+  "AWS_SES_ACCESS_KEY_ID"                    = "aws-ses-access-key-id"
+  "AWS_SES_SECRET_ACCESS_KEY"                = "aws-ses-secret-access-key"
 }

--- a/infra/container_apps/env/prod/terraform.tfvars
+++ b/infra/container_apps/env/prod/terraform.tfvars
@@ -158,6 +158,6 @@ secrets_names = {
   "JWT_TOKEN_PUBLIC_KEY"                         = "jwt-public-key"
   "KAFKA_USERS_SELFCARE_WO_SASL_JAAS_CONFIG"     = "eventhub-sc-users-selfcare-wo-connection-string-lc"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"       = "blob-storage-product-connection-string"
-  "AWS-SES-ACCESS-KEY-ID"                        = "aws-ses-access-key-id"
-  "AWS-SES-SECRET-ACCESS-KEY"                    = "aws-ses-secret-access-key"
+  "AWS_SES_ACCESS_KEY_ID"                        = "aws-ses-access-key-id"
+  "AWS_SES_SECRET_ACCESS_KEY"                    = "aws-ses-secret-access-key"
 }

--- a/infra/container_apps/env/uat-pnpg/terraform.tfvars
+++ b/infra/container_apps/env/uat-pnpg/terraform.tfvars
@@ -136,6 +136,6 @@ secrets_names = {
   "USER_REGISTRY_API_KEY"                    = "user-registry-api-key"
   "JWT_TOKEN_PUBLIC_KEY"                     = "jwt-public-key"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"   = "blob-storage-product-connection-string"
-  "AWS-SES-ACCESS-KEY-ID"                    = "aws-ses-access-key-id"
-  "AWS-SES-SECRET-ACCESS-KEY"                = "aws-ses-secret-access-key"
+  "AWS_SES_ACCESS_KEY_ID"                    = "aws-ses-access-key-id"
+  "AWS_SES_SECRET_ACCESS_KEY"                = "aws-ses-secret-access-key"
 }

--- a/infra/container_apps/env/uat/terraform.tfvars
+++ b/infra/container_apps/env/uat/terraform.tfvars
@@ -149,6 +149,6 @@ secrets_names = {
   "JWT_TOKEN_PUBLIC_KEY"                         = "jwt-public-key"
   "KAFKA_USERS_SELFCARE_WO_SASL_JAAS_CONFIG"     = "eventhub-sc-users-selfcare-wo-connection-string-lc"
   "BLOB_STORAGE_PRODUCT_CONNECTION_STRING"       = "blob-storage-product-connection-string"
-  "AWS-SES-ACCESS-KEY-ID"                        = "aws-ses-access-key-id"
-  "AWS-SES-SECRET-ACCESS-KEY"                    = "aws-ses-secret-access-key"
+  "AWS_SES_ACCESS_KEY_ID"                        = "aws-ses-access-key-id"
+  "AWS_SES_SECRET_ACCESS_KEY"                    = "aws-ses-secret-access-key"
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* **Correction of Environment Variable Names**: The names of the AWS-related environment variables have been fixed. The variables **AWS_SES_ACCESS_KEY_ID** and **AWS_SES_SECRET_ACCESS_KEY** were incorrectly named and have been updated to the correct names.
* **Block Sending Emails to Real Users in Dev and UAT**: To prevent real users from receiving emails in non-production environments (Dev and UAT), a block has been implemented. This ensures that any email-sending functionality checks if is enabled an alternative mail and only sends emails to test accounts in these environments.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.