### PR TITLE
[SELC-4910] feat: remove aggregation to retrieve taxCode field

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -90,16 +90,6 @@
             "type" : "string"
           }
         }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "Mode (full or normal) to retreieve institution's delegations",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "FULL", "NORMAL" ]
-          }
-        }, {
           "name" : "order",
           "in" : "query",
           "description" : "Order to show response NONE, ASC, DESC",
@@ -398,16 +388,6 @@
           "style" : "form",
           "schema" : {
             "type" : "string"
-          }
-        }, {
-          "name" : "mode",
-          "in" : "query",
-          "description" : "Mode (full or normal) to retreieve institution's delegations",
-          "required" : false,
-          "style" : "form",
-          "schema" : {
-            "type" : "string",
-            "enum" : [ "FULL", "NORMAL" ]
           }
         }, {
           "name" : "order",

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/DelegationConnector.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.api;
 
 import it.pagopa.selfcare.mscore.constant.DelegationState;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
@@ -13,7 +12,7 @@ public interface DelegationConnector {
 
     Delegation save(Delegation delegation);
     boolean checkIfExistsWithStatus(Delegation delegation, DelegationState status);
-    List<Delegation> find(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Order order, Integer page, Integer size);
+    List<Delegation> find(String from, String to, String productId, String search, String taxCode, Order order, Integer page, Integer size);
     DelegationWithPagination findAndCount(GetDelegationParameters delegationParameters);
     Delegation findByIdAndModifyStatus(String delegationId, DelegationState status);
     boolean checkIfDelegationsAreActive(String institutionId);

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GetDelegationsMode.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GetDelegationsMode.java
@@ -1,8 +1,0 @@
-package it.pagopa.selfcare.mscore.constant;
-
-public enum GetDelegationsMode {
-
-    FULL,
-    NORMAL;
-
-}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/GetDelegationParameters.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/delegation/GetDelegationParameters.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.mscore.model.delegation;
 
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +12,6 @@ public class GetDelegationParameters {
     private String productId;
     private String search;
     private String taxCode;
-    private GetDelegationsMode mode;
     private Order order;
     private Integer page;
     private Integer size;

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationService.java
@@ -1,7 +1,6 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.mscore.constant.DelegationState;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 import it.pagopa.selfcare.mscore.model.delegation.DelegationWithPagination;
@@ -14,7 +13,7 @@ public interface DelegationService {
 
     Delegation createDelegation(Delegation delegation);
     boolean checkIfExistsWithStatus(Delegation delegation, DelegationState status);
-    List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode, Optional<Order> order, Optional<Integer> page, Optional<Integer> size);
+    List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode, Optional<Order> order, Optional<Integer> page, Optional<Integer> size);
     Delegation createDelegationFromInstitutionsTaxCode(Delegation delegation);
     void deleteDelegationByDelegationId(String delegationId);
     DelegationWithPagination getDelegationsV2(GetDelegationParameters delegationParameters);

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/DelegationServiceImpl.java
@@ -4,7 +4,6 @@ import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
@@ -180,10 +179,10 @@ public class DelegationServiceImpl implements DelegationService {
     }
 
     @Override
-    public List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode, GetDelegationsMode mode,
+    public List<Delegation> getDelegations(String from, String to, String productId, String search, String taxCode,
                                            Optional<Order> order, Optional<Integer> page, Optional<Integer> size) {
         int pageSize = size.filter(s -> s > 0).filter(s -> s <= DEFAULT_DELEGATIONS_PAGE_SIZE).orElse(DEFAULT_DELEGATIONS_PAGE_SIZE);
-        return delegationConnector.find(from, to, productId, search, taxCode, mode, order.orElse(Order.NONE), page.orElse(0), pageSize);
+        return delegationConnector.find(from, to, productId, search, taxCode, order.orElse(Order.NONE), page.orElse(0), pageSize);
     }
 
     @Override

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -3,7 +3,6 @@ package it.pagopa.selfcare.mscore.core;
 import it.pagopa.selfcare.commons.base.utils.InstitutionType;
 import it.pagopa.selfcare.mscore.api.DelegationConnector;
 import it.pagopa.selfcare.mscore.constant.DelegationState;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.exception.MsCoreException;
 import it.pagopa.selfcare.mscore.exception.ResourceConflictException;
@@ -207,19 +206,19 @@ class DelegationServiceImplTest {
     }
 
     /**
-     * Method under test: {@link DelegationServiceImpl#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     * Method under test: {@link DelegationServiceImpl#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
      */
     @Test
     void find_shouldGetData() {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId", null, null,
-                GetDelegationsMode.NORMAL, Optional.empty(), Optional.of(0), Optional.of(100));
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", "to", "productId", null,
+                null, Optional.empty(), Optional.of(0), Optional.of(100));
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -227,19 +226,19 @@ class DelegationServiceImplTest {
     }
 
     /**
-     * Method under test: {@link DelegationServiceImpl#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     * Method under test: {@link DelegationServiceImpl#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
      */
     @Test
     void find_shouldGetData_fullMode() {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null, null,
-                GetDelegationsMode.FULL, Optional.of(Order.DESC), Optional.of(0), Optional.of(0));
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null,
+                null, Optional.of(Order.DESC), Optional.of(0), Optional.of(0));
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -247,19 +246,19 @@ class DelegationServiceImplTest {
     }
 
     /**
-     * Method under test: {@link DelegationServiceImpl#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     * Method under test: {@link DelegationServiceImpl#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
      */
     @Test
     void find_shouldGetData_fullMode_defaultPage() {
         //Given
         Delegation delegation = new Delegation();
         delegation.setId("id");
-        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
+        when(delegationConnector.find(any(), any(), any(), any(), any(), any(), any(), any())).thenReturn(List.of(delegation));
         //When
-        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null, null,
-                GetDelegationsMode.FULL, Optional.of(Order.DESC), Optional.empty(), Optional.empty());
+        List<Delegation> response = delegationServiceImpl.getDelegations("from", null, "productId", null,
+                null, Optional.of(Order.DESC), Optional.empty(), Optional.empty());
         //Then
