### PR TITLE
[SELC-5169] feat : Added record PecNotification in persistOnboarding

### DIFF
--- a/app/src/main/resources/config/core-config.properties
+++ b/app/src/main/resources/config/core-config.properties
@@ -26,3 +26,6 @@ mscore.blob-storage.connection-string-product = ${BLOB_STORAGE_PRODUCT_CONNECTIO
 mscore.aws-ses-secret-id=${AWS_SES_ACCESS_KEY_ID:secret-id-example}
 mscore.aws-ses-secret-key=${AWS_SES_SECRET_ACCESS_KEY:secret-key-example}
 mscore.aws-ses-region=${AWS_SES_REGION:eu-south-1}
+
+mscore.sending-frequency-pec-notification=${SENDING_FREQUENCY_PEC_NOTIFICATION:30}
+mscore.epoch-date-pec-notification=${EPOCH_DATE_PEC_NOTIFICATION:2024-01-01}

--- a/app/src/main/resources/swagger/api-docs.json
+++ b/app/src/main/resources/swagger/api-docs.json
@@ -1871,6 +1871,71 @@
         } ]
       }
     },
+    "/institutions/{id}/{productId}" : {
+      "delete" : {
+        "tags" : [ "Institution" ],
+        "summary" : "The service delete the users changing the user status to 'DELETE' and remove from DB the PecNotification record by productId and institutionId",
+        "description" : "The service delete the users changing the user status to 'DELETE' and remove from DB the PecNotification record by productId and institutionId",
+        "operationId" : "deleteOnboardedInstitutionUsingDELETE",
+        "parameters" : [ {
+          "name" : "productId",
+          "in" : "path",
+          "description" : "productId",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "id",
+          "in" : "path",
+          "description" : "id",
+          "required" : true,
+          "style" : "simple",
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No Content"
+          },
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Not Found",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/problem+json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Problem"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "bearerAuth" : [ "global" ]
+        } ]
+      }
+    },
     "/institutions/{institutionId}/createdAt" : {
       "put" : {
         "tags" : [ "Institution" ],

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PecNotificationConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PecNotificationConnector.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.mscore.api;
+
+import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
+
+public interface PecNotificationConnector {
+
+    boolean findAndDeletePecNotification(String institutionId, String productId);
+
+    boolean insertPecNotification(PecNotification pecNotification);
+}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
@@ -61,7 +61,9 @@ public enum GenericError {
     VERIFY_USER_ERROR("0000", "Error while searching institutions related to given productId"),
     GET_USER_ERROR("0000", "Error while searching user given UserID"),
     UPDATE_USER_INSTITUTION_ERROR("0000", "Error while updating InstitutionUser for id %s"),
-    GENERIC_ERROR("0000", "Generic Error");
+    GENERIC_ERROR("0000", "Generic Error"),
+    DELETE_ONBOARDED_OPERATION_ERROR("0000", "Error while deleting Onboarded Institution"),
+    DELETE_NOTIFICATION_OPERATION_ERROR ("0000", "PecNotificationEntity was not deleted because either it does not exist or there are multiple records");
     private final String code;
     private final String detail;
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
@@ -63,7 +63,8 @@ public enum GenericError {
     UPDATE_USER_INSTITUTION_ERROR("0000", "Error while updating InstitutionUser for id %s"),
     GENERIC_ERROR("0000", "Generic Error"),
     DELETE_ONBOARDED_OPERATION_ERROR("0000", "Error while deleting Onboarded Institution"),
-    DELETE_NOTIFICATION_OPERATION_ERROR ("0000", "PecNotificationEntity was not deleted because either it does not exist or there are multiple records");
+    DELETE_NOTIFICATION_OPERATION_ERROR ("0000", "PecNotificationEntity was not deleted because either it does not exist or there are multiple records"),
+    INVALID_INSERT_PEC_NOTIFICATION_ERROR ("0001", "PecNotificationEntity was not inserted because either it exist or the data are invalid");
     private final String code;
     private final String detail;
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/pecnotification/PecNotification.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/pecnotification/PecNotification.java
@@ -1,0 +1,22 @@
+package it.pagopa.selfcare.mscore.model.pecnotification;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PecNotification {
+
+    private String id;
+    private String institutionId;
+    private String productId;
+    private Integer moduleDayOfTheEpoch;
+
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
@@ -1,0 +1,66 @@
+package it.pagopa.selfcare.mscore.connector.dao;
+
+import it.pagopa.selfcare.mscore.api.PecNotificationConnector;
+import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
+import it.pagopa.selfcare.mscore.connector.dao.model.mapper.PecNotificationEntityMapper;
+import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class PecNotificationConnectorImpl implements PecNotificationConnector {
+
+    private final PecNotificationRepository repository;
+    private final PecNotificationEntityMapper pecNotificationMapper;
+
+    public PecNotificationConnectorImpl(PecNotificationRepository repository, PecNotificationEntityMapper pecNotificationMapper) {
+        this.repository = repository;
+        this.pecNotificationMapper = pecNotificationMapper;
+    }
+
+    @Override
+    public boolean findAndDeletePecNotification(String institutionId, String productId) {
+
+        Query query = Query.query(Criteria.where(PecNotificationEntity.Fields.institutionId.name()).is(institutionId)
+                .and(PecNotificationEntity.Fields.productId.name()).is(productId));
+
+        List<PecNotificationEntity> pecNotificationEntityList = repository.find(query, PecNotificationEntity.class);
+
+        if(null != pecNotificationEntityList && pecNotificationEntityList.size() == 1) {
+            repository.delete(pecNotificationEntityList.get(0));
+            log.trace("Deleted PecNotification with institutionId: {} and productId: {}", institutionId, productId);
+            return true;
+        }
+        
+        if (null != pecNotificationEntityList && pecNotificationEntityList.size() > 1) {
+        	log.trace("Cannot delete PecNotification with institutionId: {} and productId: {}, because there are multiple entries", institutionId, productId);
+        	return false;
+        }
+
+        log.trace("Cannot delete PecNotification with institutionId: {} and productId: {}, because it does not exist", institutionId, productId);
+        return false;
+    }
+
+    @Override
+    public boolean insertPecNotification(PecNotification pecNotification){
+
+        PecNotificationEntity pecNotificationEntity = this.pecNotificationMapper.convertToPecNotificationEntity(pecNotification);
+
+        boolean exist = repository.existsById(pecNotificationEntity.getId());
+
+        if (exist){
+        	log.trace("Cannot insert the PecNotification: {}, as it already exists in the collection", pecNotification.toString());
+            return false;
+        }
+
+        repository.insert(pecNotificationEntity);
+        log.trace("Inserted PecNotification: {}", pecNotification.toString());
+        return true;
+    }
+
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationRepository.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationRepository.java
@@ -1,0 +1,7 @@
+package it.pagopa.selfcare.mscore.connector.dao;
+
+import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface PecNotificationRepository  extends MongoRepository<PecNotificationEntity, String>, MongoCustomConnector {
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
@@ -1,0 +1,30 @@
+package it.pagopa.selfcare.mscore.connector.dao.model;
+
+import it.pagopa.selfcare.mscore.connector.dao.model.inner.UserBindingEntity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldNameConstants;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Sharded;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@Document("PecNotification")
+@Sharded(shardKey = {"id"})
+@FieldNameConstants(asEnum = true)
+public class PecNotificationEntity {
+
+    @Id
+    private String id;
+    private String institutionId;
+    private String productId;
+    private Integer moduleDayOfTheEpoch;
+
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/PecNotificationEntityMapper.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/PecNotificationEntityMapper.java
@@ -1,0 +1,17 @@
+package it.pagopa.selfcare.mscore.connector.dao.model.mapper;
+
+import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
+import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.UUID;
+
+@Mapper(componentModel = "spring", imports = UUID.class)
+public interface PecNotificationEntityMapper {
+
+    @Mapping(target = "id", defaultExpression = "java(UUID.randomUUID().toString())")
+    PecNotificationEntity convertToPecNotificationEntity(PecNotification institution);
+
+    PecNotification convertToPecNotification(PecNotificationEntity entity);
+}

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/PecNotificationEntityMapper.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/mapper/PecNotificationEntityMapper.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public interface PecNotificationEntityMapper {
 
     @Mapping(target = "id", defaultExpression = "java(UUID.randomUUID().toString())")
+    @Mapping(target = "institutionId", defaultExpression = "java(UUID.randomUUID().toString())")
     PecNotificationEntity convertToPecNotificationEntity(PecNotification institution);
 
     PecNotification convertToPecNotification(PecNotificationEntity entity);

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -40,7 +40,7 @@ class PecNotificationConnectorImplTest {
     @BeforeEach
     void setUp() {
         institutionId = UUID.randomUUID().toString();
-        productId = UUID.randomUUID().toString();
+        productId = "prod-io";
         pecNotificationEntity = new PecNotificationEntity();
         pecNotificationEntity.setInstitutionId(institutionId);
         pecNotificationEntity.setProductId(productId);

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -1,0 +1,107 @@
+package it.pagopa.selfcare.mscore.connector.dao;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ContextConfiguration;
+
+import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
+import it.pagopa.selfcare.mscore.connector.dao.model.mapper.PecNotificationEntityMapper;
+import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
+
+@ContextConfiguration(classes = {PecNotificationConnectorImpl.class})
+@ExtendWith(MockitoExtension.class)
+class PecNotificationConnectorImplTest {
+
+    @Mock
+    private PecNotificationRepository repository;
+
+    @Mock
+    private PecNotificationEntityMapper pecNotificationMapper;
+
+    @InjectMocks
+    private PecNotificationConnectorImpl pecNotificationConnector;
+
+    private String institutionId;
+    private String productId;
+    private PecNotificationEntity pecNotificationEntity;
+    private PecNotification pecNotification;
+
+    @BeforeEach
+    void setUp() {
+        institutionId = UUID.randomUUID().toString();
+        productId = UUID.randomUUID().toString();
+        pecNotificationEntity = new PecNotificationEntity();
+        pecNotificationEntity.setInstitutionId(institutionId);
+        pecNotificationEntity.setProductId(productId);
+        pecNotification = new PecNotification();
+    }
+
+    @Test
+    void findAndDeletePecNotification_success() {
+        when(repository.find(any(), eq(PecNotificationEntity.class)))
+                .thenReturn(Collections.singletonList(pecNotificationEntity));
+
+        boolean result = pecNotificationConnector.findAndDeletePecNotification(institutionId, productId);
+
+        assertTrue(result);
+        verify(repository, times(1)).delete(pecNotificationEntity);
+    }
+
+    @Test
+    void findAndDeletePecNotification_multipleEntries() {
+        when(repository.find(any(), eq(PecNotificationEntity.class)))
+                .thenReturn(List.of(pecNotificationEntity, pecNotificationEntity));
+
+        boolean result = pecNotificationConnector.findAndDeletePecNotification(institutionId, productId);
+
+        assertFalse(result);
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    void findAndDeletePecNotification_notExist() {
+    	List<PecNotificationEntity> pecNotificationList = Collections.emptyList();
+        when(repository.find(any(), eq(PecNotificationEntity.class)))
+                .thenReturn(pecNotificationList);
+
+        boolean result = pecNotificationConnector.findAndDeletePecNotification(institutionId, productId);
+
+        assertFalse(result);
+        verify(repository, never()).delete(any());
+    }
+
+    @Test
+    void insertPecNotification_success() {
+        when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(pecNotificationEntity);
+        when(repository.existsById(pecNotificationEntity.getId())).thenReturn(false);
+
+        boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
+
+        assertTrue(result);
+        verify(repository, times(1)).insert(pecNotificationEntity);
+    }
+
+    @Test
+    void insertPecNotification_alreadyExists() {
+        when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(pecNotificationEntity);
+        when(repository.existsById(pecNotificationEntity.getId())).thenReturn(true);
+
+        boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
+
+        assertFalse(result);
+        verify(repository, never()).insert(pecNotificationEntity);
+        
+    }
+	
+}

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingService.java
@@ -14,4 +14,5 @@ public interface OnboardingService {
 
     Institution persistOnboarding(String institutionId, String productId, Onboarding onboarding, StringBuilder httpStatus);
 
+    void deleteOnboardedInstitution(String institutionId, String productId);
 }

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.core;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PecNotificationConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;
+import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.util.UtilEnumList;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
@@ -10,15 +11,21 @@ import it.pagopa.selfcare.mscore.exception.ResourceNotFoundException;
 import it.pagopa.selfcare.mscore.model.institution.Institution;
 import it.pagopa.selfcare.mscore.model.institution.Onboarding;
 import it.pagopa.selfcare.mscore.model.onboarding.VerifyOnboardingFilters;
+import it.pagopa.selfcare.mscore.model.pecnotification.PecNotification;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.Month;
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import static it.pagopa.selfcare.mscore.constant.GenericError.*;
 
@@ -30,15 +37,23 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final InstitutionConnector institutionConnector;
     private final PecNotificationConnector pecNotificationConnector;
 
+    private Integer sendingFrequencyPecNotification;
+    private String epochDatePecNotification;
+
+    private LocalDate currentDate = LocalDate.now();
     public OnboardingServiceImpl(OnboardingDao onboardingDao,
                                  InstitutionService institutionService,
                                  InstitutionConnector institutionConnector,
-                                 PecNotificationConnector pecNotificationConnector) {
+                                 PecNotificationConnector pecNotificationConnector,
+                                 @Value("${mscore.sending-frequency-pec-notification}") Integer sendingFrequencyPecNotification,
+                                 @Value("${mscore.epoch-date-pec-notification}") String epochDatePecNotification) {
 
         this.onboardingDao = onboardingDao;
         this.institutionService = institutionService;
         this.institutionConnector = institutionConnector;
         this.pecNotificationConnector = pecNotificationConnector;
+        this.sendingFrequencyPecNotification = sendingFrequencyPecNotification;
+        this.epochDatePecNotification = epochDatePecNotification;
     }
 
     @Override
@@ -71,6 +86,35 @@ public class OnboardingServiceImpl implements OnboardingService {
     public Institution persistOnboarding(String institutionId, String
             productId, Onboarding onboarding, StringBuilder httpStatus) {
 
+        Institution institution = this.persistAndReturnInstitution(institutionId, productId, onboarding, httpStatus);
+        this.insertPecNotification(institutionId, productId);
+
+        return institution;
+    }
+
+    public void insertPecNotification(String institutionId, String productId) {
+
+        PecNotification pecNotification = new PecNotification();
+        pecNotification.setId(UUID.randomUUID().toString());
+        pecNotification.setCreatedAt(OffsetDateTime.now());
+        pecNotification.setProductId(productId);
+        pecNotification.setInstitutionId(institutionId);
+        pecNotification.setModuleDayOfTheEpoch(calculateModuleDayOfTheEpoch());
+
+        if (!pecNotificationConnector.insertPecNotification(pecNotification)){
+            throw new InvalidRequestException(GenericError.INVALID_INSERT_PEC_NOTIFICATION_ERROR.getMessage(), INVALID_INSERT_PEC_NOTIFICATION_ERROR.getCode());
+        }
+
+    }
+
+    public int calculateModuleDayOfTheEpoch() {
+        LocalDate epochStart = LocalDate.parse(this.epochDatePecNotification);
+        long daysDiff = ChronoUnit.DAYS.between(epochStart, this.currentDate);
+        int moduleDayOfTheEpoch = (int) (daysDiff % this.sendingFrequencyPecNotification);
+        return moduleDayOfTheEpoch;
+    }
+
+    private Institution persistAndReturnInstitution(String institutionId, String productId, Onboarding onboarding, StringBuilder httpStatus) {
         log.trace("persistForUpdate start");
         log.debug("persistForUpdate institutionId = {}, productId = {}", institutionId, productId);
         onboarding.setStatus(RelationshipState.ACTIVE);
@@ -86,9 +130,9 @@ public class OnboardingServiceImpl implements OnboardingService {
         if (Optional.ofNullable(institution.getOnboarding()).flatMap(onboardings -> onboardings.stream()
                 .filter(item -> item.getProductId().equals(productId) && UtilEnumList.VALID_RELATIONSHIP_STATES.contains(item.getStatus()))
                 .findAny()).isPresent()) {
-        	
+
         	httpStatus.append(HttpStatus.OK.value());
-        	return institution;
+            return institution;
         }
 
         try {

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -1,6 +1,7 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
+import it.pagopa.selfcare.mscore.api.PecNotificationConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.util.UtilEnumList;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-import static it.pagopa.selfcare.mscore.constant.GenericError.ONBOARDING_OPERATION_ERROR;
+import static it.pagopa.selfcare.mscore.constant.GenericError.*;
 
 @Slf4j
 @Service
@@ -27,13 +28,17 @@ public class OnboardingServiceImpl implements OnboardingService {
     private final OnboardingDao onboardingDao;
     private final InstitutionService institutionService;
     private final InstitutionConnector institutionConnector;
+    private final PecNotificationConnector pecNotificationConnector;
 
     public OnboardingServiceImpl(OnboardingDao onboardingDao,
                                  InstitutionService institutionService,
-                                 InstitutionConnector institutionConnector) {
+                                 InstitutionConnector institutionConnector,
+                                 PecNotificationConnector pecNotificationConnector) {
+
         this.onboardingDao = onboardingDao;
         this.institutionService = institutionService;
         this.institutionConnector = institutionConnector;
+        this.pecNotificationConnector = pecNotificationConnector;
     }
 
     @Override
@@ -99,6 +104,26 @@ public class OnboardingServiceImpl implements OnboardingService {
             throw new InvalidRequestException(ONBOARDING_OPERATION_ERROR.getMessage() + " " + e.getMessage(),
                     ONBOARDING_OPERATION_ERROR.getCode());
         }
+    }
+
+    @Override
+    public void deleteOnboardedInstitution(String institutionId, String productId) {
+
+        log.trace("persist logic delete Onboarding - start");
+        Onboarding onboarding = new Onboarding();
+        onboarding.setStatus(RelationshipState.DELETED);
+        onboarding.setProductId(productId);
+        institutionConnector.findAndRemoveOnboarding(institutionId, onboarding);
+        log.trace("persist logic delete Onboarding - end");
+
+        log.trace("persist delete PecNotification - start");
+        boolean isDeleted = pecNotificationConnector.findAndDeletePecNotification(institutionId, productId);
+        if (!isDeleted) {
+            throw new InvalidRequestException(DELETE_NOTIFICATION_OPERATION_ERROR.getMessage(),
+                    ONBOARDING_OPERATION_ERROR.getCode());
+        }
+        log.trace("persist delete PecNotification - end");
+
     }
 
 }

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -1,7 +1,9 @@
 package it.pagopa.selfcare.mscore.core;
 
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
+import it.pagopa.selfcare.mscore.api.PecNotificationConnector;
 import it.pagopa.selfcare.mscore.api.ProductConnector;
+import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.mapper.TokenMapper;
 import it.pagopa.selfcare.mscore.core.mapper.TokenMapperImpl;
 import it.pagopa.selfcare.mscore.core.util.UtilEnumList;
@@ -16,12 +18,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.ContextConfiguration;
 
+
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
+import static it.pagopa.selfcare.mscore.constant.GenericError.DELETE_NOTIFICATION_OPERATION_ERROR;
+import static it.pagopa.selfcare.mscore.constant.GenericError.ONBOARDING_OPERATION_ERROR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
@@ -47,6 +55,9 @@ class OnboardingServiceImplTest {
 
     @Mock
     private UserNotificationService userNotificationService;
+
+    @Mock
+    private PecNotificationConnector pecNotificationConnector;
 
     @Spy
     private TokenMapper tokenMapper = new TokenMapperImpl();
@@ -238,6 +249,47 @@ class OnboardingServiceImplTest {
         onboarding.setPricingPlan("C3");
         onboarding.setProductId("42");
         return onboarding;
+    }
+
+    @Test
+    void deleteOnboardedInstitution_success() {
+
+        String institutionId = UUID.randomUUID().toString();
+        String productId = UUID.randomUUID().toString();
+
+        Onboarding onboarding = new Onboarding();
+        onboarding.setProductId(productId);
+        onboarding.setStatus(RelationshipState.DELETED);
+
+        when(pecNotificationConnector.findAndDeletePecNotification(institutionId, productId)).thenReturn(true);
+        
+        onboardingServiceImpl.deleteOnboardedInstitution(institutionId, productId);
+
+        verify(institutionConnector, times(1)).findAndRemoveOnboarding(institutionId, onboarding);
+        verify(pecNotificationConnector, times(1)).findAndDeletePecNotification(institutionId, productId);
+    }
+
+    @Test
+    void deleteOnboardedInstitution_deletePecNotificationFails() {
+
+        String institutionId = UUID.randomUUID().toString();
+        String productId = UUID.randomUUID().toString();
+
+        Onboarding onboarding = new Onboarding();
+        onboarding.setProductId(productId);
+        onboarding.setStatus(RelationshipState.DELETED);
+        
+        when(pecNotificationConnector.findAndDeletePecNotification(institutionId, productId)).thenReturn(false);
+
+        InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
+            onboardingServiceImpl.deleteOnboardedInstitution(institutionId, productId);
+        });
+
+        assertEquals(DELETE_NOTIFICATION_OPERATION_ERROR.getMessage(), exception.getMessage());
+        assertEquals(ONBOARDING_OPERATION_ERROR.getCode(), exception.getCode());
+
+        verify(institutionConnector, times(1)).findAndRemoveOnboarding(institutionId, onboarding);
+        verify(pecNotificationConnector, times(1)).findAndDeletePecNotification(institutionId, productId);
     }
 }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -273,7 +273,7 @@ class OnboardingServiceImplTest {
     void deleteOnboardedInstitution_deletePecNotificationFails() {
 
         String institutionId = UUID.randomUUID().toString();
-        String productId = UUID.randomUUID().toString();
+        String productId = "prod-io";
 
         Onboarding onboarding = new Onboarding();
         onboarding.setProductId(productId);

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -369,6 +369,18 @@ public class InstitutionController {
                 .body(institutionResourceMapper.toInstitutionResponse(institution));
     }
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @ApiOperation(value = "${swagger.mscore.onboarding.users.delete}", notes = "${swagger.mscore.onboarding.users.delete}")
+    @DeleteMapping(value = "/{id}/{productId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public void deleteOnboardedInstitution(@PathVariable("productId") String productId,
+                                           @PathVariable("id") String institutionId) {
+
+        CustomExceptionMessage.setCustomMessage(GenericError.DELETE_ONBOARDED_OPERATION_ERROR);
+        onboardingService.deleteOnboardedInstitution(institutionId, productId);
+
+    }
+
+
     /**
      * The function return geographic taxonomies related to institution
      *

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/controller/InstitutionController.java
@@ -357,6 +357,7 @@ public class InstitutionController {
     @PostMapping(value = "/{id}/onboarding", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<InstitutionResponse> onboardingInstitution(@RequestBody @Valid InstitutionOnboardingRequest request,
                                                                      @PathVariable("id") String id) {
+
         CustomExceptionMessage.setCustomMessage(GenericError.ONBOARDING_OPERATION_ERROR);
         
         StringBuilder httpStatus = new StringBuilder();

--- a/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardedRequest.java
+++ b/web/src/main/java/it/pagopa/selfcare/mscore/web/model/institution/InstitutionOnboardedRequest.java
@@ -1,0 +1,12 @@
+package it.pagopa.selfcare.mscore.web.model.institution;
+
+import lombok.Data;
+
+import javax.validation.constraints.NotEmpty;
+
+@Data
+public class InstitutionOnboardedRequest {
+
+    @NotEmpty(message = "productId is required")
+    private String productId;
+}

--- a/web/src/main/resources/swagger/swagger_en.properties
+++ b/web/src/main/resources/swagger/swagger_en.properties
@@ -20,6 +20,7 @@ swagger.mscore.institution.relationships=returns the relationships related to th
 swagger.mscore.onboarding.operator=performs operators onboarding on an already existing institution
 swagger.mscore.onboarding.subdelegates=performs subdelegates onboarding on an already existing institution
 swagger.mscore.onboarding.users=The service adds users to the registry if they are not present and associates them with the institution and product contained in the body
+swagger.mscore.onboarding.users.delete=The service delete the users changing the user status to 'DELETE' and remove from DB the PecNotification record by productId and institutionId
 swagger.mscore.onboarding.legals=performs legals onboarding on an already existing institution
 swagger.mscore.relationships=Gets the corresponding relationship
 swagger.mscore.relationship.delete=Given a relationship identifier, it deletes the corresponding relationship

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -1376,20 +1376,17 @@ class InstitutionControllerTest {
     @Test
     void deleteOnboardedInstitution_test() throws Exception {
 
-        // Given
         String institutionId = UUID.randomUUID().toString();
-        String productId = UUID.randomUUID().toString();
+        String productId = "prod-io";
 
         doNothing().when(onboardingService).deleteOnboardedInstitution(institutionId, productId);
 
-        // Then
         MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.delete("/institutions/{id}/{productId}", institutionId, productId);
 
         ResultActions actualPerformResult = MockMvcBuilders.standaloneSetup(institutionController)
                 .build()
                 .perform(requestBuilder);
 
-        // Test
         actualPerformResult
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
                 .andExpect(MockMvcResultMatchers.content().string(""));

--- a/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/mscore/web/controller/InstitutionControllerTest.java
@@ -38,6 +38,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -1370,6 +1371,28 @@ class InstitutionControllerTest {
                 .build()
                 .perform(requestBuilder)
                 .andExpect(MockMvcResultMatchers.status().isCreated());
+    }
+
+    @Test
+    void deleteOnboardedInstitution_test() throws Exception {
+
+        // Given
+        String institutionId = UUID.randomUUID().toString();
+        String productId = UUID.randomUUID().toString();
+
+        doNothing().when(onboardingService).deleteOnboardedInstitution(institutionId, productId);
+
+        // Then
+        MockHttpServletRequestBuilder requestBuilder = MockMvcRequestBuilders.delete("/institutions/{id}/{productId}", institutionId, productId);
+
+        ResultActions actualPerformResult = MockMvcBuilders.standaloneSetup(institutionController)
+                .build()
+                .perform(requestBuilder);
+
+        // Test
+        actualPerformResult
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andExpect(MockMvcResultMatchers.content().string(""));
     }
 
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added PecNotification record to persistOnboarding during the onboarding process.

#### Motivation and Context

To meet a regulatory requirement that mandates communication to governmental entities of the user list for the SEND and App IO products, the solution allows writing the necessary information in a Mongo collection. This enables the batch process to periodically send PEC communications to the entities, containing a link to access the list of registered users in the Area Riservata.

#### How Has This Been Tested?

Junit test and local test.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.