### PR TITLE
[SELC-5227] feat: added Infocamere PDND API call in party-registry client

### DIFF
--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/api/PartyRegistryProxyConnector.java
@@ -25,4 +25,6 @@ public interface PartyRegistryProxyConnector {
     SaResource getSAFromAnac(String taxId);
 
     ASResource getASFromIvass(String ivassCode);
+
+    InfocamerePdndInstitution getInfocamerePdndInstitution(String taxCode);
 }

--- a/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/InfocamerePdndInstitution.java
+++ b/connector-api/src/main/java/it/pagopa/selfcare/mscore/model/institution/InfocamerePdndInstitution.java
@@ -1,0 +1,19 @@
+package it.pagopa.selfcare.mscore.model.institution;
+
+import lombok.Data;
+
+@Data
+public class InfocamerePdndInstitution {
+    private String businessTaxId;
+    private String businessName;
+    private String legalNature;
+    private String legalNatureDescription;
+    private String cciaa;
+    private String nRea;
+    private String businessStatus;
+    private String city;
+    private String county;
+    private String zipCode;
+    private String address;
+    private String digitalAddress;
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/client/PartyRegistryProxyRestClient.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/client/PartyRegistryProxyRestClient.java
@@ -1,5 +1,6 @@
 package it.pagopa.selfcare.mscore.connector.rest.client;
 
+import it.pagopa.selfcare.mscore.connector.rest.model.InfocamerePdndResponse;
 import it.pagopa.selfcare.mscore.connector.rest.model.geotaxonomy.GeographicTaxonomiesResponse;
 import it.pagopa.selfcare.mscore.connector.rest.model.registryproxy.*;
 import it.pagopa.selfcare.mscore.model.institution.NationalRegistriesProfessionalAddress;
@@ -43,5 +44,9 @@ public interface PartyRegistryProxyRestClient extends InsuranceCompaniesApi {
     @GetMapping(value = "${rest-client.party-registry-proxy.sa.getByTaxId.path}", consumes = APPLICATION_JSON_VALUE)
     @ResponseBody
     PdndResponse getSaByTaxId(@PathVariable(value = "taxId") String taxId);
+
+    @GetMapping(value = "${rest-client.party-registry-proxy.infocamere.pdnd.getInstitutionByTaxCode.path}", consumes = APPLICATION_JSON_VALUE)
+    @ResponseBody
+    InfocamerePdndResponse getInfocamerePdndInstitutionByTaxCode(@PathVariable(value = "taxCode") String taxCode);
 
 }

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/mapper/InfocamereMapper.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/mapper/InfocamereMapper.java
@@ -1,0 +1,10 @@
+package it.pagopa.selfcare.mscore.connector.rest.mapper;
+
+import it.pagopa.selfcare.mscore.connector.rest.model.InfocamerePdndResponse;
+import it.pagopa.selfcare.mscore.model.institution.InfocamerePdndInstitution;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface InfocamereMapper {
+    InfocamerePdndInstitution toInstitution(InfocamerePdndResponse response);
+}

--- a/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/model/InfocamerePdndResponse.java
+++ b/connector/rest/src/main/java/it/pagopa/selfcare/mscore/connector/rest/model/InfocamerePdndResponse.java
@@ -1,0 +1,19 @@
+package it.pagopa.selfcare.mscore.connector.rest.model;
+
+import lombok.Data;
+
+@Data
+public class InfocamerePdndResponse {
+    private String businessTaxId;
+    private String businessName;
+    private String legalNature;
+    private String legalNatureDescription;
+    private String cciaa;
+    private String nRea;
+    private String businessStatus;
+    private String city;
+    private String county;
+    private String zipCode;
+    private String address;
+    private String digitalAddress;
+}

--- a/connector/rest/src/main/resources/config/party-registry-proxy-rest-client.properties
+++ b/connector/rest/src/main/resources/config/party-registry-proxy-rest-client.properties
@@ -8,6 +8,7 @@ rest-client.party-registry-proxy.geo-taxonomies.getByCode.path=/geotaxonomies/{g
 rest-client.party-registry-proxy.aoo.getByCode.path=/aoo/{aooId}
 rest-client.party-registry-proxy.uo.getByCode.path=/uo/{uoId}
 rest-client.party-registry-proxy.sa.getByTaxId.path=/stations/{taxId}
+rest-client.party-registry-proxy.infocamere.pdnd.getInstitutionByTaxCode.path=/infocamere-pdnd/institution/{taxCode}
 
 feign.client.config.party-registry-proxy.requestInterceptors[0]=it.pagopa.selfcare.commons.connector.rest.interceptor.AuthorizationHeaderInterceptor
 feign.client.config.party-registry-proxy.requestInterceptors[1]=it.pagopa.selfcare.commons.connector.rest.interceptor.PartyTraceIdInterceptor

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
@@ -52,11 +52,11 @@ class PartyRegistryProxyConnectorImplTest {
     @Spy
     private InfocamereMapper infocamereMapper = new InfocamereMapperImpl();
 
-    private final static AooResponse aooResponse;
-    private final static UoResponse uoResponse;
-    private final static PdndResponse pdndResponse;
-    private final static InsuranceCompanyResource asResponse;
-    private final static InfocamerePdndResponse infocamerePdndResponse;
+    private static final AooResponse aooResponse;
+    private static final UoResponse uoResponse;
+    private static final PdndResponse pdndResponse;
+    private static final InsuranceCompanyResource asResponse;
+    private static final InfocamerePdndResponse infocamerePdndResponse;
 
     static {
         aooResponse = new AooResponse();

--- a/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
+++ b/connector/rest/src/test/java/it/pagopa/selfcare/mscore/connector/rest/PartyRegistryProxyConnectorImplTest.java
@@ -3,6 +3,7 @@ package it.pagopa.selfcare.mscore.connector.rest;
 import feign.FeignException;
 import it.pagopa.selfcare.mscore.connector.rest.client.PartyRegistryProxyRestClient;
 import it.pagopa.selfcare.mscore.connector.rest.mapper.*;
+import it.pagopa.selfcare.mscore.connector.rest.model.InfocamerePdndResponse;
 import it.pagopa.selfcare.mscore.connector.rest.model.geotaxonomy.GeographicTaxonomiesResponse;
 import it.pagopa.selfcare.mscore.connector.rest.model.registryproxy.*;
 import it.pagopa.selfcare.mscore.constant.Origin;
@@ -48,11 +49,14 @@ class PartyRegistryProxyConnectorImplTest {
     private SaMapper saMapper = new SaMapperImpl();
     @Spy
     private AsMapper asMapper = new AsMapperImpl();
+    @Spy
+    private InfocamereMapper infocamereMapper = new InfocamereMapperImpl();
 
     private final static AooResponse aooResponse;
     private final static UoResponse uoResponse;
     private final static PdndResponse pdndResponse;
     private final static InsuranceCompanyResource asResponse;
+    private final static InfocamerePdndResponse infocamerePdndResponse;
 
     static {
         aooResponse = new AooResponse();
@@ -66,6 +70,7 @@ class PartyRegistryProxyConnectorImplTest {
         uoResponse.setOrigin(Origin.IPA);
         pdndResponse = mockInstance(new PdndResponse());
         asResponse = mockInstance(new InsuranceCompanyResource());
+        infocamerePdndResponse = mockInstance(new InfocamerePdndResponse());
     }
 
     /**
@@ -586,6 +591,44 @@ class PartyRegistryProxyConnectorImplTest {
         when(partyRegistryProxyRestClient._searchByOriginIdUsingGET(ivassCode)).thenReturn(null);
 
         assertThrows(ResourceNotFoundException.class, () -> partyRegistryProxyConnectorImpl.getASFromIvass(ivassCode));
+    }
+
+    @Test
+    void getInfocamerePdndInstitution() {
+        //given
+        String taxCode = "taxCode";
+        when(partyRegistryProxyRestClient.getInfocamerePdndInstitutionByTaxCode(anyString())).thenReturn(infocamerePdndResponse);
+        //when
+        InfocamerePdndInstitution result = partyRegistryProxyConnectorImpl.getInfocamerePdndInstitution(taxCode);
+        //then
+        checkNotNullFields(result);
+        verify(partyRegistryProxyRestClient, times(1)).getInfocamerePdndInstitutionByTaxCode(taxCode);
+    }
+
+    @Test
+    void getInfocamerePdndInstitutionNotFound() {
+        //given
+        String taxCode = "taxCode";
+        when(partyRegistryProxyRestClient.getInfocamerePdndInstitutionByTaxCode(anyString())).thenThrow(ResourceNotFoundException.class);
+
+        //when
+        Executable executable = () -> partyRegistryProxyConnectorImpl.getInfocamerePdndInstitution(taxCode);
+        //then
+        assertThrows(ResourceNotFoundException.class, executable);
+        verify(partyRegistryProxyRestClient, times(1)).getInfocamerePdndInstitutionByTaxCode(taxCode);
+    }
+
+    @Test
+    void getInfocamerePdndInstitutionFeignException() {
+        //given
+        String taxCode = "taxCode";
+        when(partyRegistryProxyRestClient.getInfocamerePdndInstitutionByTaxCode(anyString())).thenThrow(FeignException.class);
+
+        //when
+        Executable executable = () -> partyRegistryProxyConnectorImpl.getInfocamerePdndInstitution(taxCode);
+        //then
+        assertThrows(MsCoreException.class, executable);
+        verify(partyRegistryProxyRestClient, times(1)).getInfocamerePdndInstitutionByTaxCode(taxCode);
     }
 }
 


### PR DESCRIPTION
#### List of Changes

Added Infocamere PDND API call in party-registry client

#### Motivation and Context

This api is used in the context of onboarding when creating SCP institution

#### How Has This Been Tested?

local env

#### Screenshots (if appropriate):

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.