-        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any(), any());
+        verify(delegationConnector).find(any(), any(), any(), any(), any(), any(), any(), any());
 
         assertNotNull(response);
         assertFalse(response.isEmpty());
@@ -276,8 +275,8 @@ class DelegationServiceImplTest {
         delegation.setId("id");
         DelegationWithPagination delegationWithPagination = new DelegationWithPagination(List.of(delegation), new PageInfo(10, 0, 10, 1));
         when(delegationConnector.findAndCount(any())).thenReturn(delegationWithPagination);
-        GetDelegationParameters delegationParameters = createDelegationParameters("from", "to", "productId", null, null,
-                GetDelegationsMode.NORMAL, null, 0, 100);
+        GetDelegationParameters delegationParameters = createDelegationParameters("from", "to", "productId", null,
+                null, null, 0, 100);
 
         //When
         DelegationWithPagination response = delegationServiceImpl.getDelegationsV2(delegationParameters);
@@ -424,15 +423,14 @@ class DelegationServiceImplTest {
 
 
     private GetDelegationParameters createDelegationParameters(String from, String to, String productId,
-                                                               String search, String taxCode, GetDelegationsMode mode,
-                                                               Order order, Integer page, Integer size) {
+                                                               String search, String taxCode, Order order,
+                                                               Integer page, Integer size) {
         return GetDelegationParameters.builder()
                 .from(from)
                 .to(to)
                 .productId(productId)
                 .search(search)
                 .taxCode(taxCode)
-                .mode(mode)
                 .order(order)
                 .page(page)
                 .size(size)

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -25,7 +25,6 @@
     import java.util.List;
     import java.util.Objects;
     import java.util.Optional;
-    import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value = "/delegations", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -112,8 +111,8 @@ public class DelegationController {
             throw new InvalidRequestException("institutionId or brokerId must not be null!!", GenericError.GENERIC_ERROR.getCode());
 
         return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId, search, taxCode, order, page, size).stream()
-                .map(delegationMapper::toDelegationResponse)
-                .collect(Collectors.toList()));
+                .map(delegation -> delegationMapper.toDelegationResponseGet(delegation, brokerId))
+                .toList());
     }
 
     /**

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationController.java
@@ -1,32 +1,31 @@
     package it.pagopa.selfcare.mscore.web.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.tags.Tags;
-import it.pagopa.selfcare.mscore.constant.GenericError;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
-import it.pagopa.selfcare.mscore.constant.Order;
-import it.pagopa.selfcare.mscore.core.DelegationService;
-import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
-import it.pagopa.selfcare.mscore.model.delegation.Delegation;
-import it.pagopa.selfcare.mscore.web.model.delegation.DelegationRequest;
-import it.pagopa.selfcare.mscore.web.model.delegation.DelegationRequestFromTaxcode;
-import it.pagopa.selfcare.mscore.web.model.delegation.DelegationResponse;
-import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapper;
-import it.pagopa.selfcare.mscore.web.util.CustomExceptionMessage;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+    import io.swagger.annotations.Api;
+    import io.swagger.annotations.ApiOperation;
+    import io.swagger.annotations.ApiParam;
+    import io.swagger.v3.oas.annotations.tags.Tag;
+    import io.swagger.v3.oas.annotations.tags.Tags;
+    import it.pagopa.selfcare.mscore.constant.GenericError;
+    import it.pagopa.selfcare.mscore.constant.Order;
+    import it.pagopa.selfcare.mscore.core.DelegationService;
+    import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
+    import it.pagopa.selfcare.mscore.model.delegation.Delegation;
+    import it.pagopa.selfcare.mscore.web.model.delegation.DelegationRequest;
+    import it.pagopa.selfcare.mscore.web.model.delegation.DelegationRequestFromTaxcode;
+    import it.pagopa.selfcare.mscore.web.model.delegation.DelegationResponse;
+    import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapper;
+    import it.pagopa.selfcare.mscore.web.util.CustomExceptionMessage;
+    import lombok.extern.slf4j.Slf4j;
+    import org.springframework.http.HttpStatus;
+    import org.springframework.http.MediaType;
+    import org.springframework.http.ResponseEntity;
+    import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
+    import javax.validation.Valid;
+    import java.util.List;
+    import java.util.Objects;
+    import java.util.Optional;
+    import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping(value = "/delegations", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -104,8 +103,6 @@ public class DelegationController {
                                                                    @RequestParam(name = "search", required = false) String search,
                                                                    @ApiParam("${swagger.mscore.institutions.model.taxCode}")
                                                                    @RequestParam(name = "taxCode", required = false) String taxCode,
-                                                                   @ApiParam("${swagger.mscore.institutions.delegations.mode}")
-                                                                   @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
                                                                    @ApiParam("${swagger.mscore.institutions.delegations.order}")
                                                                    @RequestParam(name = "order", required = false) Optional<Order> order,
                                                                    @RequestParam(name = "page", required = false) Optional<Integer> page,
@@ -114,7 +111,7 @@ public class DelegationController {
         if(Objects.isNull(institutionId) && Objects.isNull(brokerId))
             throw new InvalidRequestException("institutionId or brokerId must not be null!!", GenericError.GENERIC_ERROR.getCode());
 
-        return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId, search, taxCode, mode, order, page, size).stream()
+        return ResponseEntity.status(HttpStatus.OK).body(delegationService.getDelegations(institutionId, brokerId, productId, search, taxCode, order, page, size).stream()
                 .map(delegationMapper::toDelegationResponse)
                 .collect(Collectors.toList()));
     }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
@@ -5,7 +5,6 @@
     import io.swagger.annotations.ApiParam;
     import io.swagger.v3.oas.annotations.tags.Tag;
     import it.pagopa.selfcare.mscore.constant.GenericError;
-    import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
     import it.pagopa.selfcare.mscore.constant.Order;
     import it.pagopa.selfcare.mscore.core.DelegationService;
     import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
@@ -64,8 +63,6 @@
                                                                        @RequestParam(name = "search", required = false) String search,
                                                                        @ApiParam("${swagger.mscore.institutions.model.taxCode}")
                                                                        @RequestParam(name = "taxCode", required = false) String taxCode,
-                                                                       @ApiParam("${swagger.mscore.institutions.delegations.mode}")
-                                                                       @RequestParam(name = "mode", required = false) GetDelegationsMode mode,
                                                                        @ApiParam("${swagger.mscore.institutions.delegations.order}")
                                                                        @RequestParam(name = "order", required = false, defaultValue = "NONE") Order order,
                                                                        @RequestParam (name = "page", required = false, defaultValue = "0") @Min(0) Integer page,
@@ -80,7 +77,6 @@
                     .productId(productId)
                     .search(search)
                     .taxCode(taxCode)
-                    .mode(mode)
                     .order(order)
                     .page(page)
                     .size(size)

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2Controller.java
@@ -84,7 +84,10 @@
 
             DelegationWithPagination delegationWithPagination = delegationService.getDelegationsV2(delegationParameters);
 
-            DelegationWithPaginationResponse response = new DelegationWithPaginationResponse(delegationWithPagination.getDelegations().stream().map(delegationMapper::toDelegationResponse).toList(), delegationWithPagination.getPageInfo());
+            DelegationWithPaginationResponse response = new DelegationWithPaginationResponse(
+                    delegationWithPagination.getDelegations().stream().map(
+                            delegation -> delegationMapper.toDelegationResponseGet(delegation, brokerId))
+                            .toList(), delegationWithPagination.getPageInfo());
 
             return ResponseEntity.status(HttpStatus.OK).body(response);
         }

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/DelegationMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/DelegationMapper.java
@@ -16,6 +16,7 @@ public interface DelegationMapper {
 
     @Mapping(source = "from", target = "institutionId")
     @Mapping(source = "to", target = "brokerId")
+    @Mapping(source = "fromTaxCode", target = "taxCode")
     @Mapping(source = "institutionFromName", target = "institutionName")
     @Mapping(source = "institutionToName", target = "brokerName")
     @Mapping(source = "institutionFromRootName", target = "institutionRootName")

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/DelegationMapper.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/mapper/DelegationMapper.java
@@ -7,6 +7,8 @@ import it.pagopa.selfcare.mscore.web.model.delegation.DelegationResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
+import java.util.Objects;
+
 @Mapper(componentModel = "spring")
 public interface DelegationMapper {
 
@@ -16,10 +18,21 @@ public interface DelegationMapper {
 
     @Mapping(source = "from", target = "institutionId")
     @Mapping(source = "to", target = "brokerId")
-    @Mapping(source = "fromTaxCode", target = "taxCode")
     @Mapping(source = "institutionFromName", target = "institutionName")
     @Mapping(source = "institutionToName", target = "brokerName")
     @Mapping(source = "institutionFromRootName", target = "institutionRootName")
     DelegationResponse toDelegationResponse(Delegation delegation);
+
+    @Mapping(source = "delegation.from", target = "institutionId")
+    @Mapping(source = "delegation.to", target = "brokerId")
+    @Mapping(expression = "java(getTaxCodeValue(delegation, to))", target = "taxCode")
+    @Mapping(source = "delegation.institutionFromName", target = "institutionName")
+    @Mapping(source = "delegation.institutionToName", target = "brokerName")
+    @Mapping(source = "delegation.institutionFromRootName", target = "institutionRootName")
+    DelegationResponse toDelegationResponseGet(Delegation delegation, String to);
+
+    default String getTaxCodeValue(Delegation delegation, String to) {
+        return Objects.nonNull(to) ? delegation.getFromTaxCode() : delegation.getToTaxCode();
+    }
 
 }

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -94,7 +94,6 @@ swagger.mscore.api.users.updateUserStatus=Update user status with optional filte
 swagger.mscore.api.users.getOnboardedUsers=Retrieve onboarded users according to identifiers in input
 swagger.mscore.institutions.delegations=Retrieve institution's delegations
 swagger.mscore.institutions.delegationsV2=Retrieve institution's delegations with pagination
-swagger.mscore.institutions.delegations.mode=Mode (full or normal) to retreieve institution's delegations
 swagger.mscore.institutions.delegations.order=Order to show response NONE, ASC, DESC
 swagger.mscore.institutions.brokers=Retrieve institution brokers
 swagger.mscore.institutions.getInstitutionBrokers=Retrieve institution brokers

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
@@ -3,8 +3,6 @@ package it.pagopa.selfcare.mscore.web.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
-import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.core.DelegationService;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
 import it.pagopa.selfcare.mscore.web.model.delegation.DelegationRequest;
@@ -52,9 +50,7 @@ class DelegationControllerTest {
 
     final String FROM1 = "from1";
     final String FROM2 = "from2";
-    final String FROM3 = "from3";
     final String TO1 = "to1";
-    final String TO2 = "to2";
 
     /**
      * Method under test: {@link DelegationController#createDelegation(DelegationRequest)}
@@ -131,7 +127,7 @@ class DelegationControllerTest {
     }
 
     /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
      */
     @Test
     void getDelegations_shouldGetData() throws Exception {
@@ -139,92 +135,7 @@ class DelegationControllerTest {
         Delegation expectedDelegation = dummyDelegation();
 
         when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Optional.empty(), Optional.empty(), Optional.empty()))
