### PR TITLE
[SELC-4976] feat: add EA DelegationType

### DIFF
--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -2815,7 +2815,7 @@
           },
           "type" : {
             "type" : "string",
-            "enum" : [ "AOO", "PT" ]
+            "enum" : [ "AOO", "EA", "PT" ]
           }
         }
       },
@@ -2846,7 +2846,7 @@
           },
           "type" : {
             "type" : "string",
-            "enum" : [ "AOO", "PT" ]
+            "enum" : [ "AOO", "EA", "PT" ]
           }
         }
       },
@@ -2898,7 +2898,7 @@
           },
           "type" : {
             "type" : "string",
-            "enum" : [ "AOO", "PT" ]
+            "enum" : [ "AOO", "EA", "PT" ]
           },
           "updatedAt" : {
             "type" : "string",

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/DelegationType.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/DelegationType.java
@@ -3,4 +3,5 @@ package it.pagopa.selfcare.mscore.constant;
 public enum DelegationType {
     PT,
     AOO,
+    EA
 }

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
@@ -214,47 +214,6 @@ class DelegationControllerTest {
         verifyNoMoreInteractions(delegationService);
     }
 
-    /**
-     * Method under test: {@link DelegationController#getDelegations(String, String, String, String, String, Optional, Optional, Optional)}
-     */
-    @Test
-    void getDelegations_shouldGetData_nullMode() throws Exception {
-        // Given
-        Delegation expectedDelegation = dummyDelegation();
-
-        when(delegationService.getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty(), Optional.empty()))
-                .thenReturn(List.of(expectedDelegation));
-        // When
-        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
-                .get("/delegations?institutionId={institutionId}&brokerId={brokerId}&productId={productId}", expectedDelegation.getFrom(),
-                        expectedDelegation.getTo(), expectedDelegation.getProductId());
-        MvcResult result = MockMvcBuilders.standaloneSetup(delegationController)
-                .build()
-                .perform(requestBuilder)
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(MockMvcResultMatchers.content().contentType("application/json"))
-                .andReturn();
-
-        List<DelegationResponse> response = objectMapper.readValue(
-                result.getResponse().getContentAsString(), new TypeReference<>() {});
-        // Then
-        assertThat(response).isNotNull();
-        assertThat(response.size()).isEqualTo(1);
-        DelegationResponse actual = response.get(0);
-        assertThat(actual.getId()).isEqualTo(expectedDelegation.getId());
-        assertThat(actual.getInstitutionName()).isEqualTo(expectedDelegation.getInstitutionFromName());
-        assertThat(actual.getBrokerId()).isEqualTo(expectedDelegation.getTo());
-        assertThat(actual.getProductId()).isEqualTo(expectedDelegation.getProductId());
-        assertThat(actual.getInstitutionId()).isEqualTo(expectedDelegation.getFrom());
-        assertThat(actual.getInstitutionRootName()).isEqualTo(expectedDelegation.getInstitutionFromRootName());
-
-        verify(delegationService, times(1))
-                .getDelegations(expectedDelegation.getFrom(), expectedDelegation.getTo(),
-                        expectedDelegation.getProductId(), null, null, Optional.empty(), Optional.empty(), Optional.empty());
-        verifyNoMoreInteractions(delegationService);
-    }
-
     private Delegation dummyDelegation() {
         Delegation delegation = new Delegation();
         delegation.setFrom("from");

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/DelegationControllerTest.java
@@ -12,6 +12,8 @@ import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapper;
 import it.pagopa.selfcare.mscore.web.model.mapper.DelegationMapperImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -55,8 +57,9 @@ class DelegationControllerTest {
     /**
      * Method under test: {@link DelegationController#createDelegation(DelegationRequest)}
      */
-    @Test
-    void testCreateDelegation() throws Exception {
+    @ParameterizedTest
+    @EnumSource(value = DelegationType.class)
+    void testCreateDelegation(DelegationType delegationType) throws Exception {
 
         Delegation delegation = new Delegation();
         delegation.setId("id");
@@ -69,7 +72,7 @@ class DelegationControllerTest {
         delegationRequest.setInstitutionFromName("Test name");
         delegationRequest.setInstitutionToName("Test to name");
         delegationRequest.setProductId("productId");
-        delegationRequest.setType(DelegationType.PT);
+        delegationRequest.setType(delegationType);
         String content = (new ObjectMapper()).writeValueAsString(delegationRequest);
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders
                 .post("/delegations")


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- add EA (Enti Aggregatori) DelegationType
- align open api
- align unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
This modification pertains to the feature of Enti Aggregatori, enabling the association of an aggregator with aggregated institutions.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested by running ms locally and calling createDelegation API with field "type" set to "EA".

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.