### PR TITLE
[SELC-5169] feat : Added record PecNotification in persistOnboarding

### DIFF
--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${APP_SERVER_PORT:8080}
+  port: ${APP_SERVER_PORT:8081}
   shutdown: graceful
 
 spring:

--- a/app/src/main/resources/config/application.yml
+++ b/app/src/main/resources/config/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: ${APP_SERVER_PORT:8081}
+  port: ${APP_SERVER_PORT:8080}
   shutdown: graceful
 
 spring:

--- a/app/src/main/resources/config/core-config.properties
+++ b/app/src/main/resources/config/core-config.properties
@@ -26,3 +26,6 @@ mscore.blob-storage.connection-string-product = ${BLOB_STORAGE_PRODUCT_CONNECTIO
 mscore.aws-ses-secret-id=${AWS_SES_ACCESS_KEY_ID:secret-id-example}
 mscore.aws-ses-secret-key=${AWS_SES_SECRET_ACCESS_KEY:secret-key-example}
 mscore.aws-ses-region=${AWS_SES_REGION:eu-south-1}
+
+mscore.sending-frequency-pec-notification=${SENDING_FREQUENCY_PEC_NOTIFICATION:30}
+mscore.epoch-date-pec-notification=${EPOCH_DATE_PEC_NOTIFICATION:2024-01-01}

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/constant/GenericError.java
@@ -63,7 +63,9 @@ public enum GenericError {
     UPDATE_USER_INSTITUTION_ERROR("0000", "Error while updating InstitutionUser for id %s"),
     GENERIC_ERROR("0000", "Generic Error"),
     DELETE_ONBOARDED_OPERATION_ERROR("0000", "Error while deleting Onboarded Institution"),
-    DELETE_NOTIFICATION_OPERATION_ERROR ("0000", "PecNotificationEntity was not deleted because either it does not exist or there are multiple records");
+    DELETE_NOTIFICATION_OPERATION_ERROR ("0000", "PecNotificationEntity was not deleted because either it does not exist or there are multiple records"),
+    INVALID_INSERT_PEC_NOTIFICATION_ERROR ("0001", "PecNotificationEntity was not inserted because either it exist or the data are invalid");
+
     private final String code;
     private final String detail;
 

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/pecnotification/PecNotification.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/pecnotification/PecNotification.java
@@ -16,6 +16,7 @@ public class PecNotification {
     private String institutionId;
     private String productId;
     private Integer moduleDayOfTheEpoch;
+    private String digitalAddress;
 
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImpl.java
@@ -52,7 +52,7 @@ public class PecNotificationConnectorImpl implements PecNotificationConnector {
 
         PecNotificationEntity pecNotificationEntity = this.pecNotificationMapper.convertToPecNotificationEntity(pecNotification);
 
-        boolean exist = repository.existsById(pecNotificationEntity.getId());
+        boolean exist = repository.existsByInstitutionIdAndProductId(pecNotificationEntity.getInstitutionId(), pecNotificationEntity.getProductId());
 
         if (exist){
         	log.trace("Cannot insert the PecNotification: {}, as it already exists in the collection", pecNotification.toString());

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationRepository.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationRepository.java
@@ -4,4 +4,5 @@ import it.pagopa.selfcare.mscore.connector.dao.model.PecNotificationEntity;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface PecNotificationRepository  extends MongoRepository<PecNotificationEntity, String>, MongoCustomConnector {
+    boolean existsByInstitutionIdAndProductId(String institutionId, String productId);
 }

--- a/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
+++ b/connector/dao/src/main/java/it/pagopa/selfcare/mscore/connector/dao/model/PecNotificationEntity.java
@@ -1,6 +1,5 @@
 package it.pagopa.selfcare.mscore.connector.dao.model;
 
-import it.pagopa.selfcare.mscore.connector.dao.model.inner.UserBindingEntity;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
@@ -9,7 +8,6 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Sharded;
 
 import java.time.OffsetDateTime;
-import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -23,6 +21,7 @@ public class PecNotificationEntity {
     private String institutionId;
     private String productId;
     private Integer moduleDayOfTheEpoch;
+    private String digitalAddress;
 
     private OffsetDateTime createdAt;
     private OffsetDateTime updatedAt;

--- a/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
+++ b/connector/dao/src/test/java/it/pagopa/selfcare/mscore/connector/dao/PecNotificationConnectorImplTest.java
@@ -84,7 +84,7 @@ class PecNotificationConnectorImplTest {
     @Test
     void insertPecNotification_success() {
         when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(pecNotificationEntity);
-        when(repository.existsById(pecNotificationEntity.getId())).thenReturn(false);
+        when(repository.existsByInstitutionIdAndProductId(any(), any())).thenReturn(false);
 
         boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
 
@@ -95,7 +95,7 @@ class PecNotificationConnectorImplTest {
     @Test
     void insertPecNotification_alreadyExists() {
         when(pecNotificationMapper.convertToPecNotificationEntity(pecNotification)).thenReturn(pecNotificationEntity);
-        when(repository.existsById(pecNotificationEntity.getId())).thenReturn(true);
+        when(repository.existsByInstitutionIdAndProductId(any(), any())).thenReturn(true);
 
         boolean result = pecNotificationConnector.insertPecNotification(pecNotification);
 

--- a/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
+++ b/core/src/main/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImpl.java
@@ -3,7 +3,6 @@ package it.pagopa.selfcare.mscore.core;
 import it.pagopa.selfcare.mscore.api.InstitutionConnector;
 import it.pagopa.selfcare.mscore.api.PecNotificationConnector;
 import it.pagopa.selfcare.mscore.constant.CustomError;
-import it.pagopa.selfcare.mscore.constant.GenericError;
 import it.pagopa.selfcare.mscore.constant.RelationshipState;
 import it.pagopa.selfcare.mscore.core.util.UtilEnumList;
 import it.pagopa.selfcare.mscore.exception.InvalidRequestException;
@@ -80,7 +79,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         }
     }
 
-    public void insertPecNotification(String institutionId, String productId) {
+    public void insertPecNotification(String institutionId, String productId, String digitalAddress) {
 
         PecNotification pecNotification = new PecNotification();
         pecNotification.setId(UUID.randomUUID().toString());
@@ -88,6 +87,7 @@ public class OnboardingServiceImpl implements OnboardingService {
         pecNotification.setProductId(productId);
         pecNotification.setInstitutionId(institutionId);
         pecNotification.setModuleDayOfTheEpoch(calculateModuleDayOfTheEpoch());
+        pecNotification.setDigitalAddress(digitalAddress);
 
         if (!pecNotificationConnector.insertPecNotification(pecNotification)){
             throw new InvalidRequestException(INVALID_INSERT_PEC_NOTIFICATION_ERROR.getMessage(), INVALID_INSERT_PEC_NOTIFICATION_ERROR.getCode());
@@ -107,7 +107,7 @@ public class OnboardingServiceImpl implements OnboardingService {
             productId, Onboarding onboarding, StringBuilder httpStatus) {
 
         Institution institution = persistAndGetInstitution(institutionId, productId, onboarding, httpStatus);
-        this.insertPecNotification(institutionId, productId);
+        this.insertPecNotification(institutionId, productId, institution.getDigitalAddress());
         return institution;
     }
 

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -31,8 +31,7 @@ import java.util.UUID;
 
 import static it.pagopa.selfcare.mscore.constant.GenericError.DELETE_NOTIFICATION_OPERATION_ERROR;
 import static it.pagopa.selfcare.mscore.constant.GenericError.ONBOARDING_OPERATION_ERROR;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ContextConfiguration(classes = {OnboardingServiceImpl.class})
@@ -222,6 +221,7 @@ class OnboardingServiceImplTest {
         Institution institution = new Institution();
         institution.setId("institutionId");
         institution.setOnboarding(List.of(onboarding));
+        institution.setDigitalAddress("test@junit.pagopa");
 
         Token token = new Token();
         token.setId(onboarding.getTokenId());
@@ -252,7 +252,7 @@ class OnboardingServiceImplTest {
         verify(pecNotificationConnector, times(1)). insertPecNotification(argCaptor.capture());
         assertEquals(productId, argCaptor.getValue().getProductId());
         assertEquals("institutionId", argCaptor.getValue().getInstitutionId());
-
+        assertEquals("test@junit.pagopa", argCaptor.getValue().getDigitalAddress());
     }
 
     private Onboarding dummyOnboarding() {

--- a/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
+++ b/core/src/test/java/it/pagopa/selfcare/mscore/core/OnboardingServiceImplTest.java
@@ -248,6 +248,11 @@ class OnboardingServiceImplTest {
         assertEquals(actual.getCreatedAt().getDayOfYear(), LocalDate.now().getDayOfYear());
         assertEquals(HttpStatus.CREATED.value(), Integer.parseInt(statusCode.toString()));
 
+        ArgumentCaptor< PecNotification > argCaptor = ArgumentCaptor.forClass(PecNotification.class);
+        verify(pecNotificationConnector, times(1)). insertPecNotification(argCaptor.capture());
+        assertEquals(productId, argCaptor.getValue().getProductId());
+        assertEquals("institutionId", argCaptor.getValue().getInstitutionId());
+
     }
 
     private Onboarding dummyOnboarding() {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Added PecNotification record to persistOnboarding during the onboarding process.

#### Motivation and Context

To meet a regulatory requirement that mandates communication to governmental entities of the user list for the SEND and App IO products, the solution allows writing the necessary information in a Mongo collection. This enables the batch process to periodically send PEC communications to the entities, containing a link to access the list of registered users in the Area Riservata.

#### How Has This Been Tested?

Junit test and local test.

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.