-                .thenReturn(List.of(expectedDelegation));
-        // When
-        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}&mode={mode}", expectedDelegation.getFrom(),
-                        expectedDelegation.getTo(), expectedDelegation.getProductId(), GetDelegationsMode.NORMAL);
-        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
-                .build()
-                .perform(requestBuilder)
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andReturn();
-
-        List<DelegationResponse> response = objectMapper.readValue(
-                result.getResponse().getContentAsString(), new TypeReference<>() {});
-        // Then
-        assertThat(response).isNotNull();
-        assertThat(response.size()).isEqualTo(1);
-        DelegationResponse actual = response.get(0);
-        assertThat(actual.getId()).isEqualTo(expectedDelegation.getId());
-        assertThat(actual.getInstitutionName()).isEqualTo(expectedDelegation.getInstitutionFromName());
-        assertThat(actual.getBrokerId()).isEqualTo(expectedDelegation.getTo());
-        assertThat(actual.getProductId()).isEqualTo(expectedDelegation.getProductId());
-        assertThat(actual.getInstitutionId()).isEqualTo(expectedDelegation.getFrom());
-        assertThat(actual.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
-
-        verify(delegationService, times(1))
-                .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Optional.empty(),
-                        Optional.empty(), Optional.empty());
-
-        verifyNoMoreInteractions(delegationService);
-    }
-
-    @Test
-    void getDelegations_shouldGetDataCustom() throws Exception {
-        // Given
-        List<Delegation> expectedDelegations = new ArrayList<>();
-        Delegation delegation1 = createDelegation("1", FROM1, TO1);
-        Delegation delegation2 = createDelegation("2", FROM2, TO1);
-        expectedDelegations.add(delegation1);
-        expectedDelegations.add(delegation2);
-
-        when(delegationService.getDelegations(null, TO1,
-                null, null, null, GetDelegationsMode.FULL, Optional.empty(), Optional.empty(), Optional.empty()))
-                .thenReturn(expectedDelegations);
-        // When
-        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/delegations?brokerId={brokerId}&mode={mode}", TO1, GetDelegationsMode.FULL);
-        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
-                .build()
-                .perform(requestBuilder)
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andReturn();
-
-        List<DelegationResponse> response = objectMapper.readValue(
-                result.getResponse().getContentAsString(), new TypeReference<>() {});
-        // Then
-        assertThat(response).isNotNull();
-        assertThat(response.size()).isEqualTo(2);
-        DelegationResponse actual = response.get(0);
-        assertThat(actual.getId()).isEqualTo(delegation1.getId());
-        assertThat(actual.getInstitutionName()).isEqualTo(delegation1.getInstitutionFromName());
-        assertThat(actual.getBrokerId()).isEqualTo(delegation1.getTo());
-        assertThat(actual.getProductId()).isEqualTo(delegation1.getProductId());
-        assertThat(actual.getInstitutionId()).isEqualTo(delegation1.getFrom());
-        assertThat(actual.getInstitutionRootName()).isEqualTo(delegation1.getInstitutionFromRootName());
-
-        verify(delegationService, times(1))
-                .getDelegations(null, TO1, null,
-                        null, null, GetDelegationsMode.FULL, Optional.empty(),
-                        Optional.empty(), Optional.empty());
-        verifyNoMoreInteractions(delegationService);
-    }
-
-    /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
-     */
-    @Test
-    void getDelegations_shouldGetData_nullMode() throws Exception {
-        // Given
-        Delegation expectedDelegation = dummyDelegation();
-
-        when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, null, null, Optional.empty(), Optional.empty(), Optional.empty()))
+                expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty(), Optional.empty()))
                 .thenReturn(List.of(expectedDelegation));
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
@@ -252,7 +163,92 @@ class DelegationControllerTest {
 
         verify(delegationService, times(1))
                 .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, null, null, Optional.empty(), Optional.empty(), Optional.empty());
