### PR TITLE
[SELC-4908] feat: add toTaxCode and fromTaxCode in delegation

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/Delegation.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/Delegation.java
@@ -26,6 +26,8 @@ public class Delegation {
     private String productId;
     private InstitutionType institutionType;
     private String taxCode;
+    private String toTaxCode;
+    private String fromTaxCode;
     private InstitutionType brokerType;
     private String brokerTaxCode;
     private String fromSubunitCode;

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/DelegationEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/DelegationEntity.java
@@ -23,6 +23,8 @@ public class DelegationEntity {
     private String institutionToName;
     private String institutionFromRootName;
     private String to;
+    private String toTaxCode;
+    private String fromTaxCode;
     private String productId;
     private DelegationType type;
     private DelegationState status;

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
@@ -89,6 +89,7 @@ public class DelegationServiceImpl implements DelegationService {
         /*
             In case the api returns more institutions we always try to take the PT,
             otherwise it is okay to take the first one
+            It is caused by this issue https://pagopa.atlassian.net/wiki/spaces/SCP/pages/1058832442/RFC+-+Gestione+di+pi+institutionType+su+una+Institution
          */
         List<Institution> institutionsTo = institutionService.getInstitutions(delegation.getTo(), null);
         Institution partner = institutionsTo.stream()

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static it.pagopa.selfcare.mscore.constant.GenericError.CREATE_INSTITUTION_ERROR;
 
@@ -112,11 +111,6 @@ public class InstitutionServiceImpl implements InstitutionService {
     }
 
     @Override
-    public List<Institution> getInstitutions(String taxCode, String subunitCode) {
-        return institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
-    }
-
-    @Override
     public Institution createInstitutionFromIpa(String taxCode, InstitutionPaSubunitType subunitType, String subunitCode, List<InstitutionGeographicTaxonomies> geographicTaxonomies, InstitutionType institutionType) {
         CreateInstitutionStrategy institutionStrategy = createInstitutionStrategyFactory.createInstitutionStrategyIpa();
         return institutionStrategy.createInstitution(CreateInstitutionStrategyInput.builder()
@@ -126,6 +120,11 @@ public class InstitutionServiceImpl implements InstitutionService {
                 .geographicTaxonomies(geographicTaxonomies)
                 .institutionType(institutionType)
                 .build());
+    }
+
+    @Override
+    public List<Institution> getInstitutions(String taxCode, String subunitCode) {
+        return institutionConnector.findByTaxCodeAndSubunitCode(taxCode, subunitCode);
     }
 
     @Override
@@ -263,7 +262,7 @@ public class InstitutionServiceImpl implements InstitutionService {
             if (states != null && !states.isEmpty()) {
                 onboardingList = institution.getOnboarding().stream()
                         .filter(onboarding -> states.contains(onboarding.getStatus()))
-                        .collect(Collectors.toList());
+                        .toList();
             } else {
                 onboardingList = institution.getOnboarding();
             }
@@ -286,7 +285,7 @@ public class InstitutionServiceImpl implements InstitutionService {
             List<GeographicTaxonomies> geographicTaxonomies = institution.getGeographicTaxonomies().stream()
                     .map(institutionGeoTax -> retrieveGeoTaxonomies(institutionGeoTax.getCode())
                             .orElseThrow(() -> new MsCoreException(String.format(CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getMessage(), institutionGeoTax.getCode()), CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getCode())))
-                    .collect(Collectors.toList());
+                    .toList();
             if (!geographicTaxonomies.isEmpty()) {
                 return geographicTaxonomies;
             }
@@ -323,7 +322,7 @@ public class InstitutionServiceImpl implements InstitutionService {
                     .map(geoTaxonomy -> retrieveGeoTaxonomies(geoTaxonomy.getCode())
                             .orElseThrow(() -> new MsCoreException(String.format(CustomError.GEO_TAXONOMY_CODE_NOT_FOUND.getMessage(), geoTaxonomy.getCode()), geoTaxonomy.getCode())))
                     .map(geo -> new InstitutionGeographicTaxonomies(geo.getGeotaxId(), geo.getDescription()))
-                    .collect(Collectors.toList());
+                    .toList();
         }
         return Collections.emptyList();
     }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -78,13 +78,13 @@ class DelegationServiceImplTest {
         Institution institutionFrom = new Institution();
         institutionTo.setId("idFrom");
         institutionTo.setTaxCode("taxCodeFrom");
-        when(delegationConnector.save(any())).thenReturn(dummyDelegationProdIo);
+        when(delegationConnector.save(dummyDelegationProdIo)).thenAnswer(arg ->arg.getArguments()[0]);
         when(institutionService.retrieveInstitutionById(dummyDelegationProdIo.getFrom())).thenReturn(institutionFrom);
         when(institutionService.retrieveInstitutionById(dummyDelegationProdIo.getTo())).thenReturn(institutionTo);
         doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
         Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdIo);
-        verify(delegationConnector).save(any());
+        verify(delegationConnector).save(dummyDelegationProdIo);
         assertNotNull(response);
         assertNotNull(response.getId());
         assertEquals(dummyDelegationProdIo.getId(), response.getId());
@@ -104,9 +104,9 @@ class DelegationServiceImplTest {
         Institution institutionFrom = new Institution();
         institutionFrom.setId("id");
         institutionFrom.setTaxCode("taxCodeFrom");
-        when(delegationConnector.save(any())).thenReturn(dummyDelegationProdPagopa);
+        when(delegationConnector.save(dummyDelegationProdPagopa)).thenAnswer(arg ->arg.getArguments()[0]);
         doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
-        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institutionTo));
+        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), null)).thenReturn(List.of(institutionTo));
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
         when(institutionService.retrieveInstitutionById(dummyDelegationProdPagopa.getFrom())).thenReturn(institutionFrom);
         Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdPagopa);
