### PR TITLE
[SELC-5020] Fix: Return existing Institution if it already exists, instead of throwing ResourceConflict Exception 

### DIFF
--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -226,16 +226,19 @@ public class InstitutionServiceImpl implements InstitutionService {
 
     @Override
     public Institution createPgInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser) {
-        checkIfAlreadyExists(taxId);
+        return institutionConnector.findByExternalId(taxId)
+                .orElse(createNewInstitution(taxId, description, existsInRegistry, selfCareUser));
+    }
+
+    private Institution createNewInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser) {
         Institution newInstitution = new Institution();
         newInstitution.setExternalId(taxId);
         newInstitution.setDescription(description);
         newInstitution.setInstitutionType(InstitutionType.PG);
         newInstitution.setTaxCode(taxId);
         newInstitution.setCreatedAt(OffsetDateTime.now());
-        newInstitution.setOriginId(taxId); //TODO: CHE CAMPO USARE
+        newInstitution.setOriginId(taxId);
 
-        //TODO: QUANDO SARA' DISPONIBILE IL SERVIZIO PUNTUALE PER CONOSCERE LA RAGIONE SOCIALE DATA LA PIVA SOSTITUIRE LA CHIAMATA
         if (existsInRegistry) {
             if (coreConfig.isInfoCamereEnable()) {
                 List<InstitutionByLegal> institutionByLegal = partyRegistryProxyConnector.getInstitutionsByLegal(selfCareUser.getFiscalCode());

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImpl.java
@@ -227,7 +227,7 @@ public class InstitutionServiceImpl implements InstitutionService {
     @Override
     public Institution createPgInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser) {
         return institutionConnector.findByExternalId(taxId)
-                .orElse(createNewInstitution(taxId, description, existsInRegistry, selfCareUser));
+                .orElseGet(() -> createNewInstitution(taxId, description, existsInRegistry, selfCareUser));
     }
 
     private Institution createNewInstitution(String taxId, String description, boolean existsInRegistry, SelfCareUser selfCareUser) {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/InstitutionServiceImplTest.java
@@ -290,6 +290,7 @@ class InstitutionServiceImplTest {
         assertEquals(response.getTaxCode(), taxId);
         assertEquals(response.getExternalId(), taxId);
         verify(institutionConnector).findByExternalId(any());
+        verify(institutionConnector, never()).save(any());
     }
 
     @Test
@@ -357,7 +358,6 @@ class InstitutionServiceImplTest {
         Institution institution = institutionServiceImpl.createInstitutionFromIvass(new Institution());
         assertNotNull(institution);
     }
-
 
 
     @Test


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Refactor method createPgInstitution to return already existing institution instead of throwing ResourceConflict Exception
<!--- Describe your changes in detail -->

#### Motivation and Context
To prevent errors in the event of parallel institution creation requests, it is necessary to modify the flow in order to call a single API that retrieves or saves the institution via the taxCode
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.