+                        expectedDelegation.getProductId(), null, null, Optional.empty(),
+                        Optional.empty(), Optional.empty());
+
+        verifyNoMoreInteractions(delegationService);
+    }
+
+    @Test
+    void getDelegations_shouldGetDataCustom() throws Exception {
+        // Given
+        List<Delegation> expectedDelegations = new ArrayList<>();
+        Delegation delegation1 = createDelegation("1", FROM1, TO1);
+        Delegation delegation2 = createDelegation("2", FROM2, TO1);
+        expectedDelegations.add(delegation1);
+        expectedDelegations.add(delegation2);
+
+        when(delegationService.getDelegations(null, TO1,
+                null, null, null, Optional.empty(), Optional.empty(), Optional.empty()))
+                .thenReturn(expectedDelegations);
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/delegations?brokerId={brokerId}", TO1);
+        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andReturn();
+
+        List<DelegationResponse> response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.size()).isEqualTo(2);
+        DelegationResponse actual = response.get(0);
+        assertThat(actual.getId()).isEqualTo(delegation1.getId());
+        assertThat(actual.getInstitutionName()).isEqualTo(delegation1.getInstitutionFromName());
+        assertThat(actual.getBrokerId()).isEqualTo(delegation1.getTo());
+        assertThat(actual.getProductId()).isEqualTo(delegation1.getProductId());
+        assertThat(actual.getInstitutionId()).isEqualTo(delegation1.getFrom());
+        assertThat(actual.getInstitutionRootName()).isEqualTo(delegation1.getInstitutionFromRootName());
+
+        verify(delegationService, times(1))
+                .getDelegations(null, TO1, null,
+                        null, null, Optional.empty(),
+                        Optional.empty(), Optional.empty());
+        verifyNoMoreInteractions(delegationService);
+    }
+
+    /**
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
+     */
+    @Test
+    void getDelegations_shouldGetData_nullMode() throws Exception {
+        // Given
+        Delegation expectedDelegation = dummyDelegation();
+
+        when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
+                expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty(), Optional.empty()))
+                .thenReturn(List.of(expectedDelegation));
+        // When
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
+                .get("/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}", expectedDelegation.getFrom(),
+                        expectedDelegation.getTo(), expectedDelegation.getProductId());
+        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
+                .build()
+                .perform(requestBuilder)
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
+                .andReturn();
+
+        List<DelegationResponse> response = objectMapper.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<>() {});
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.size()).isEqualTo(1);
+        DelegationResponse actual = response.get(0);
+        assertThat(actual.getId()).isEqualTo(expectedDelegation.getId());
+        assertThat(actual.getInstitutionName()).isEqualTo(expectedDelegation.getInstitutionFromName());
+        assertThat(actual.getBrokerId()).isEqualTo(expectedDelegation.getTo());
+        assertThat(actual.getProductId()).isEqualTo(expectedDelegation.getProductId());
+        assertThat(actual.getInstitutionId()).isEqualTo(expectedDelegation.getFrom());
+        assertThat(actual.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
+
+        verify(delegationService, times(1))
+                .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
+                        expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty(), Optional.empty());
         verifyNoMoreInteractions(delegationService);
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2ControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationV2ControllerTest.java
@@ -3,7 +3,6 @@ package it.pagopa.selfcare.mscore.web.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.pagopa.selfcare.mscore.constant.DelegationType;
-import it.pagopa.selfcare.mscore.constant.GetDelegationsMode;
 import it.pagopa.selfcare.mscore.constant.Order;
 import it.pagopa.selfcare.mscore.core.DelegationService;
 import it.pagopa.selfcare.mscore.model.delegation.Delegation;
