### PR TITLE
[SELC - 5131] bugfix: fixed filters in verify onboarding

### DIFF
--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImpl.java
@@ -308,8 +308,9 @@ public class InstitutionConnectorImpl implements InstitutionConnector {
                 .isIfNotNull(InstitutionEntity.Fields.taxCode.name(), filters.getTaxCode())
                 .isIfNotNull(InstitutionEntity.Fields.origin.name(), filters.getOrigin())
                 .isIfNotNull(InstitutionEntity.Fields.originId.name(), filters.getOriginId())
-                .isIfNotNull(InstitutionEntity.Fields.subunitCode.name(), filters.getSubunitCode())
                 .build();
+
+        criteriaInstitution.and(InstitutionEntity.Fields.subunitCode.name()).is(filters.getSubunitCode());
 
         Criteria criteriaOnboarding = Criteria.where(Onboarding.Fields.status.name()).in(filters.getValidRelationshipStates())
                 .and(Onboarding.Fields.productId.name()).is(filters.getProductId());

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -790,7 +790,7 @@ class InstitutionConnectorImplTest {
     }
 
     @Test
-    @DisplayName("Should return true when onboarding exists by filters")
+    @DisplayName("Should return true when onboarding exists by filters when subunitCode is null")
     void shouldReturnTrueWhenOnboardingExistsByFiltersAndSubunitCodeIsNull() {
         // Given
         VerifyOnboardingFilters filters = new VerifyOnboardingFilters("productId", "externalId", "taxCode", "origin", "originId", null);
@@ -805,7 +805,7 @@ class InstitutionConnectorImplTest {
     }
 
     @Test
-    @DisplayName("Should return true when onboarding exists by filters")
+    @DisplayName("Should return false when onboarding exists by filters when subunitCode is null")
     void shouldReturnFalseWhenOnboardingExistsByFiltersAndSubunitCodeIsNull() {
         // Given
         VerifyOnboardingFilters filters = new VerifyOnboardingFilters("productId", "externalId", "taxCode", "origin", "originId", null);

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/InstitutionConnectorImplTest.java
@@ -790,6 +790,36 @@ class InstitutionConnectorImplTest {
     }
 
     @Test
+    @DisplayName("Should return true when onboarding exists by filters")
+    void shouldReturnTrueWhenOnboardingExistsByFiltersAndSubunitCodeIsNull() {
+        // Given
+        VerifyOnboardingFilters filters = new VerifyOnboardingFilters("productId", "externalId", "taxCode", "origin", "originId", null);
+        filters.setValidRelationshipStates(List.of(RelationshipState.ACTIVE));
+        when(institutionRepository.exists(any(Query.class), any())).thenReturn(true);
+
+        // When
+        Boolean exists = institutionConnectorImpl.existsOnboardingByFilters(filters);
+
+        // Then
+        assertTrue(exists);
+    }
+
+    @Test
+    @DisplayName("Should return true when onboarding exists by filters")
+    void shouldReturnFalseWhenOnboardingExistsByFiltersAndSubunitCodeIsNull() {
+        // Given
+        VerifyOnboardingFilters filters = new VerifyOnboardingFilters("productId", "externalId", "taxCode", "origin", "originId", null);
+        filters.setValidRelationshipStates(List.of(RelationshipState.ACTIVE));
+        when(institutionRepository.exists(any(Query.class), any())).thenReturn(false);
+
+        // When
+        Boolean exists = institutionConnectorImpl.existsOnboardingByFilters(filters);
+
+        // Then
+        assertFalse(exists);
+    }
+
+    @Test
     @DisplayName("Should return false when onboarding does not exist by filters")
     void shouldReturnFalseWhenOnboardingDoesNotExistByFilters() {
         // Given


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- fixed filters in verify onboarding

#### Motivation and Context

During the current verify onboarding procedure, if a parent Institution tried to subscribe to a product that was ACTIVE on one of its UOs or AOOs, a 204 was returned and therefore it was erroneously not allowed to carry out onboarding. This happened because even if the originId was passed with the taxCode in the current code the originId was passed null and therefore the search was made only for taxCode, which shared between the parent Institution and its UO/AOOs, the body was found in the find. To solve this problem it was decided to use the subunitCode as a filter even if null is passed, in such a way as to search for the entity without that attribute so as to ignore the presence of any UO/AOOs in the find.

#### How Has This Been Tested?

the verify onboarding API was invoked by passing taxCode, origin, originId and productId as input and it was verified that 404 was returned and no longer 204 for the parent Institution, subsequently the same test was done adding the subunitCode and it was verified that a 204 was returned

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.