@@ -123,20 +123,20 @@ class DelegationServiceImplTest {
     @Test
     void testCreateDelegationForEcWithProductPagopa() {
         Institution institutionTo = new Institution();
-        institutionTo.setId("id");
+        institutionTo.setId("to");
         institutionTo.setInstitutionType(InstitutionType.PT);
         institutionTo.setTaxCode("taxCodeTo");
         Institution institutionFrom = new Institution();
-        institutionFrom.setId("id");
+        institutionFrom.setId("from");
         institutionFrom.setTaxCode("taxCodeFrom");
-        when(delegationConnector.findAndActivate(anyString(), anyString(), anyString())).thenReturn(dummyDelegationProdPagopa);
+        when(delegationConnector.findAndActivate(institutionFrom.getId(), institutionTo.getId(), dummyDelegationProdPagopa.getProductId())).thenReturn(dummyDelegationProdPagopa);;
         doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
-        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institutionTo));
+        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), null)).thenReturn(List.of(institutionTo));
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
         when(delegationServiceImpl.checkIfExistsWithStatus(dummyDelegationProdPagopa, DelegationState.DELETED)).thenReturn(true);
         when(institutionService.retrieveInstitutionById(dummyDelegationProdPagopa.getFrom())).thenReturn(institutionFrom);
         Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdPagopa);