@@ -72,7 +71,7 @@ class DelegationV2ControllerTest {
     }
 
     /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
      */
     @Test
     void getDelegations_shouldGetData() throws Exception {
@@ -83,12 +82,12 @@ class DelegationV2ControllerTest {
         DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(List.of(expectedDelegation), exptectedPageInfo);
 
         when(delegationService.getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Order.ASC, 0, 10)))
+                expectedDelegation.getProductId(), null, null, Order.ASC, 0, 10)))
                 .thenReturn(expectedDelegationWithPagination);
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/v2/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}&mode={mode}&order={order}&page={page}&size={size}",
-                        expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId(), GetDelegationsMode.NORMAL,
+                .get("/v2/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}&order={order}&page={page}&size={size}",
+                        expectedDelegation.getFrom(), expectedDelegation.getTo(), expectedDelegation.getProductId(),
                         Order.ASC ,exptectedPageInfo.getPageNo(), exptectedPageInfo.getPageSize());
         MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
                 .build()
@@ -116,7 +115,7 @@ class DelegationV2ControllerTest {
 
         verify(delegationService, times(1))
                 .getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, null, GetDelegationsMode.NORMAL, Order.ASC,
+                        expectedDelegation.getProductId(), null, null, Order.ASC,
                         0, 10));
 
         verifyNoMoreInteractions(delegationService);
