### PR TITLE
[SELC-4883] feat: add retry on retrieveGeographicTaxonomies

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -49,3 +49,12 @@ core:
     type: ${CORE_USER_EVENT_SERVICE_TYPE:ignore}
   contract-event-service:
     type: ${CORE_CONTRACT_EVENT_SERVICE_TYPE:ignore}
+  resilience4j:
+    retry:
+      retry-aspect-order: 1
+      instances:
+        retryTimeout:
+          max-attempts: 3
+          wait-duration: 5s
+          retry-exceptions:
+            - feign.RetryableException

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -30,6 +30,10 @@
             <groupId>io.github.openfeign</groupId>
             <artifactId>feign-okhttp</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot2</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImpl.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.mscore.connector.rest;
 
 import feign.FeignException;
+import io.github.resilience4j.retry.annotation.Retry;
 import it.pagopa.selfcare.commons.base.logging.LogUtils;
 import it.pagopa.selfcare.mscore.api.PartyRegistryProxyConnector;
 import it.pagopa.selfcare.mscore.connector.rest.client.PartyRegistryProxyRestClient;
@@ -30,6 +31,7 @@ import static it.pagopa.selfcare.mscore.constant.CustomError.CREATE_INSTITUTION_
 @Service
 public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnector {
 
+    public static final String CODE_IS_REQUIRED = "Code is required";
     private final PartyRegistryProxyRestClient restClient;
     private final AooMapper aooMapper;
     private final UoMapper uoMapper;
@@ -137,9 +139,10 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     }
 
     @Override
+    @Retry(name = "retryTimeout")
     public GeographicTaxonomies getExtByCode(String code) {
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getExtByCode code = {}", code);
-        Assert.hasText(code, "Code is required");
+        Assert.hasText(code, CODE_IS_REQUIRED);
         GeographicTaxonomiesResponse result = restClient.getExtByCode(code);
         log.debug(LogUtils.CONFIDENTIAL_MARKER, "getExtByCode result = {}", result);
         return toGeoTaxonomies(result);
@@ -148,7 +151,7 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     @Override
     public AreaOrganizzativaOmogenea getAooById(String aooId) {
         log.debug("getAooById id = {}", aooId);
-        Assert.hasText(aooId, "Code is required");
+        Assert.hasText(aooId, CODE_IS_REQUIRED);
         AooResponse result = restClient.getAooById(aooId);
         log.debug("getAooById id = {}", aooId);
         return aooMapper.toEntity(result);
@@ -157,7 +160,7 @@ public class PartyRegistryProxyConnectorImpl implements PartyRegistryProxyConnec
     @Override
     public UnitaOrganizzativa getUoById(String uoId) {
         log.debug("getUoById id = {}", uoId);
-        Assert.hasText(uoId, "Code is required");
+        Assert.hasText(uoId, CODE_IS_REQUIRED);
         UoResponse result = restClient.getUoById(uoId);
         log.debug("getUoById id = {}", uoId);
         return uoMapper.toEntity(result);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added the resilience4j-spring-boot2 dependency to the pom.xml 
- Configured the retry properties in the application.yml
- Added Retry annotation on getExtByCode method
- Add constant to resolve code smell

<!--- Describe your changes in detail -->

#### Motivation and Context
This PR introduces a retry mechanism for getExtByCode call by utilizing the resilience4j-spring-boot2 library.
This change was necessary because of sporiadic endpoint's failures.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.