### PR TITLE
[SELC-5223] feat: remove product pagoPa condition in createDelegation

### DIFF
--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/DelegationServiceImplTest.java
@@ -99,61 +99,9 @@ class DelegationServiceImplTest {
      * Method under test: {@link DelegationServiceImpl#createDelegation(Delegation)}
      */
     @Test
-    void testCreateDelegationForPTWithProductPagopa() {
-        Institution institutionTo = new Institution();
-        institutionTo.setId("id");
-        institutionTo.setInstitutionType(InstitutionType.PT);
-        institutionTo.setTaxCode("taxCodeTo");
-        Institution institutionFrom = new Institution();
-        institutionFrom.setId("id");
-        institutionFrom.setTaxCode("taxCodeFrom");
-        when(delegationConnector.save(dummyDelegationProdPagopa)).thenAnswer(arg ->arg.getArguments()[0]);
-        doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), null)).thenReturn(List.of(institutionTo));
-        doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
-        when(institutionService.retrieveInstitutionById(dummyDelegationProdPagopa.getFrom())).thenReturn(institutionFrom);
-        Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdPagopa);
-        verify(institutionService).getInstitutions(any(), any());
-        verify(delegationConnector).save(any());
-        assertNotNull(response);
-        assertNotNull(response.getId());
-        assertEquals(dummyDelegationProdPagopa.getId(), response.getId());
-    }
-
-    /**
-     * Method under test: {@link DelegationServiceImpl#createDelegation(Delegation)}
-     */
-    @Test
-    void testCreateDelegationForEcWithProductPagopa() {
-        Institution institutionTo = new Institution();
-        institutionTo.setId("to");
-        institutionTo.setInstitutionType(InstitutionType.PT);
-        institutionTo.setTaxCode("taxCodeTo");
-        Institution institutionFrom = new Institution();
-        institutionFrom.setId("from");
-        institutionFrom.setTaxCode("taxCodeFrom");
-        when(delegationConnector.findAndActivate(institutionFrom.getId(), institutionTo.getId(), dummyDelegationProdPagopa.getProductId())).thenReturn(dummyDelegationProdPagopa);
-        doNothing().when(mailNotificationService).sendMailForDelegation(any(), any(), any());
-        when(institutionService.getInstitutions(dummyDelegationProdPagopa.getTo(), null)).thenReturn(List.of(institutionTo));
-        doNothing().when(institutionService).updateInstitutionDelegation(any(),anyBoolean());
-        when(delegationServiceImpl.checkIfExistsWithStatus(dummyDelegationProdPagopa, DelegationState.DELETED)).thenReturn(true);
-        when(institutionService.retrieveInstitutionById(dummyDelegationProdPagopa.getFrom())).thenReturn(institutionFrom);
-        Delegation response = delegationServiceImpl.createDelegation(dummyDelegationProdPagopa);
-        verify(delegationConnector).findAndActivate(institutionFrom.getId(), institutionTo.getId(), dummyDelegationProdPagopa.getProductId());
-        verify(institutionService).getInstitutions(any(), any());
-        assertNotNull(response);
-        assertNotNull(response.getId());
-        assertEquals(dummyDelegationProdPagopa.getId(), response.getId());
-    }
-
-    /**
-     * Method under test: {@link DelegationServiceImpl#createDelegation(Delegation)}
-     */
-    @Test
     void testCreateDelegationWithSendMailError() {
         Institution institution = new Institution();
         institution.setId("id");
-        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of(institution));
         when(institutionService.retrieveInstitutionById(any())).thenReturn(institution);
         doThrow(new MsCoreException(SEND_MAIL_FOR_DELEGATION_ERROR.getMessage(), SEND_MAIL_FOR_DELEGATION_ERROR.getCode()))
                 .when(mailNotificationService)
@@ -173,15 +121,6 @@ class DelegationServiceImplTest {
         when(delegationConnector.save(any())).thenThrow(new MsCoreException(CREATE_DELEGATION_ERROR.getMessage(), CREATE_DELEGATION_ERROR.getCode()));
         assertThrows(MsCoreException.class, () -> delegationServiceImpl.createDelegation(dummyDelegationProdIo));
         verify(delegationConnector).save(any());
-    }
-
-    /**
-     * Method under test: {@link DelegationServiceImpl#createDelegation(Delegation)}
-     */
-    @Test
-    void testCreateDelegationWithResourceNotFoundException() {
-        when(institutionService.getInstitutions(any(), any())).thenReturn(List.of());
-        assertThrows(ResourceNotFoundException.class, () -> delegationServiceImpl.createDelegation(dummyDelegationProdPagopa));
     }
 
     /**


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- remove product pagoPa condition in createDelegation
- remove and align unit tests

<!--- Describe your changes in detail -->

#### Motivation and Context
This change was required to move product pagoPa logic from BE to BFF.
With this modification createDelegation API on ms-core is semplied and reusable.

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
It was tested locally by running both ms-core and bff-dashboard locally and calling createDelegation API. on bff-dashboard.
It was tested with both product prod-pagopa and prod-io.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.