@@ -136,11 +135,11 @@ class DelegationV2ControllerTest {
         DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(expectedDelegations, exptectedPageInfo);
 
         when(delegationService.getDelegationsV2(createDelegationParameters(null, TO1,
-                null, null, null, GetDelegationsMode.FULL, Order.DESC, 0, 10000)))
+                null, null, null, Order.DESC, 0, 10000)))
                 .thenReturn(expectedDelegationWithPagination);
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/v2/delegations?brokerId={brokerId}&mode={mode}&order={order}", TO1, GetDelegationsMode.FULL, Order.DESC);
+                .get("/v2/delegations?brokerId={brokerId}&order={order}", TO1, Order.DESC);
         MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
                 .build()
                 .perform(requestBuilder)
@@ -167,13 +166,13 @@ class DelegationV2ControllerTest {
 
         verify(delegationService, times(1))
                 .getDelegationsV2(createDelegationParameters(null, TO1, null,
-                        null, null, GetDelegationsMode.FULL, Order.DESC,
+                        null, null, Order.DESC,
                         0, 10000));
         verifyNoMoreInteractions(delegationService);
     }
 
     /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, GetDelegationsMode, Optional, Optional, Optional)}
+     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
      */
     @Test
     void getDelegations_shouldGetData_nullMode() throws Exception {
@@ -184,7 +183,7 @@ class DelegationV2ControllerTest {
         DelegationWithPagination expectedDelegationWithPagination = new DelegationWithPagination(List.of(expectedDelegation), exptectedPageInfo);
 
         when(delegationService.getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, null, null, Order.NONE, 0, 10000)))