-        verify(delegationConnector).findAndActivate(anyString(), anyString(), anyString());
+        verify(delegationConnector).findAndActivate(institutionFrom.getId(), institutionTo.getId(), dummyDelegationProdPagopa.getProductId());
         verify(institutionService).getInstitutions(any(), any());
         assertNotNull(response);
         assertNotNull(response.getId());

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -45,16 +45,26 @@ class DelegationServiceImplTest {
     private static final Delegation dummyDelegationProdIo;
     private static final Delegation dummyDelegationProdPagopa;
 
+    private static final Delegation dummyDelegationTaxCode;
+
     static {
         dummyDelegationProdIo = new Delegation();
         dummyDelegationProdIo.setId("id");
+        dummyDelegationProdIo.setTo("to");
+        dummyDelegationProdIo.setFrom("from");
         dummyDelegationProdIo.setProductId("prod-io");
 
         dummyDelegationProdPagopa = new Delegation();
         dummyDelegationProdPagopa.setId("id");
         dummyDelegationProdPagopa.setProductId("prod-pagopa");
-        dummyDelegationProdPagopa.setTo("to");
+        dummyDelegationProdPagopa.setTo("taxCodeTo");
         dummyDelegationProdPagopa.setFrom("from");
+
+        dummyDelegationTaxCode = new Delegation();
+        dummyDelegationTaxCode.setToTaxCode("taxCodeTo");
+        dummyDelegationTaxCode.setFromTaxCode("taxCodeFrom");
+        dummyDelegationTaxCode.setProductId("prod-pagopa");
+        dummyDelegationTaxCode.setId("id");
     }
 
     /**
@@ -62,9 +72,15 @@ class DelegationServiceImplTest {
      */
     @Test
     void testCreateDelegationWithProductProdIo() {
-        Institution institution = new Institution();
-        institution.setId("id");
+        Institution institutionTo = new Institution();
+        institutionTo.setId("idTo");
+        institutionTo.setTaxCode("taxCodeTo");
+        Institution institutionFrom = new Institution();
+        institutionTo.setId("idFrom");
+        institutionTo.setTaxCode("taxCodeFrom");
         when(delegationConnector.save(any())).thenReturn(dummyDelegationProdIo);
+        when(institutionService.retrieveInstitutionById(dummyDelegationProdIo.getFrom())).thenReturn(institutionFrom);
+        when(institutionService.retrieveInstitutionById(dummyDelegationProdIo.getTo())).thenReturn(institutionTo);
         doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
         Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdIo);
@@ -72,6 +88,8 @@ class DelegationServiceImplTest {
         assertNotNull(response);
         assertNotNull(response.getId());
         assertEquals(dummyDelegationProdIo.getId(), response.getId());
+        assertEquals(institutionTo.getTaxCode(), response.getToTaxCode());
+        assertEquals(institutionFrom.getTaxCode(), response.getFromTaxCode());
     }
 
     /**
@@ -79,13 +97,18 @@ class DelegationServiceImplTest {
      */
     @Test
     void testCreateDelegationForPTWithProductPagopa() {
-        Institution institution = new Institution();
-        institution.setId("id");
-        institution.setInstitutionType(InstitutionType.PT);
+        Institution institutionTo = new Institution();
+        institutionTo.setId("id");
+        institutionTo.setInstitutionType(InstitutionType.PT);
+        institutionTo.setTaxCode("taxCodeTo");
+        Institution institutionFrom = new Institution();
+        institutionFrom.setId("id");
+        institutionFrom.setTaxCode("taxCodeFrom");
         when(delegationConnector.save(any())).thenReturn(dummyDelegationProdPagopa);
         doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
-        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institution));
+        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institutionTo));
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
+        when(institutionService.retrieveInstitutionById(dummyDelegationProdPagopa.getFrom())).thenReturn(institutionFrom);
         Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdPagopa);
         verify(institutionService).getInstitutions(any(), any());
         verify(delegationConnector).save(any());
@@ -99,14 +122,19 @@ class DelegationServiceImplTest {
      */
     @Test
     void testCreateDelegationForEcWithProductPagopa() {
-        Institution institution = new Institution();
-        institution.setId("id");
-        institution.setInstitutionType(InstitutionType.PT);
+        Institution institutionTo = new Institution();
+        institutionTo.setId("id");
+        institutionTo.setInstitutionType(InstitutionType.PT);
+        institutionTo.setTaxCode("taxCodeTo");
+        Institution institutionFrom = new Institution();
+        institutionFrom.setId("id");
+        institutionFrom.setTaxCode("taxCodeFrom");
         when(delegationConnector.findAndActivate(anyString(), anyString(), anyString())).thenReturn(dummyDelegationProdPagopa);
         doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
-        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institution));
+        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institutionTo));
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
         when(delegationServiceImpl.checkIfExistsWithStatus(dummyDelegationProdPagopa, DelegationState.DELETED)).thenReturn(true);
+        when(institutionService.retrieveInstitutionById(dummyDelegationProdPagopa.getFrom())).thenReturn(institutionFrom);
         Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdPagopa);
         verify(delegationConnector).findAndActivate(anyString(), anyString(), anyString());
         verify(institutionService).getInstitutions(any(), any());
@@ -123,6 +151,7 @@ class DelegationServiceImplTest {
         Institution institution = new Institution();
         institution.setId("id");
         when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institution));
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(institution);
         doThrow(new MsCoreException(SEND_MAIL_FOR_DELEGATION_ERROR.getMessage(), SEND_MAIL_FOR_DELEGATION_ERROR.getCode()))
                 .when(mailNotificationService)
                 .sendMailForDelegation(any(), any(), any());
@@ -137,6 +166,7 @@ class DelegationServiceImplTest {
     void testCreateDelegationWithError() {
         Institution institution = new Institution();
         institution.setId("id");
+        when(institutionService.retrieveInstitutionById(any())).thenReturn(institution);
         when(delegationConnector.save(any())).thenThrow(new MsCoreException(CREATE_DELEGATION_ERROR.getMessage(), CREATE_DELEGATION_ERROR.getCode()));
         assertThrows(MsCoreException.class, () -> delegationServiceImpl.createDelegation(dummyDelegationProdIo));
         verify(delegationConnector).save(any());
@@ -158,6 +188,8 @@ class DelegationServiceImplTest {
     void testCreateDelegationWithConflict() {
         Institution institution = new Institution();
         institution.setId("id");
+        when(institutionService.retrieveInstitutionById(dummyDelegationProdIo.getTo())).thenReturn(institution);
+        when(institutionService.retrieveInstitutionById(dummyDelegationProdIo.getFrom())).thenReturn(institution);
         when(delegationServiceImpl.checkIfExistsWithStatus(dummyDelegationProdIo, DelegationState.ACTIVE)).thenReturn(true);
         assertThrows(ResourceConflictException.class, () -> delegationServiceImpl.createDelegation(dummyDelegationProdIo));
         verifyNoMoreInteractions(delegationConnector);
@@ -264,34 +296,46 @@ class DelegationServiceImplTest {
 
     @Test
     void testCreateDelegationFromTaxCode() {
-        Institution institution = new Institution();
-        institution.setId("id");
-        when(delegationConnector.save(any())).thenReturn(dummyDelegationProdPagopa);
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), dummyDelegationProdPagopa.getToSubunitCode())).thenReturn(List.of(institution));
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getFrom(), dummyDelegationProdPagopa.getFromSubunitCode())).thenReturn(List.of(institution));
+        Institution institutionTo = new Institution();
+        institutionTo.setId("id");
+        institutionTo.setTaxCode("taxCodeTo");
+        when(delegationConnector.save(any())).thenReturn(dummyDelegationTaxCode);
+        Institution institutionFrom = new Institution();
+        institutionFrom.setId("id");
+        institutionFrom.setTaxCode("taxCodeFrom");
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getToTaxCode(), dummyDelegationTaxCode.getToSubunitCode())).thenReturn(List.of(institutionTo));
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getFromTaxCode(), dummyDelegationTaxCode.getFromSubunitCode())).thenReturn(List.of(institutionFrom));
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
-        Delegation response = delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationProdPagopa);
+        Delegation response = delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationTaxCode);
         verify(delegationConnector).save(any());
         assertNotNull(response);
         assertNotNull(response.getId());
-        assertEquals(dummyDelegationProdPagopa.getId(), response.getId());
+        assertEquals(dummyDelegationTaxCode.getId(), response.getId());
+        assertEquals(institutionTo.getTaxCode(), response.getToTaxCode());
+        assertEquals(institutionFrom.getTaxCode(), response.getFromTaxCode());
     }
 
     @Test
     void testCreateDelegationFromTaxCodeWithSubunitCode() {
-        Institution institution = new Institution();
-        institution.setId("id");
-        when(delegationConnector.findAndActivate(anyString(), anyString(), anyString())).thenReturn(dummyDelegationProdPagopa);
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), dummyDelegationProdPagopa.getToSubunitCode())).thenReturn(List.of(institution));
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getFrom(), dummyDelegationProdPagopa.getFromSubunitCode())).thenReturn(List.of(institution));
+        Institution institutionTo = new Institution();
+        institutionTo.setId("id");
+        institutionTo.setTaxCode("taxCodeTo");
+        Institution institutionFrom = new Institution();
+        institutionFrom.setId("id");
+        institutionFrom.setTaxCode("taxCodeFrom");
+        when(delegationConnector.findAndActivate(anyString(), anyString(), anyString())).thenReturn(dummyDelegationTaxCode);
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getToTaxCode(), dummyDelegationTaxCode.getToSubunitCode())).thenReturn(List.of(institutionTo));
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getFromTaxCode(), dummyDelegationTaxCode.getFromSubunitCode())).thenReturn(List.of(institutionFrom));
         doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