+                expectedDelegation.getProductId(), null, null, Order.NONE, 0, 10000)))
                 .thenReturn(expectedDelegationWithPagination);
         // When
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
@@ -216,7 +215,7 @@ class DelegationV2ControllerTest {
 
         verify(delegationService, times(1))
                 .getDelegationsV2(createDelegationParameters(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, null, null, Order.NONE, 0, 10000));
+                        expectedDelegation.getProductId(), null, null, Order.NONE,0, 10000));
         verifyNoMoreInteractions(delegationService);
     }
 
@@ -280,15 +279,14 @@ class DelegationV2ControllerTest {
     }
 
     private GetDelegationParameters createDelegationParameters(String from, String to, String productId,
-                                                               String search, String taxCode, GetDelegationsMode mode,
-                                                               Order order, Integer page, Integer size) {
+                                                               String search, String taxCode, Order order,
+                                                               Integer page, Integer size) {
         return GetDelegationParameters.builder()
                 .from(from)
                 .to(to)
                 .productId(productId)
                 .search(search)
                 .taxCode(taxCode)
-                .mode(mode)
                 .order(order)
                 .page(page)
                 .size(size)


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- remove aggregation to retrieve taxCode
- add filter taxCode in collection Delegation
- add delegation response mapper to return the appropriate taxCode
- remove mode filter
- align unit tests
- align open api

<!--- Describe your changes in detail -->

#### Motivation and Context
This change is related to the addition of fields toTaxCode and fromTaxCode in collection Delegation, in this way it's possible to retrieve taxCode direclty from Delegation Collection.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by running locally both getDelegations and getDelegationsV2 APIs

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.