-        when(delegationConnector.checkIfExistsWithStatus(dummyDelegationProdPagopa, DelegationState.ACTIVE)).thenReturn(false);
-        when(delegationConnector.checkIfExistsWithStatus(dummyDelegationProdPagopa, DelegationState.DELETED)).thenReturn(true);
-        Delegation response = delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationProdPagopa);
+        when(delegationConnector.checkIfExistsWithStatus(dummyDelegationTaxCode, DelegationState.ACTIVE)).thenReturn(false);
+        when(delegationConnector.checkIfExistsWithStatus(dummyDelegationTaxCode, DelegationState.DELETED)).thenReturn(true);
+        Delegation response = delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationTaxCode);
         verify(delegationConnector).findAndActivate(anyString(), anyString(), anyString());
         assertNotNull(response);
         assertNotNull(response.getId());
-        assertEquals(dummyDelegationProdPagopa.getId(), response.getId());
+        assertEquals(dummyDelegationTaxCode.getId(), response.getId());
+        assertEquals(dummyDelegationTaxCode.getFromTaxCode(), response.getFromTaxCode());
+        assertEquals(dummyDelegationTaxCode.getToTaxCode(), response.getToTaxCode());
     }
 
     /**
@@ -301,10 +345,10 @@ class DelegationServiceImplTest {
     void testCreateDelegationFromTaxCodeWithError() {
         Institution institution = new Institution();
         institution.setId("id");
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), null)).thenReturn(List.of(institution));
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getFrom(), null)).thenReturn(List.of(institution));
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getToTaxCode(), null)).thenReturn(List.of(institution));
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getFromTaxCode(), null)).thenReturn(List.of(institution));
         when(delegationConnector.save(any())).thenThrow(new MsCoreException(CREATE_DELEGATION_ERROR.getMessage(), CREATE_DELEGATION_ERROR.getCode()));
-        assertThrows(MsCoreException.class, () -> delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationProdPagopa));
+        assertThrows(MsCoreException.class, () -> delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationTaxCode));
         verify(delegationConnector).save(any());
     }
 
@@ -324,10 +368,10 @@ class DelegationServiceImplTest {
     void testCreateDelegationFromTaxCodeConflict() {
         Institution institution = new Institution();
         institution.setId("id");
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), dummyDelegationProdPagopa.getToSubunitCode())).thenReturn(List.of(institution));
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getFrom(), dummyDelegationProdPagopa.getFromSubunitCode())).thenReturn(List.of(institution));
-        when(delegationConnector.checkIfExistsWithStatus(dummyDelegationProdPagopa, DelegationState.ACTIVE)).thenReturn(true);
-        assertThrows(ResourceConflictException.class, () -> delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationProdPagopa));
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getToTaxCode(), dummyDelegationProdPagopa.getToSubunitCode())).thenReturn(List.of(institution));
+        when(institutionService.getInstitutions(dummyDelegationTaxCode.getFromTaxCode(), dummyDelegationProdPagopa.getFromSubunitCode())).thenReturn(List.of(institution));
+        when(delegationConnector.checkIfExistsWithStatus(dummyDelegationTaxCode, DelegationState.ACTIVE)).thenReturn(true);
+        assertThrows(ResourceConflictException.class, () -> delegationServiceImpl.createDelegationFromInstitutionsTaxCode(dummyDelegationTaxCode));
     }
 
     @Test

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/DelegationMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/DelegationMapper.java
@@ -12,8 +12,6 @@ public interface DelegationMapper {
 
     Delegation toDelegation(DelegationRequest delegation);
 
-    @Mapping(source = "fromTaxCode", target = "from")
-    @Mapping(source = "toTaxCode", target = "to")
     Delegation toDelegation(DelegationRequestFromTaxcode delegation);
 
     @Mapping(source = "from", target = "institutionId")


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add toTaxCode and fromTaxCode fields in delegation Entity
- align unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
This change is needed to retrieve delegation taxCodes through Delegation Collection.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by running ms-core locally and calling both createDelegation and crateDelegationFromTaxCode APIs.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.